### PR TITLE
Fix FromPrimitive overflow check

### DIFF
--- a/src/fixeduint/num_traits_casts.rs
+++ b/src/fixeduint/num_traits_casts.rs
@@ -30,6 +30,9 @@ impl<T: MachineWord, const N: usize> num_traits::FromPrimitive for FixedUInt<T, 
         None
     }
     fn from_u64(input: u64) -> Option<Self> {
+        // If max_value() fits in a u64, verify the input does not exceed it.
+        // When to_u64() returns `None`, the target type is wider than 64 bits
+        // and therefore any u64 value will fit.
         if let Some(max) = Self::max_value().to_u64() {
             if input > max {
                 return None;

--- a/src/fixeduint/num_traits_casts.rs
+++ b/src/fixeduint/num_traits_casts.rs
@@ -1,13 +1,13 @@
 use super::{FixedUInt, MachineWord};
 
-use num_traits::{FromPrimitive, ToPrimitive};
+use num_traits::{Bounded, FromPrimitive, ToPrimitive};
 
 impl<T: MachineWord, const N: usize> num_traits::NumCast for FixedUInt<T, N> {
     fn from<X>(arg: X) -> Option<Self>
     where
         X: ToPrimitive,
     {
-        Some(Self::from_u64(arg.to_u64()?).unwrap())
+        Self::from_u64(arg.to_u64()?)
     }
 }
 
@@ -30,6 +30,11 @@ impl<T: MachineWord, const N: usize> num_traits::FromPrimitive for FixedUInt<T, 
         None
     }
     fn from_u64(input: u64) -> Option<Self> {
+        if let Some(max) = Self::max_value().to_u64() {
+            if input > max {
+                return None;
+            }
+        }
         Some(Self::from_le_bytes(&input.to_le_bytes()))
     }
 }

--- a/tests/core_functionality.rs
+++ b/tests/core_functionality.rs
@@ -1,5 +1,5 @@
-use fixed_bigint::FixedUInt;
 use fixed_bigint::num_traits::{self, FromPrimitive};
+use fixed_bigint::FixedUInt;
 
 #[test]
 fn test_from_le_bytes() {
@@ -491,5 +491,8 @@ fn test_numcast_overflow() {
     // Casting a value larger than the destination should fail
     assert_eq!(num_traits::cast::<u32, Small>(300u32), None);
     // Casting a fitting value should succeed
-    assert_eq!(num_traits::cast::<u32, Small>(123u32), Some(Small::from(123u8)));
+    assert_eq!(
+        num_traits::cast::<u32, Small>(123u32),
+        Some(Small::from(123u8))
+    );
 }

--- a/tests/core_functionality.rs
+++ b/tests/core_functionality.rs
@@ -1,5 +1,5 @@
 use fixed_bigint::FixedUInt;
-use fixed_bigint::num_traits::FromPrimitive;
+use fixed_bigint::num_traits::{self, FromPrimitive};
 
 #[test]
 fn test_from_le_bytes() {
@@ -482,4 +482,14 @@ fn test_from_u64_overflow() {
     type Medium = FixedUInt<u8, 2>; // 16-bit capacity
     assert_eq!(Medium::from_u64(65535), Some(Medium::from(65535u16)));
     assert_eq!(Medium::from_u64(65536), None);
+}
+
+#[test]
+fn test_numcast_overflow() {
+    type Small = FixedUInt<u8, 1>;
+
+    // Casting a value larger than the destination should fail
+    assert_eq!(num_traits::cast::<u32, Small>(300u32), None);
+    // Casting a fitting value should succeed
+    assert_eq!(num_traits::cast::<u32, Small>(123u32), Some(Small::from(123u8)));
 }

--- a/tests/core_functionality.rs
+++ b/tests/core_functionality.rs
@@ -1,4 +1,5 @@
 use fixed_bigint::FixedUInt;
+use fixed_bigint::num_traits::FromPrimitive;
 
 #[test]
 fn test_from_le_bytes() {
@@ -466,4 +467,19 @@ fn test_string_conversion_edge_cases() {
     let result = value.to_radix_str(&mut buffer, 16);
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), "f");
+}
+
+#[test]
+fn test_from_u64_overflow() {
+    type Small = FixedUInt<u8, 1>; // 8-bit capacity
+
+    // Value that fits
+    assert_eq!(Small::from_u64(255), Some(Small::from(255u8)));
+
+    // Value that exceeds 8-bit should return None
+    assert_eq!(Small::from_u64(256), None);
+
+    type Medium = FixedUInt<u8, 2>; // 16-bit capacity
+    assert_eq!(Medium::from_u64(65535), Some(Medium::from(65535u16)));
+    assert_eq!(Medium::from_u64(65536), None);
 }


### PR DESCRIPTION
## Summary
- handle overflow in `FromPrimitive::from_u64`
- update `NumCast` to use the checked conversion
- test overflow behavior for `from_u64`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687dcdd370dc8331a31d7e9872b5c88d

## Summary by Sourcery

Prevent unchecked overflow when converting from u64 to FixedUInt by adding range checks and corresponding tests.

Enhancements:
- Add overflow check in FromPrimitive::from_u64 to return None for out-of-range inputs.

Tests:
- Add tests for from_u64 overflow behavior on 8-bit and 16-bit FixedUInt types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric conversions to prevent overflow when converting large values to fixed-size integers.

* **Tests**
  * Added tests to verify correct behavior when converting values that exceed the capacity of fixed-size integers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->