### PR TITLE
Implement decimal string conversions, cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-bigint"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ In addition to basic arithmetic, two main traits are implemented: [num_traits::P
 _TODO list_:
  * Implement experimental `unchecked_math` operands, unchecked_mul, unchecked_div etc.
  * Probably needs its own error structs instead of reusing core::fmt::Error and core::num::ParseIntError
- * Decimal string to/from conversion, currently only binary and hex strings are supported.
- * Comprehensive testing fixture, fully validate all ops up to 32-bit against native types
  * Some test code relies on 64-bit ToPrimitive/FromPrimitive conversions, clean this up
  * Lots of test code can be written cleaner
  * Maybe implement signed version as well.

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -160,9 +160,9 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
             let word = self.array[iter_words];
             let mut encoded = [0u8; LONGEST_WORD_IN_BITS / 4];
             let encode_slice = &mut encoded[0..word_size * 2];
-            let mut wordbytes = word.to_ne_bytes();
-            let wordslice = &mut wordbytes[0..word_size];
-            wordslice.reverse();
+            let mut wordbytes = word.to_le_bytes();
+            wordbytes.as_mut().reverse();
+            let wordslice = wordbytes.as_ref();
             to_slice_hex(wordslice, encode_slice).map_err(|_| Error {})?;
             for iter_chars in 0..encode_slice.len() {
                 let copy_char_to = (iter_words * word_size * 2) + iter_chars;

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -88,7 +88,7 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
         ret
     }
 
-    /// Create a little-endian integer value from its representation as a byte array in big endian.
+    /// Create a big-endian integer value from its representation as a byte array in big endian.
     pub fn from_be_bytes(bytes: &[u8]) -> Self {
         let iter: usize = core::cmp::min(bytes.len() / Self::WORD_SIZE, N);
         let total_bytes = iter * Self::WORD_SIZE;
@@ -107,7 +107,7 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
         ret
     }
 
-    // Converts the FixedUInt into a little-endian byte array.
+    /// Converts the FixedUInt into a little-endian byte array.
     pub fn to_le_bytes<'a>(&self, output_buffer: &'a mut [u8]) -> Result<&'a [u8], bool> {
         let total_bytes = N * Self::WORD_SIZE;
         if output_buffer.len() < total_bytes {
@@ -122,7 +122,7 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
         Ok(&output_buffer[..total_bytes])
     }
 
-    // Converts the FixedUInt into a big-endian byte array.
+    /// Converts the FixedUInt into a big-endian byte array.
     pub fn to_be_bytes<'a>(&self, output_buffer: &'a mut [u8]) -> Result<&'a [u8], bool> {
         let total_bytes = N * Self::WORD_SIZE;
         if output_buffer.len() < total_bytes {
@@ -137,7 +137,7 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
         Ok(&output_buffer[..total_bytes])
     }
 
-    /// Converts to hex string, given a buffer. CAVEAT: This method removes any leading zero
+    /// Converts to hex string, given a buffer. CAVEAT: This method removes any leading zeroes
     pub fn to_hex_str<'a>(&self, result: &'a mut [u8]) -> Result<&'a str, core::fmt::Error> {
         type Error = core::fmt::Error;
 
@@ -190,7 +190,7 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
         }
     }
 
-    /// Converts to decimal string, given a buffer. CAVEAT: This method removes any leading zero
+    /// Converts to decimal string, given a buffer. CAVEAT: This method removes any leading zeroes
     pub fn to_radix_str<'a>(
         &self,
         result: &'a mut [u8],

--- a/src/machineword.rs
+++ b/src/machineword.rs
@@ -36,11 +36,11 @@ pub trait MachineWord:
 
 impl MachineWord for u8 {
     type DoubleWord = u16;
-    fn to_double(self) -> u16 {
-        self as u16
+    fn to_double(self) -> Self::DoubleWord {
+        self as Self::DoubleWord
     }
-    fn from_double(word: u16) -> u8 {
-        word as u8
+    fn from_double(word: Self::DoubleWord) -> Self {
+        word as Self
     }
     fn to_ne_bytes(self) -> [u8; 8] {
         let mut ret = [0; 8];
@@ -50,11 +50,11 @@ impl MachineWord for u8 {
 }
 impl MachineWord for u16 {
     type DoubleWord = u32;
-    fn to_double(self) -> u32 {
-        self as u32
+    fn to_double(self) -> Self::DoubleWord {
+        self as Self::DoubleWord
     }
-    fn from_double(word: u32) -> u16 {
-        word as u16
+    fn from_double(word: Self::DoubleWord) -> Self {
+        word as Self
     }
     fn to_ne_bytes(self) -> [u8; 8] {
         let mut ret = [0; 8];
@@ -65,11 +65,26 @@ impl MachineWord for u16 {
 }
 impl MachineWord for u32 {
     type DoubleWord = u64;
-    fn to_double(self) -> u64 {
-        self as u64
+    fn to_double(self) -> Self::DoubleWord {
+        self as Self::DoubleWord
     }
-    fn from_double(word: u64) -> u32 {
-        word as u32
+    fn from_double(word: Self::DoubleWord) -> Self {
+        word as Self
+    }
+    fn to_ne_bytes(self) -> [u8; 8] {
+        let mut ret = [0; 8];
+        let halfslice = &mut ret[0..4];
+        halfslice.copy_from_slice(&self.to_ne_bytes());
+        ret
+    }
+}
+impl MachineWord for u64 {
+    type DoubleWord = u128;
+    fn to_double(self) -> Self::DoubleWord {
+        self as Self::DoubleWord
+    }
+    fn from_double(word: Self::DoubleWord) -> Self {
+        word as Self
     }
     fn to_ne_bytes(self) -> [u8; 8] {
         let mut ret = [0; 8];

--- a/src/machineword.rs
+++ b/src/machineword.rs
@@ -29,9 +29,6 @@ pub trait MachineWord:
     type DoubleWord: num_traits::PrimInt;
     fn to_double(self) -> Self::DoubleWord;
     fn from_double(word: Self::DoubleWord) -> Self;
-
-    // Todo: get rid of this, single use
-    fn to_ne_bytes(self) -> [u8; 8];
 }
 
 impl MachineWord for u8 {
@@ -42,11 +39,6 @@ impl MachineWord for u8 {
     fn from_double(word: Self::DoubleWord) -> Self {
         word as Self
     }
-    fn to_ne_bytes(self) -> [u8; 8] {
-        let mut ret = [0; 8];
-        ret[0] = self;
-        ret
-    }
 }
 impl MachineWord for u16 {
     type DoubleWord = u32;
@@ -55,12 +47,6 @@ impl MachineWord for u16 {
     }
     fn from_double(word: Self::DoubleWord) -> Self {
         word as Self
-    }
-    fn to_ne_bytes(self) -> [u8; 8] {
-        let mut ret = [0; 8];
-        let halfslice = &mut ret[0..2];
-        halfslice.copy_from_slice(&self.to_ne_bytes());
-        ret
     }
 }
 impl MachineWord for u32 {
@@ -71,12 +57,6 @@ impl MachineWord for u32 {
     fn from_double(word: Self::DoubleWord) -> Self {
         word as Self
     }
-    fn to_ne_bytes(self) -> [u8; 8] {
-        let mut ret = [0; 8];
-        let halfslice = &mut ret[0..4];
-        halfslice.copy_from_slice(&self.to_ne_bytes());
-        ret
-    }
 }
 impl MachineWord for u64 {
     type DoubleWord = u128;
@@ -85,31 +65,5 @@ impl MachineWord for u64 {
     }
     fn from_double(word: Self::DoubleWord) -> Self {
         word as Self
-    }
-    fn to_ne_bytes(self) -> [u8; 8] {
-        let mut ret = [0; 8];
-        let halfslice = &mut ret[0..4];
-        halfslice.copy_from_slice(&self.to_ne_bytes());
-        ret
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn machineword_to_ne() {
-        fn compare<T: MachineWord>(input: T, reference: [u8; 8]) {
-            assert_eq!(input.to_ne_bytes(), reference);
-        }
-        compare(1u8, [1u8, 0, 0, 0, 0, 0, 0, 0]);
-        compare(2u8, [2u8, 0, 0, 0, 0, 0, 0, 0]);
-        compare(255u8, [255u8, 0, 0, 0, 0, 0, 0, 0]);
-        compare(0xa3f4u16, [0xf4, 0xa3, 0, 0, 0, 0, 0, 0]);
-        compare(2u16, [2u8, 0, 0, 0, 0, 0, 0, 0]);
-        compare(257u16, [1u8, 1, 0, 0, 0, 0, 0, 0]);
-        compare(2u32, [2u8, 0, 0, 0, 0, 0, 0, 0]);
-        compare(65537u32, [1u8, 0, 1, 0, 0, 0, 0, 0]);
     }
 }

--- a/tests/string_convert.rs
+++ b/tests/string_convert.rs
@@ -113,6 +113,70 @@ fn test_to_hex_str() {
 }
 
 #[test]
+fn test_to_radix_str() {
+    let mut buf = [0u8; 20];
+
+    let n1 = Bn::<u8, 8>::zero();
+    let slice = n1.to_radix_str(&mut buf, 2);
+    assert_eq!(Ok("0"), slice);
+
+    let n1 = Bn::<u8, 8>::one();
+    assert_eq!(n1.to_u8().unwrap(), 1);
+    let slice = n1.to_radix_str(&mut buf, 2);
+    assert_eq!(Ok("1"), slice);
+
+    let n1 = Bn::<u32, 2>::from_u64(0b110110110101).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 2);
+    assert_eq!(Ok("110110110101"), slice);
+
+    let n1 = Bn::<u32, 2>::from_u64(0o1234567).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 8);
+    assert_eq!(Ok("1234567"), slice);
+
+    let n1 = Bn::<u16, 4>::from_u64(0o7654321).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 8);
+    assert_eq!(Ok("7654321"), slice);
+
+    let n1 = Bn::<u32, 2>::from_u64(987654321).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 10);
+    assert_eq!(Ok("987654321"), slice);
+
+    let n1 = Bn::<u16, 4>::from_u64(123456789).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 10);
+    assert_eq!(Ok("123456789"), slice);
+
+    let n1 = Bn::<u32, 2>::from_u64(0x9a802e1c01b2a3f4).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 16);
+    assert_eq!(Ok("9a802e1c01b2a3f4"), slice);
+
+    let n1 = Bn::<u16, 4>::from_u64(0x01b2a3f4).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 16);
+    assert_eq!(Ok("1b2a3f4"), slice);
+
+    let n1 = Bn::<u32, 2>::from_u64(123456).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 7);
+    assert_eq!(Ok("1022634"), slice);
+
+    let n1 = Bn::<u16, 4>::from_u64(7654321).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 7);
+    assert_eq!(Ok("122026543"), slice);
+
+    let n1 = Bn::<u32, 2>::from_u64(123456789).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 13);
+    assert_eq!(Ok("1c767471"), slice);
+
+    let n1 = Bn::<u16, 4>::from_u64(987654321).unwrap();
+    let slice = n1.to_radix_str(&mut buf, 13);
+    assert_eq!(Ok("129806a54"), slice);
+
+    let mut buf_small = [0u8; 5];
+    let slice = Bn::<u32, 2>::from_u64(123456)
+        .unwrap()
+        .to_radix_str(&mut buf_small, 10);
+    assert!(slice.is_err());
+}
+
+#[test]
 fn from_str_radix() {
     fn test8_bit<
         INT: num_traits::PrimInt<FromStrRadixErr = core::num::ParseIntError>


### PR DESCRIPTION
- Add u64 word sizes
- Remove clunky `to_ne_bytes` implementation
- add `to_radix_str` 
- Fix `to_radix_str` to support any radix from 2 to 16

Fixes #36 