### PR TITLE
Constify From<u8/u16/u32/u64> conversions

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -886,11 +886,7 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::convert::From<u8> for FixedUInt<T, N> {
         fn from(x: u8) -> Self {
-            let mut arr: [T; N] = [T::zero(); N];
-            if N > 0 {
-                arr[0] = T::from(x);
-            }
-            Self { array: arr }
+            Self { array: const_from_le_bytes(x.to_le_bytes()) }
         }
     }
 


### PR DESCRIPTION
Const convert::from #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a const-compatible little-endian byte conversion helper and enabled const construction of FixedUInt from standard integers (u8, u16, u32, u64), allowing compile-time creation of these values.

* **Tests**
  * Added nightly-guarded tests validating const initialization behavior across various types and sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->