### PR TITLE
Constify bitwise ops (Not, And, Or, Xor, Shl, Shr)

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -580,9 +580,22 @@ c0nst::c0nst! {
         target: &mut FixedUInt<T, N>,
         bits: usize,
     ) {
+        if N == 0 {
+            return;
+        }
         let word_bits = FixedUInt::<T, N>::WORD_BITS;
         let nwords = bits / word_bits;
         let nbits = bits - nwords * word_bits;
+
+        // If shift >= total bits, result is zero
+        if nwords >= N {
+            let mut i = 0;
+            while i < N {
+                target.array[i] = T::zero();
+                i += 1;
+            }
+            return;
+        }
 
         // Move words (backwards)
         let mut i = N;
@@ -592,7 +605,7 @@ c0nst::c0nst! {
         }
         // Zero out the lower words
         let mut i = 0;
-        while i < nwords && i < N {
+        while i < nwords {
             target.array[i] = T::zero();
             i += 1;
         }
@@ -615,9 +628,22 @@ c0nst::c0nst! {
         target: &mut FixedUInt<T, N>,
         bits: usize,
     ) {
+        if N == 0 {
+            return;
+        }
         let word_bits = FixedUInt::<T, N>::WORD_BITS;
         let nwords = bits / word_bits;
         let nbits = bits - nwords * word_bits;
+
+        // If shift >= total bits, result is zero
+        if nwords >= N {
+            let mut i = 0;
+            while i < N {
+                target.array[i] = T::zero();
+                i += 1;
+            }
+            return;
+        }
 
         let last_index = N - 1;
         let last_word = N - nwords;

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -299,7 +299,13 @@ impl<T: MachineWord, const N: usize> OverflowingShl for FixedUInt<T, N> {
     fn overflowing_shl(self, bits: u32) -> (Self, bool) {
         let bitsu = bits as usize;
         let (shift, overflow) = if bitsu >= Self::BIT_SIZE {
-            (bitsu & (Self::BIT_SIZE - 1), true)
+            // Use modulo for correct wrapping with non-power-of-2 bit sizes
+            let shift = if Self::BIT_SIZE == 0 {
+                0
+            } else {
+                bitsu % Self::BIT_SIZE
+            };
+            (shift, true)
         } else {
             (bitsu, false)
         };
@@ -312,7 +318,13 @@ impl<T: MachineWord, const N: usize> OverflowingShr for FixedUInt<T, N> {
     fn overflowing_shr(self, bits: u32) -> (Self, bool) {
         let bitsu = bits as usize;
         let (shift, overflow) = if bitsu >= Self::BIT_SIZE {
-            (bitsu & (Self::BIT_SIZE - 1), true)
+            // Use modulo for correct wrapping with non-power-of-2 bit sizes
+            let shift = if Self::BIT_SIZE == 0 {
+                0
+            } else {
+                bitsu % Self::BIT_SIZE
+            };
+            (shift, true)
         } else {
             (bitsu, false)
         };
@@ -494,8 +506,8 @@ mod tests {
             const AND_AB: TestInt = A & B;
             const OR_AB: TestInt = A | B;
             const XOR_AB: TestInt = A ^ B;
-            const SHL_1: TestInt = FixedUInt::<u8, 2> { array: [1, 0] } << 4usize;
-            const SHR_16: TestInt = FixedUInt::<u8, 2> { array: [16, 0] } >> 2usize;
+            const SHL_1: TestInt = FixedUInt { array: [1u8, 0] } << 4usize;
+            const SHR_16: TestInt = FixedUInt { array: [16u8, 0] } >> 2usize;
 
             assert_eq!(NOT_A.array[0], 0b00110011);
             assert_eq!(AND_AB.array[0], 0b10001000);


### PR DESCRIPTION
Bitwise ops constified #58

## Summary by Sourcery

Const-enable bitwise operations and shifting for FixedUInt and add tests to validate both runtime and const-evaluated behavior.

Enhancements:
- Introduce const-compatible left and right shift implementations for FixedUInt using ConstMachineWord.
- Refine internal shift normalization utilities to support const-friendly rotation and shifting behavior.

Tests:
- Add runtime tests for bitwise NOT, AND, OR, XOR, left shift, and right shift on FixedUInt.
- Add nightly-only const-eval tests to ensure FixedUInt bitwise operations and shifts work in const contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Shift and bitwise operations reorganized to enable compile-time evaluation and broader const-compatible usage.

* **Behavior**
  * Shift behavior normalized for out-of-range counts and consistent word/bit handling across contexts.

* **Tests**
  * Added tests validating const-context bitwise and shift operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->