### PR TITLE
Add ConstCheckedDiv and ConstCheckedRem traits

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -436,6 +436,42 @@ const_saturating_mul_impl!(u32);
 const_saturating_mul_impl!(u64);
 const_saturating_mul_impl!(u128);
 
+macro_rules! const_checked_div_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstCheckedDiv for $t {
+                fn checked_div(&self, v: &Self) -> Option<Self> {
+                    if v.is_zero() { None } else { Some(*self / *v) }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! const_checked_rem_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstCheckedRem for $t {
+                fn checked_rem(&self, v: &Self) -> Option<Self> {
+                    if v.is_zero() { None } else { Some(*self % *v) }
+                }
+            }
+        }
+    };
+}
+
+const_checked_div_impl!(u8);
+const_checked_div_impl!(u16);
+const_checked_div_impl!(u32);
+const_checked_div_impl!(u64);
+const_checked_div_impl!(u128);
+
+const_checked_rem_impl!(u8);
+const_checked_rem_impl!(u16);
+const_checked_rem_impl!(u32);
+const_checked_rem_impl!(u64);
+const_checked_rem_impl!(u128);
+
 macro_rules! const_to_bytes_impl {
     ($t:ty, $n:expr) => {
         c0nst::c0nst! {

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -212,7 +212,7 @@ c0nst::c0nst! {
             if <Self as ConstZero>::is_zero(other) {
                 None
             } else {
-                Some(Self { array: div_impl(&self.array, &other.array) })
+                Some(*self / *other)
             }
         }
     }
@@ -284,7 +284,7 @@ c0nst::c0nst! {
             if <Self as ConstZero>::is_zero(other) {
                 None
             } else {
-                Some(Self { array: rem_impl(&self.array, &other.array) })
+                Some(*self % *other)
             }
         }
     }
@@ -491,12 +491,10 @@ mod tests {
             const CHECKED_REM_OK: Option<FixedUInt<u8, 2>> = const_checked_rem(&A, &B);
             const CHECKED_REM_ZERO: Option<FixedUInt<u8, 2>> = const_checked_rem(&A, &ZERO);
 
-            assert!(CHECKED_DIV_OK.is_some());
-            assert_eq!(CHECKED_DIV_OK.unwrap().array, [7, 0]);
-            assert!(CHECKED_DIV_ZERO.is_none());
-            assert!(CHECKED_REM_OK.is_some());
-            assert_eq!(CHECKED_REM_OK.unwrap().array, [1, 0]);
-            assert!(CHECKED_REM_ZERO.is_none());
+            assert_eq!(CHECKED_DIV_OK, Some(FixedUInt { array: [7, 0] }));
+            assert_eq!(CHECKED_DIV_ZERO, None);
+            assert_eq!(CHECKED_REM_OK, Some(FixedUInt { array: [1, 0] }));
+            assert_eq!(CHECKED_REM_ZERO, None);
         }
     }
 }


### PR DESCRIPTION
One more leg of #58

## Summary by Sourcery

Add const-evaluable checked division and remainder support for integer types and FixedUInt, and reuse these implementations in existing checked ops.

New Features:
- Introduce ConstCheckedDiv and ConstCheckedRem traits for const-friendly checked division and remainder operations.
- Implement ConstCheckedDiv and ConstCheckedRem for primitive unsigned integers and FixedUInt, with corresponding const helper functions for FixedUInt.

Tests:
- Add runtime and nightly const-eval tests covering successful and divide-by-zero cases for const_checked_div and const_checked_rem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checked division and remainder operations that return `None` on divide-by-zero and extended them to fixed-size unsigned integer types, including const-evaluable variants.
* **Tests**
  * Added tests covering valid results and divide-by-zero behavior, including compile-time (const) checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->