### PR TITLE
Constify PartialEq, Eq, Ord, PartialOrd

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -840,7 +840,7 @@ impl<T: MachineWord, const N: usize> num_traits::Unsigned for FixedUInt<T, N> {}
 c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::cmp::PartialEq for FixedUInt<T, N> {
         fn eq(&self, other: &Self) -> bool {
-            matches!(const_cmp(&self.array, &other.array), core::cmp::Ordering::Equal)
+            self.array == other.array
         }
     }
 


### PR DESCRIPTION
Continue c0nstify #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fixed-size unsigned integer types now support compile-time (const) equality and ordering comparisons.

* **Tests**
  * Added test coverage exercising const-enabled comparison and ordering behavior at compile time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->