### PR TITLE
Fix coveralls action version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,4 +24,4 @@ jobs:
         cargo llvm-cov --lcov --output-path lcov.info
 
     - name: Coveralls GitHub Action
-      uses: coverallsapp/github-action@v2.3.6
+      uses: coverallsapp/github-action@v2


### PR DESCRIPTION
## Summary
- update workflow to use coveralls action major version

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687df1e1c0c48331989bd51e6cd7438b

## Summary by Sourcery

CI:
- Bump Coveralls GitHub Action from v2.3.6 to v2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the coverage reporting workflow to use the latest v2 version of the Coveralls GitHub Action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->