### PR TITLE
Implement Display, FromStr and Hash

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,5 @@
 name: coverage
 
-# on: [ push, pull_request ]
 on: [ push ]
 
 jobs:
@@ -8,9 +7,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
     - name: Push to coveralls.io
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,4 +12,4 @@ jobs:
       with:
           toolchain: stable
           components: rustfmt, clippy
-    - uses: pre-commit/action@v2.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,7 +6,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v2
     - uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,11 +7,14 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-bigint"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2018"

--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -41,11 +41,11 @@ impl<T: MachineWord, const N: usize> num_traits::PrimInt for FixedUInt<T, N> {
         let b = self << (Self::BIT_SIZE - bits as usize);
         a | b
     }
-    fn signed_shl(self, _: u32) -> Self {
-        todo!()
+    fn signed_shl(self, bits: u32) -> Self {
+        self.unsigned_shl(bits)
     }
-    fn signed_shr(self, _: u32) -> Self {
-        todo!()
+    fn signed_shr(self, bits: u32) -> Self {
+        self.unsigned_shr(bits)
     }
     fn unsigned_shl(self, bits: u32) -> Self {
         core::ops::Shl::<u32>::shl(self, bits)

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -1,10 +1,9 @@
 use super::MachineWord;
 
 #[cfg(feature = "use-unsafe")]
-use core::{
-    borrow::{Borrow, BorrowMut},
-    hash::Hash,
-};
+use core::borrow::{Borrow, BorrowMut};
+
+use core::hash::Hash;
 
 #[cfg(feature = "zeroize")]
 use zeroize::DefaultIsZeroes;
@@ -76,10 +75,9 @@ impl<T: MachineWord, const N: usize> AsMut<[u8]> for BytesHolder<T, N> {
         self.as_byte_slice_mut()
     }
 }
-#[cfg(feature = "use-unsafe")]
 impl<T: MachineWord, const N: usize> Hash for BytesHolder<T, N> {
-    fn hash<H: core::hash::Hasher>(&self, _state: &mut H) {
-        todo!()
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.array.hash(state)
     }
 }
 

--- a/src/machineword.rs
+++ b/src/machineword.rs
@@ -28,6 +28,7 @@ pub trait MachineWord:
     + num_traits::FromBytes
     + num_traits::ToBytes
     + Default
+    + core::hash::Hash
 {
     type DoubleWord: num_traits::PrimInt;
     fn to_double(self) -> Self::DoubleWord;

--- a/tests/integer.rs
+++ b/tests/integer.rs
@@ -37,7 +37,10 @@ fn test_divides() {
     fn divides<T: num_integer::Integer + From<u8>>() {
         let tests = [(6u8, 3u8, true), (8, 2, true), (8, 1, true), (17, 2, false)];
         for &(multiple, multiplier, expected) in &tests {
-            assert_eq!(multiple.is_multiple_of(&multiplier), expected);
+            assert_eq!(
+                num_integer::Integer::is_multiple_of(&multiple, &multiplier),
+                expected
+            );
             assert_eq!(multiple.divides(&multiplier), expected);
         }
         let divrem = [

--- a/tests/string_convert.rs
+++ b/tests/string_convert.rs
@@ -365,3 +365,66 @@ fn fmt_to_hex() {
     test_16_bit::<Bn<u8, 2>>();
     test_16_bit::<Bn<u16, 1>>();
 }
+
+#[test]
+fn test_display() {
+    // Test zero
+    let zero = Bn::<u32, 2>::zero();
+    assert_eq!(format!("{}", zero), "0");
+
+    // Test small numbers
+    let small = Bn::<u32, 2>::from_u64(42).unwrap();
+    assert_eq!(format!("{}", small), "42");
+
+    // Test larger numbers
+    let large = Bn::<u32, 2>::from_u64(123456789).unwrap();
+    assert_eq!(format!("{}", large), "123456789");
+
+    // Test maximum u64 value
+    let max_u64 = Bn::<u64, 1>::from_u64(u64::MAX).unwrap();
+    assert_eq!(format!("{}", max_u64), "18446744073709551615");
+
+    // Test with different types
+    let u8_val = Bn::<u8, 4>::from_u32(0x12345678).unwrap();
+    assert_eq!(format!("{}", u8_val), "305419896");
+
+    let u16_val = Bn::<u16, 2>::from_u32(0x12345678).unwrap();
+    assert_eq!(format!("{}", u16_val), "305419896");
+}
+
+#[test]
+fn test_fromstr() {
+    // Test zero
+    let zero: Bn<u32, 2> = "0".parse().unwrap();
+    assert_eq!(zero, Bn::<u32, 2>::zero());
+
+    // Test small numbers
+    let small: Bn<u32, 2> = "42".parse().unwrap();
+    assert_eq!(small, Bn::<u32, 2>::from_u64(42).unwrap());
+
+    // Test larger numbers
+    let large: Bn<u32, 2> = "123456789".parse().unwrap();
+    assert_eq!(large, Bn::<u32, 2>::from_u64(123456789).unwrap());
+
+    // Test maximum u64 value
+    let max_u64: Bn<u64, 1> = "18446744073709551615".parse().unwrap();
+    assert_eq!(max_u64, Bn::<u64, 1>::from_u64(u64::MAX).unwrap());
+
+    // Test round-trip with Display
+    let original = Bn::<u32, 2>::from_u64(987654321).unwrap();
+    let string_form = format!("{}", original);
+    let parsed: Bn<u32, 2> = string_form.parse().unwrap();
+    assert_eq!(original, parsed);
+
+    // Test error cases
+    assert!("".parse::<Bn<u32, 2>>().is_err()); // empty string
+    assert!("abc".parse::<Bn<u32, 2>>().is_err()); // invalid characters
+    assert!("12a34".parse::<Bn<u32, 2>>().is_err()); // mixed valid/invalid
+
+    // Test with different types
+    let u8_val: Bn<u8, 4> = "305419896".parse().unwrap();
+    assert_eq!(u8_val, Bn::<u8, 4>::from_u32(0x12345678).unwrap());
+
+    let u16_val: Bn<u16, 2> = "305419896".parse().unwrap();
+    assert_eq!(u16_val, Bn::<u16, 2>::from_u32(0x12345678).unwrap());
+}


### PR DESCRIPTION
## Summary by Sourcery

Add string conversion support (Display and FromStr) and hashing for fixed-size big integers, fill in missing shift and hash implementations, update trait bounds, bump version, and cover new functionality with tests.

New Features:
- Implement Display formatter for FixedUInt<T, N>
- Implement FromStr parsing for FixedUInt<T, N>

Enhancements:
- Add signed_shl and signed_shr methods for FixedUInt PrimInt implementation
- Implement Hash trait for BytesHolder by hashing its internal array

Build:
- Bump crate version to 0.1.15

Tests:
- Add unit tests for Display and FromStr covering zero, small and large values, different types, round-trips, and error cases

Chores:
- Extend MachineWord trait bound to include core::hash::Hash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for displaying and parsing fixed-size unsigned integers as decimal strings.
  * Implemented signed shift operations for fixed-size unsigned integers.

* **Bug Fixes**
  * Enabled correct hashing for byte array holders, ensuring consistent behavior.

* **Tests**
  * Introduced tests for string conversion, covering formatting, parsing, and error scenarios.

* **Chores**
  * Updated package version to 0.1.15.
  * Upgraded CI workflows and pre-commit hooks to use newer versions and improved Rust toolchain setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->