### PR TITLE
Add no-std::no-alloc category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ Fixed-size big integer implementation for Rust
 """
 
 keywords = ["mathematics", "numerics", "bignum"]
-categories = [ "algorithms", "data-structures", "no-std"]
+categories = [ "algorithms", "data-structures", "no-std", "no-std::no-alloc" ]
 repository = "https://github.com/kaidokert/fixed-bigint-rs"
 readme = "README.md"
 homepage = "https://github.com/kaidokert/fixed-bigint-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ Fixed-size big integer implementation for Rust
 """
 
 keywords = ["mathematics", "numerics", "bignum"]
-categories = [ "algorithms", "data-structures", "no-std", "no-std::no-alloc" ]
+categories = [ "algorithms", "data-structures", "no-std", "no-std::no-alloc"]
 repository = "https://github.com/kaidokert/fixed-bigint-rs"
 readme = "README.md"
 homepage = "https://github.com/kaidokert/fixed-bigint-rs"


### PR DESCRIPTION
## Summary
- add `no-std::no-alloc` crate category in Cargo.toml

## Testing
- `pre-commit run --files Cargo.toml`
- `cargo test`
- `cargo test --features zeroize`
- `cargo test --features use-unsafe`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_687fac4589b483318b7f1eb4eb95e6b1

## Summary by Sourcery

Enhancements:
- Include "no-std::no-alloc" in the crate's categories list in Cargo.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to include an additional category tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->