### PR TITLE
Refactor: shorten names

### DIFF
--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -1,6 +1,6 @@
 use num_traits::Zero;
 
-use super::{const_array_mul, maybe_panic, FixedUInt, MachineWord, PanicReason};
+use super::{const_mul, maybe_panic, FixedUInt, MachineWord, PanicReason};
 use crate::const_numtrait::{
     ConstBounded, ConstCheckedMul, ConstOverflowingMul, ConstSaturatingMul, ConstWrappingMul,
 };
@@ -17,14 +17,14 @@ impl<T: MachineWord, const N: usize> num_traits::ops::overflowing::OverflowingMu
 c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstOverflowingMul for FixedUInt<T, N> {
         fn overflowing_mul(&self, other: &Self) -> (Self, bool) {
-            let (array, overflow) = const_array_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
             (Self { array }, overflow)
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstWrappingMul for FixedUInt<T, N> {
         fn wrapping_mul(&self, other: &Self) -> Self {
-            let (array, _) = const_array_mul::<T, N, false>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, _) = const_mul::<T, N, false>(&self.array, &other.array, Self::WORD_BITS);
             Self { array }
         }
     }
@@ -48,7 +48,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul for FixedUInt<T, N> {
         type Output = Self;
         fn mul(self, other: Self) -> Self::Output {
-            let (array, overflow) = const_array_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
             if overflow {
                 maybe_panic(PanicReason::Mul);
             }
@@ -59,7 +59,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul<&FixedUInt<T, N>> for FixedUInt<T, N> {
         type Output = Self;
         fn mul(self, other: &FixedUInt<T, N>) -> Self::Output {
-            let (array, overflow) = const_array_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
             if overflow {
                 maybe_panic(PanicReason::Mul);
             }
@@ -70,7 +70,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul<FixedUInt<T, N>> for &FixedUInt<T, N> {
         type Output = FixedUInt<T, N>;
         fn mul(self, other: FixedUInt<T, N>) -> Self::Output {
-            let (array, overflow) = const_array_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
             if overflow {
                 maybe_panic(PanicReason::Mul);
             }
@@ -81,7 +81,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul<&FixedUInt<T, N>> for &FixedUInt<T, N> {
         type Output = FixedUInt<T, N>;
         fn mul(self, other: &FixedUInt<T, N>) -> Self::Output {
-            let (array, overflow) = const_array_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
             if overflow {
                 maybe_panic(PanicReason::Mul);
             }
@@ -92,7 +92,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul<&&FixedUInt<T, N>> for &FixedUInt<T, N> {
         type Output = FixedUInt<T, N>;
         fn mul(self, other: &&FixedUInt<T, N>) -> Self::Output {
-            let (array, overflow) = const_array_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
             if overflow {
                 maybe_panic(PanicReason::Mul);
             }
@@ -102,7 +102,7 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::MulAssign for FixedUInt<T, N> {
         fn mul_assign(&mut self, other: Self) {
-            let (array, overflow) = const_array_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
             if overflow {
                 maybe_panic(PanicReason::Mul);
             }
@@ -112,7 +112,7 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::MulAssign<&FixedUInt<T, N>> for FixedUInt<T, N> {
         fn mul_assign(&mut self, other: &FixedUInt<T, N>) {
-            let (array, overflow) = const_array_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
             if overflow {
                 maybe_panic(PanicReason::Mul);
             }

--- a/src/fixeduint/num_traits_identity.rs
+++ b/src/fixeduint/num_traits_identity.rs
@@ -1,4 +1,4 @@
-use super::{const_array_is_zero, FixedUInt, MachineWord};
+use super::{const_is_zero, FixedUInt, MachineWord};
 use crate::const_numtrait::{ConstBounded, ConstOne, ConstZero};
 use crate::machineword::ConstMachineWord;
 
@@ -10,7 +10,7 @@ c0nst::c0nst! {
             }
         }
         fn is_zero(&self) -> bool {
-            const_array_is_zero(&self.array)
+            const_is_zero(&self.array)
         }
         fn set_zero(&mut self) {
             let mut i = 0;

--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -1,4 +1,4 @@
-use super::{const_array_leading_zeros, const_array_trailing_zeros, FixedUInt, MachineWord};
+use super::{const_leading_zeros, const_trailing_zeros, FixedUInt, MachineWord};
 
 use num_traits::One;
 
@@ -10,10 +10,10 @@ impl<T: MachineWord, const N: usize> num_traits::PrimInt for FixedUInt<T, N> {
         self.array.iter().map(|&val| val.count_zeros()).sum()
     }
     fn leading_zeros(self) -> u32 {
-        const_array_leading_zeros(&self.array)
+        const_leading_zeros(&self.array)
     }
     fn trailing_zeros(self) -> u32 {
-        const_array_trailing_zeros(&self.array)
+        const_trailing_zeros(&self.array)
     }
     fn rotate_left(self, bits: u32) -> Self {
         let shift = Self::normalize_shift(bits);


### PR DESCRIPTION
## Summary by Sourcery

Rename const helper functions for FixedUInt to use shorter, array-agnostic names and update all call sites accordingly.

Enhancements:
- Shorten and standardize names of const helper functions for multiplication, bit operations, comparisons, and shifts, and propagate these renames across FixedUInt implementations and tests.
- Rename related test functions to match the new const helper naming scheme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization and naming updates to improve maintainability. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->