### PR TITLE
Add 6 remaining methods to ConstPrimInt

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -171,6 +171,14 @@ c0nst::c0nst! {
             fn signed_shr(self, n: u32) -> Self {
                 self.unsigned_shr(n)
             }
+
+            // PR 2: Endianness conversions, reverse_bits, pow
+            fn reverse_bits(self) -> Self;
+            fn from_be(x: Self) -> Self;
+            fn from_le(x: Self) -> Self;
+            fn to_be(self) -> Self;
+            fn to_le(self) -> Self;
+            fn pow(self, exp: u32) -> Self;
     }
 }
 
@@ -222,6 +230,12 @@ macro_rules! const_prim_int_impl {
                 fn rotate_right(self, n: u32) -> Self { self.rotate_right(n) }
                 fn unsigned_shl(self, n: u32) -> Self { self << n }
                 fn unsigned_shr(self, n: u32) -> Self { self >> n }
+                fn reverse_bits(self) -> Self { self.reverse_bits() }
+                fn from_be(x: Self) -> Self { <$t>::from_be(x) }
+                fn from_le(x: Self) -> Self { <$t>::from_le(x) }
+                fn to_be(self) -> Self { self.to_be() }
+                fn to_le(self) -> Self { self.to_le() }
+                fn pow(self, exp: u32) -> Self { self.pow(exp) }
             }
         }
     };

--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -65,6 +65,51 @@ c0nst::c0nst! {
         fn unsigned_shr(self, n: u32) -> Self {
             core::ops::Shr::<u32>::shr(self, n)
         }
+        fn reverse_bits(self) -> Self {
+            let mut ret = <Self as crate::const_numtrait::ConstZero>::zero();
+            let mut i = 0;
+            while i < N {
+                ret.array[N - 1 - i] = self.array[i].reverse_bits();
+                i += 1;
+            }
+            ret
+        }
+        fn from_be(x: Self) -> Self {
+            let mut ret = <Self as crate::const_numtrait::ConstZero>::zero();
+            let mut i = 0;
+            while i < N {
+                ret.array[i] = x.array[N - 1 - i].swap_bytes();
+                i += 1;
+            }
+            ret
+        }
+        fn from_le(x: Self) -> Self {
+            x
+        }
+        fn to_be(self) -> Self {
+            let mut ret = <Self as crate::const_numtrait::ConstZero>::zero();
+            let mut i = 0;
+            while i < N {
+                ret.array[i] = self.array[N - 1 - i].swap_bytes();
+                i += 1;
+            }
+            ret
+        }
+        fn to_le(self) -> Self {
+            self
+        }
+        fn pow(self, exp: u32) -> Self {
+            if exp == 0 {
+                return <Self as crate::const_numtrait::ConstOne>::one();
+            }
+            let mut ret = self;
+            let mut i = 1u32;
+            while i < exp {
+                ret = core::ops::Mul::mul(ret, self);
+                i += 1;
+            }
+            ret
+        }
     }
 }
 


### PR DESCRIPTION
Adds reverse_bits, from_be, from_le, to_be, to_le, pow. #58

## Summary by Sourcery

Extend const integer traits and implementations with additional bit and endianness operations.

New Features:
- Add reverse_bits, endianness conversion (from_be/from_le/to_be/to_le), and pow methods to the const integer trait.
- Provide corresponding implementations of the new methods for fixed-width const integers and primitive integer types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bit reversal and endianness conversion methods (`reverse_bits`, `from_be`, `from_le`, `to_be`, `to_le`) to primitive integer types.
  * Added exponentiation method (`pow`) for computing powers of integers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->