### PR TITLE
Reduce stack size in division

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -533,12 +533,6 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
         let dividend_bits = dividend.bit_length() as usize;
         let divisor_bits = divisor.bit_length() as usize;
 
-        if dividend_bits < divisor_bits {
-            let remainder = *dividend;
-            *dividend = Self::zero();
-            return remainder;
-        }
-
         let mut bit_pos = dividend_bits.saturating_sub(divisor_bits);
 
         // Adjust bit position to find the first position where divisor can be subtracted

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -249,7 +249,7 @@ impl<T: MachineWord, const N: usize> core::ops::RemAssign<Self> for FixedUInt<T,
         if other.is_zero() {
             maybe_panic(PanicReason::RemByZero)
         }
-        *self = Self::div_assign_impl(self, &other);
+        *self = self.div_rem(&other).1;
     }
 }
 
@@ -258,7 +258,7 @@ impl<T: MachineWord, const N: usize> core::ops::RemAssign<&'_ Self> for FixedUIn
         if other.is_zero() {
             maybe_panic(PanicReason::RemByZero)
         }
-        *self = Self::div_assign_impl(self, other);
+        *self = self.div_rem(other).1;
     }
 }
 

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -181,7 +181,7 @@ impl<T: MachineWord, const N: usize> core::ops::DivAssign<Self> for FixedUInt<T,
         if other.is_zero() {
             maybe_panic(PanicReason::DivByZero)
         }
-        *self = Self::div_impl(self, &other);
+        Self::div_assign_impl(self, &other);
     }
 }
 
@@ -190,7 +190,7 @@ impl<T: MachineWord, const N: usize> core::ops::DivAssign<&'_ Self> for FixedUIn
         if other.is_zero() {
             maybe_panic(PanicReason::DivByZero)
         }
-        *self = Self::div_impl(self, other);
+        Self::div_assign_impl(self, other);
     }
 }
 
@@ -249,7 +249,7 @@ impl<T: MachineWord, const N: usize> core::ops::RemAssign<Self> for FixedUInt<T,
         if other.is_zero() {
             maybe_panic(PanicReason::RemByZero)
         }
-        *self = self.div_rem(&other).1;
+        *self = Self::div_assign_impl(self, &other);
     }
 }
 
@@ -258,7 +258,7 @@ impl<T: MachineWord, const N: usize> core::ops::RemAssign<&'_ Self> for FixedUIn
         if other.is_zero() {
             maybe_panic(PanicReason::RemByZero)
         }
-        *self = self.div_rem(other).1;
+        *self = Self::div_assign_impl(self, other);
     }
 }
 


### PR DESCRIPTION
Removes 2 extra temporary full number copies from
division #15

## Summary by Sourcery

Replace the previous division routine with an optimized in-place algorithm that uses bit-level helper methods to eliminate extra temporaries and reduce stack usage; update division and remainder operators to leverage the new implementation and add comprehensive tests covering helper functions and division correctness.

New Features:
- Add helper methods for bit-level operations: set_bit, cmp_shifted, get_shifted_word, sub_shifted, and sub_with_borrow.
- Introduce div_assign_impl to perform in-place division on a mutable dividend and return the remainder.

Enhancements:
- Simplify div_impl to forward to div_assign_impl on a copy.
- Update DivAssign and RemAssign operator implementations to call the in-place division routine instead of reallocating temporaries.

Tests:
- Add extensive tests for the optimized division implementation, helper methods, shifted operations, operator forwarding, stack efficiency, and division property-based checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved division performance with a new, optimized in-place algorithm for large unsigned integers.
  * Added new helper methods for advanced bitwise operations.

* **Bug Fixes**
  * Enhanced correctness and reliability of division and remainder operations, especially for edge cases.

* **Tests**
  * Introduced extensive new tests to verify division accuracy and helper method behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->