### PR TITLE
Add ConstSaturatingAdd/Sub for FixedUInt

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use num_traits::ops::overflowing::{OverflowingAdd, OverflowingSub};
-use num_traits::{Bounded, One, PrimInt, ToPrimitive, Zero};
+use num_traits::{One, PrimInt, ToPrimitive, Zero};
 
 use core::convert::TryFrom;
 use core::fmt::Write;
@@ -327,18 +326,6 @@ c0nst::c0nst! {
     }
 }
 
-impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
-    // Here to avoid duplicating this in two traits
-    fn saturating_add_impl(self, other: &Self) -> Self {
-        let res = self.overflowing_add(other);
-        if res.1 {
-            Self::max_value()
-        } else {
-            res.0
-        }
-    }
-}
-
 c0nst::c0nst! {
     /// Const-compatible sub implementation operating on raw arrays
     pub(crate) c0nst fn sub_impl<T: [c0nst] ConstMachineWord, const N: usize>(
@@ -363,15 +350,6 @@ c0nst::c0nst! {
 }
 
 impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
-    fn saturating_sub_impl(self, other: &Self) -> Self {
-        let res = self.overflowing_sub(other);
-        if res.1 {
-            <Self as Zero>::zero()
-        } else {
-            res.0
-        }
-    }
-
     // Multiply op1 with op2, return overflow status
     // Note: uses extra `result` variable, not sure if in-place multiply is possible at all.
     fn mul_impl<const CHECK_OVERFLOW: bool>(op1: &Self, op2: &Self) -> (Self, bool) {


### PR DESCRIPTION
#58

## Summary by Sourcery

Introduce const-evaluable saturating addition and subtraction support and integrate it with FixedUInt and existing saturating traits.

New Features:
- Add ConstSaturatingAdd and ConstSaturatingSub traits with const-compatible saturating add/sub operations for integer types and FixedUInt.
- Expose generic const functions for saturating_add and saturating_sub over ConstSaturatingAdd/ConstSaturatingSub types.

Enhancements:
- Refactor FixedUInt’s num_traits::SaturatingAdd/SaturatingSub and deprecated num_traits::Saturating implementations to reuse the new ConstSaturatingAdd/ConstSaturatingSub logic.
- Adjust FixedUInt tests to use the Bounded trait for max_value retrieval instead of direct associated methods where appropriate.

Tests:
- Add unit tests (including const-evaluated nightly tests) covering saturating_add and saturating_sub behavior for primitive integers and FixedUInt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added compile-time saturating arithmetic operations for improved overflow safety
  - Enables saturating addition and subtraction in const evaluation contexts
  - Automatically prevents overflow by clamping addition results to maximum value
  - Automatically prevents underflow by clamping subtraction results to zero
  - Integrated across numeric type implementations for consistent behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->