### PR TITLE
Improve rotate tests

### DIFF
--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -32,13 +32,15 @@ impl<T: MachineWord, const N: usize> num_traits::PrimInt for FixedUInt<T, N> {
         ret
     }
     fn rotate_left(self, bits: u32) -> Self {
-        let a = self << bits;
-        let b = self >> (Self::BIT_SIZE - bits as usize);
+        let shift = bits % (Self::BIT_SIZE as u32);
+        let a = self << shift;
+        let b = self >> (Self::BIT_SIZE as u32 - shift);
         a | b
     }
     fn rotate_right(self, bits: u32) -> Self {
-        let a = self >> bits;
-        let b = self << (Self::BIT_SIZE - bits as usize);
+        let shift = bits % (Self::BIT_SIZE as u32);
+        let a = self >> shift;
+        let b = self << (Self::BIT_SIZE as u32 - shift);
         a | b
     }
     fn signed_shl(self, bits: u32) -> Self {

--- a/tests/bit_shift.rs
+++ b/tests/bit_shift.rs
@@ -245,6 +245,14 @@ fn test_rotate() {
         assert_eq!(a.rotate_left(full_shift), a);
         assert_eq!(b.rotate_right(1), a);
         assert_eq!(b.rotate_right(full_shift), b);
+
+        // Rotations larger than the bit width should wrap around
+        let bit_width = (core::mem::size_of::<INT>() * 8) as u32;
+        let overflow_shift = full_shift + 5;
+        let expected_left = a.rotate_left(overflow_shift % bit_width);
+        assert_eq!(a.rotate_left(overflow_shift), expected_left);
+        let expected_right = a.rotate_right(overflow_shift % bit_width);
+        assert_eq!(a.rotate_right(overflow_shift), expected_right);
     }
     let test_8bit = (0xc1, 0x83, 0x1C);
     test_rotate::<u8, u8>(test_8bit, 4, 8);


### PR DESCRIPTION
## Summary
- expand `test_rotate` in `bit_shift` to cover large shift values
- handle overflow rotation in `FixedUInt::rotate_left` and `rotate_right`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ddcf16bd08331b7f8a6526fe28793