### PR TITLE
Const div implementation

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -765,28 +765,30 @@ c0nst::c0nst! {
     ) -> [T; N] {
         use core::cmp::Ordering;
 
-        // dividend < divisor: quotient = 0, remainder = dividend
-        if matches!(const_cmp::<T, N>(dividend, divisor), Ordering::Less) {
-            let remainder = *dividend;
-            let mut i = 0;
-            while i < N {
-                dividend[i] = <T as ConstZero>::zero();
-                i += 1;
+        match const_cmp::<T, N>(dividend, divisor) {
+            // dividend < divisor: quotient = 0, remainder = dividend
+            Ordering::Less => {
+                let remainder = *dividend;
+                let mut i = 0;
+                while i < N {
+                    dividend[i] = <T as ConstZero>::zero();
+                    i += 1;
+                }
+                return remainder;
             }
-            return remainder;
-        }
-
-        // dividend == divisor: quotient = 1, remainder = 0
-        if matches!(const_cmp::<T, N>(dividend, divisor), Ordering::Equal) {
-            let mut i = 0;
-            while i < N {
-                dividend[i] = <T as ConstZero>::zero();
-                i += 1;
+            // dividend == divisor: quotient = 1, remainder = 0
+            Ordering::Equal => {
+                let mut i = 0;
+                while i < N {
+                    dividend[i] = <T as ConstZero>::zero();
+                    i += 1;
+                }
+                if N > 0 {
+                    dividend[0] = <T as ConstOne>::one();
+                }
+                return [<T as ConstZero>::zero(); N];
             }
-            if N > 0 {
-                dividend[0] = <T as ConstOne>::one();
-            }
-            return [<T as ConstZero>::zero(); N];
+            Ordering::Greater => {}
         }
 
         let mut quotient = [<T as ConstZero>::zero(); N];


### PR DESCRIPTION
Div part of c0nstification #58

## Summary by Sourcery

Implement const-evaluable division for FixedUInt and update internal helpers to use array-based const operations.

New Features:
- Add const-compatible division routine operating on FixedUInt backing arrays.

Enhancements:
- Refactor FixedUInt division implementation to delegate to shared const_div logic.
- Introduce const_sub_shifted helper for subtracting shifted divisors in-place on word arrays.
- Adapt helper-method tests to exercise const-based bit, compare, and subtract operations on underlying arrays.

Tests:
- Update and extend helper method tests to validate const_cmp_shifted, const_sub_shifted, and const_set_bit behavior across edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed several utility methods from fixed-size unsigned integer handling.

* **Improvements**
  * Added broader compile-time (const) evaluation support for arithmetic operations.
  * Reworked division to use a const-friendly path that yields quotient in-place and returns remainder.
  * Introduced const helpers for array-based arithmetic to enable const-context algorithms.

* **Tests**
  * Updated test suite and scaffolding to use the new const-based helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->