### PR TITLE
Add const shift variant traits

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -103,6 +103,38 @@ c0nst::c0nst! {
         fn checked_rem(&self, v: &Self) -> Option<Self>;
     }
 
+    pub c0nst trait ConstOverflowingShl: Sized + [c0nst] core::ops::Shl<u32, Output = Self> {
+        /// Shift left with overflow detection.
+        /// Returns the shifted value and whether the shift amount exceeded the bit width.
+        fn overflowing_shl(self, rhs: u32) -> (Self, bool);
+    }
+
+    pub c0nst trait ConstOverflowingShr: Sized + [c0nst] core::ops::Shr<u32, Output = Self> {
+        /// Shift right with overflow detection.
+        /// Returns the shifted value and whether the shift amount exceeded the bit width.
+        fn overflowing_shr(self, rhs: u32) -> (Self, bool);
+    }
+
+    pub c0nst trait ConstWrappingShl: Sized + [c0nst] ConstOverflowingShl {
+        /// Wrapping shift left. Shifts, masking the shift amount to the bit width.
+        fn wrapping_shl(self, rhs: u32) -> Self;
+    }
+
+    pub c0nst trait ConstWrappingShr: Sized + [c0nst] ConstOverflowingShr {
+        /// Wrapping shift right. Shifts, masking the shift amount to the bit width.
+        fn wrapping_shr(self, rhs: u32) -> Self;
+    }
+
+    pub c0nst trait ConstCheckedShl: Sized + [c0nst] ConstOverflowingShl {
+        /// Checked shift left. Returns `None` if the shift amount exceeds bit width.
+        fn checked_shl(self, rhs: u32) -> Option<Self>;
+    }
+
+    pub c0nst trait ConstCheckedShr: Sized + [c0nst] ConstOverflowingShr {
+        /// Checked shift right. Returns `None` if the shift amount exceeds bit width.
+        fn checked_shr(self, rhs: u32) -> Option<Self>;
+    }
+
     pub c0nst trait ConstToBytes {
         type Bytes: Copy + AsRef<[u8]> + AsMut<[u8]>;
         fn to_le_bytes(&self) -> Self::Bytes;
@@ -516,6 +548,116 @@ const_checked_rem_impl!(u16);
 const_checked_rem_impl!(u32);
 const_checked_rem_impl!(u64);
 const_checked_rem_impl!(u128);
+
+macro_rules! const_overflowing_shl_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstOverflowingShl for $t {
+                fn overflowing_shl(self, rhs: u32) -> (Self, bool) {
+                    self.overflowing_shl(rhs)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! const_overflowing_shr_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstOverflowingShr for $t {
+                fn overflowing_shr(self, rhs: u32) -> (Self, bool) {
+                    self.overflowing_shr(rhs)
+                }
+            }
+        }
+    };
+}
+
+macro_rules! const_wrapping_shl_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstWrappingShl for $t {
+                fn wrapping_shl(self, rhs: u32) -> Self {
+                    self.overflowing_shl(rhs).0
+                }
+            }
+        }
+    };
+}
+
+macro_rules! const_wrapping_shr_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstWrappingShr for $t {
+                fn wrapping_shr(self, rhs: u32) -> Self {
+                    self.overflowing_shr(rhs).0
+                }
+            }
+        }
+    };
+}
+
+macro_rules! const_checked_shl_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstCheckedShl for $t {
+                fn checked_shl(self, rhs: u32) -> Option<Self> {
+                    let (res, overflow) = self.overflowing_shl(rhs);
+                    if overflow { None } else { Some(res) }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! const_checked_shr_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstCheckedShr for $t {
+                fn checked_shr(self, rhs: u32) -> Option<Self> {
+                    let (res, overflow) = self.overflowing_shr(rhs);
+                    if overflow { None } else { Some(res) }
+                }
+            }
+        }
+    };
+}
+
+const_overflowing_shl_impl!(u8);
+const_overflowing_shl_impl!(u16);
+const_overflowing_shl_impl!(u32);
+const_overflowing_shl_impl!(u64);
+const_overflowing_shl_impl!(u128);
+
+const_overflowing_shr_impl!(u8);
+const_overflowing_shr_impl!(u16);
+const_overflowing_shr_impl!(u32);
+const_overflowing_shr_impl!(u64);
+const_overflowing_shr_impl!(u128);
+
+const_wrapping_shl_impl!(u8);
+const_wrapping_shl_impl!(u16);
+const_wrapping_shl_impl!(u32);
+const_wrapping_shl_impl!(u64);
+const_wrapping_shl_impl!(u128);
+
+const_wrapping_shr_impl!(u8);
+const_wrapping_shr_impl!(u16);
+const_wrapping_shr_impl!(u32);
+const_wrapping_shr_impl!(u64);
+const_wrapping_shr_impl!(u128);
+
+const_checked_shl_impl!(u8);
+const_checked_shl_impl!(u16);
+const_checked_shl_impl!(u32);
+const_checked_shl_impl!(u64);
+const_checked_shl_impl!(u128);
+
+const_checked_shr_impl!(u8);
+const_checked_shr_impl!(u16);
+const_checked_shr_impl!(u32);
+const_checked_shr_impl!(u64);
+const_checked_shr_impl!(u128);
 
 macro_rules! const_to_bytes_impl {
     ($t:ty, $n:expr) => {

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -106,33 +106,33 @@ c0nst::c0nst! {
     pub c0nst trait ConstOverflowingShl: Sized + [c0nst] core::ops::Shl<u32, Output = Self> {
         /// Shift left with overflow detection.
         /// Returns the shifted value and whether the shift amount exceeded the bit width.
-        fn overflowing_shl(self, rhs: u32) -> (Self, bool);
+        fn overflowing_shl(&self, rhs: u32) -> (Self, bool);
     }
 
     pub c0nst trait ConstOverflowingShr: Sized + [c0nst] core::ops::Shr<u32, Output = Self> {
         /// Shift right with overflow detection.
         /// Returns the shifted value and whether the shift amount exceeded the bit width.
-        fn overflowing_shr(self, rhs: u32) -> (Self, bool);
+        fn overflowing_shr(&self, rhs: u32) -> (Self, bool);
     }
 
     pub c0nst trait ConstWrappingShl: Sized + [c0nst] ConstOverflowingShl {
         /// Wrapping shift left. Shifts, masking the shift amount to the bit width.
-        fn wrapping_shl(self, rhs: u32) -> Self;
+        fn wrapping_shl(&self, rhs: u32) -> Self;
     }
 
     pub c0nst trait ConstWrappingShr: Sized + [c0nst] ConstOverflowingShr {
         /// Wrapping shift right. Shifts, masking the shift amount to the bit width.
-        fn wrapping_shr(self, rhs: u32) -> Self;
+        fn wrapping_shr(&self, rhs: u32) -> Self;
     }
 
     pub c0nst trait ConstCheckedShl: Sized + [c0nst] ConstOverflowingShl {
         /// Checked shift left. Returns `None` if the shift amount exceeds bit width.
-        fn checked_shl(self, rhs: u32) -> Option<Self>;
+        fn checked_shl(&self, rhs: u32) -> Option<Self>;
     }
 
     pub c0nst trait ConstCheckedShr: Sized + [c0nst] ConstOverflowingShr {
         /// Checked shift right. Returns `None` if the shift amount exceeds bit width.
-        fn checked_shr(self, rhs: u32) -> Option<Self>;
+        fn checked_shr(&self, rhs: u32) -> Option<Self>;
     }
 
     pub c0nst trait ConstToBytes {
@@ -553,8 +553,8 @@ macro_rules! const_overflowing_shl_impl {
     ($t:ty) => {
         c0nst::c0nst! {
             impl c0nst ConstOverflowingShl for $t {
-                fn overflowing_shl(self, rhs: u32) -> (Self, bool) {
-                    self.overflowing_shl(rhs)
+                fn overflowing_shl(&self, rhs: u32) -> (Self, bool) {
+                    (*self).overflowing_shl(rhs)
                 }
             }
         }
@@ -565,8 +565,8 @@ macro_rules! const_overflowing_shr_impl {
     ($t:ty) => {
         c0nst::c0nst! {
             impl c0nst ConstOverflowingShr for $t {
-                fn overflowing_shr(self, rhs: u32) -> (Self, bool) {
-                    self.overflowing_shr(rhs)
+                fn overflowing_shr(&self, rhs: u32) -> (Self, bool) {
+                    (*self).overflowing_shr(rhs)
                 }
             }
         }
@@ -577,9 +577,8 @@ macro_rules! const_wrapping_shl_impl {
     ($t:ty) => {
         c0nst::c0nst! {
             impl c0nst ConstWrappingShl for $t {
-                fn wrapping_shl(self, rhs: u32) -> Self {
-                    // Use inherent method which masks shift amount correctly
-                    self.wrapping_shl(rhs)
+                fn wrapping_shl(&self, rhs: u32) -> Self {
+                    (*self).wrapping_shl(rhs)
                 }
             }
         }
@@ -590,9 +589,8 @@ macro_rules! const_wrapping_shr_impl {
     ($t:ty) => {
         c0nst::c0nst! {
             impl c0nst ConstWrappingShr for $t {
-                fn wrapping_shr(self, rhs: u32) -> Self {
-                    // Use inherent method which masks shift amount correctly
-                    self.wrapping_shr(rhs)
+                fn wrapping_shr(&self, rhs: u32) -> Self {
+                    (*self).wrapping_shr(rhs)
                 }
             }
         }
@@ -603,9 +601,8 @@ macro_rules! const_checked_shl_impl {
     ($t:ty) => {
         c0nst::c0nst! {
             impl c0nst ConstCheckedShl for $t {
-                fn checked_shl(self, rhs: u32) -> Option<Self> {
-                    // Use inherent method for correct semantics
-                    self.checked_shl(rhs)
+                fn checked_shl(&self, rhs: u32) -> Option<Self> {
+                    (*self).checked_shl(rhs)
                 }
             }
         }
@@ -616,9 +613,8 @@ macro_rules! const_checked_shr_impl {
     ($t:ty) => {
         c0nst::c0nst! {
             impl c0nst ConstCheckedShr for $t {
-                fn checked_shr(self, rhs: u32) -> Option<Self> {
-                    // Use inherent method for correct semantics
-                    self.checked_shr(rhs)
+                fn checked_shr(&self, rhs: u32) -> Option<Self> {
+                    (*self).checked_shr(rhs)
                 }
             }
         }

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -578,7 +578,7 @@ macro_rules! const_wrapping_shl_impl {
         c0nst::c0nst! {
             impl c0nst ConstWrappingShl for $t {
                 fn wrapping_shl(&self, rhs: u32) -> Self {
-                    (*self).wrapping_shl(rhs)
+                    ConstOverflowingShl::overflowing_shl(self, rhs).0
                 }
             }
         }
@@ -590,7 +590,7 @@ macro_rules! const_wrapping_shr_impl {
         c0nst::c0nst! {
             impl c0nst ConstWrappingShr for $t {
                 fn wrapping_shr(&self, rhs: u32) -> Self {
-                    (*self).wrapping_shr(rhs)
+                    ConstOverflowingShr::overflowing_shr(self, rhs).0
                 }
             }
         }
@@ -602,7 +602,8 @@ macro_rules! const_checked_shl_impl {
         c0nst::c0nst! {
             impl c0nst ConstCheckedShl for $t {
                 fn checked_shl(&self, rhs: u32) -> Option<Self> {
-                    (*self).checked_shl(rhs)
+                    let (res, overflow) = ConstOverflowingShl::overflowing_shl(self, rhs);
+                    if overflow { None } else { Some(res) }
                 }
             }
         }
@@ -614,7 +615,8 @@ macro_rules! const_checked_shr_impl {
         c0nst::c0nst! {
             impl c0nst ConstCheckedShr for $t {
                 fn checked_shr(&self, rhs: u32) -> Option<Self> {
-                    (*self).checked_shr(rhs)
+                    let (res, overflow) = ConstOverflowingShr::overflowing_shr(self, rhs);
+                    if overflow { None } else { Some(res) }
                 }
             }
         }

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -578,7 +578,8 @@ macro_rules! const_wrapping_shl_impl {
         c0nst::c0nst! {
             impl c0nst ConstWrappingShl for $t {
                 fn wrapping_shl(self, rhs: u32) -> Self {
-                    self.overflowing_shl(rhs).0
+                    // Use inherent method which masks shift amount correctly
+                    self.wrapping_shl(rhs)
                 }
             }
         }
@@ -590,7 +591,8 @@ macro_rules! const_wrapping_shr_impl {
         c0nst::c0nst! {
             impl c0nst ConstWrappingShr for $t {
                 fn wrapping_shr(self, rhs: u32) -> Self {
-                    self.overflowing_shr(rhs).0
+                    // Use inherent method which masks shift amount correctly
+                    self.wrapping_shr(rhs)
                 }
             }
         }
@@ -602,8 +604,8 @@ macro_rules! const_checked_shl_impl {
         c0nst::c0nst! {
             impl c0nst ConstCheckedShl for $t {
                 fn checked_shl(self, rhs: u32) -> Option<Self> {
-                    let (res, overflow) = self.overflowing_shl(rhs);
-                    if overflow { None } else { Some(res) }
+                    // Use inherent method for correct semantics
+                    self.checked_shl(rhs)
                 }
             }
         }
@@ -615,8 +617,8 @@ macro_rules! const_checked_shr_impl {
         c0nst::c0nst! {
             impl c0nst ConstCheckedShr for $t {
                 fn checked_shr(self, rhs: u32) -> Option<Self> {
-                    let (res, overflow) = self.overflowing_shr(rhs);
-                    if overflow { None } else { Some(res) }
+                    // Use inherent method for correct semantics
+                    self.checked_shr(rhs)
                 }
             }
         }

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -371,38 +371,28 @@ impl<T: MachineWord, const N: usize> OverflowingShr for FixedUInt<T, N> {
     }
 }
 
-// num_traits wrappers
+// num_traits wrappers - delegate to const impls
 impl<T: MachineWord, const N: usize> num_traits::WrappingShl for FixedUInt<T, N> {
     fn wrapping_shl(&self, bits: u32) -> Self {
-        OverflowingShl::overflowing_shl(*self, bits).0
+        ConstWrappingShl::wrapping_shl(*self, bits)
     }
 }
 
 impl<T: MachineWord, const N: usize> num_traits::WrappingShr for FixedUInt<T, N> {
     fn wrapping_shr(&self, bits: u32) -> Self {
-        OverflowingShr::overflowing_shr(*self, bits).0
+        ConstWrappingShr::wrapping_shr(*self, bits)
     }
 }
 
 impl<T: MachineWord, const N: usize> num_traits::CheckedShl for FixedUInt<T, N> {
     fn checked_shl(&self, bits: u32) -> Option<Self> {
-        let (res, overflow) = OverflowingShl::overflowing_shl(*self, bits);
-        if overflow {
-            None
-        } else {
-            Some(res)
-        }
+        ConstCheckedShl::checked_shl(*self, bits)
     }
 }
 
 impl<T: MachineWord, const N: usize> num_traits::CheckedShr for FixedUInt<T, N> {
     fn checked_shr(&self, bits: u32) -> Option<Self> {
-        let (res, overflow) = OverflowingShr::overflowing_shr(*self, bits);
-        if overflow {
-            None
-        } else {
-            Some(res)
-        }
+        ConstCheckedShr::checked_shr(*self, bits)
     }
 }
 


### PR DESCRIPTION
Adds ConstOverflowingShl/Shr, ConstWrappingShl/Shr, ConstCheckedShl/Shr with implementations for primitives (u8-u128) and FixedUInt. #58

## Summary by Sourcery

Introduce const-evaluable shift trait variants and wire FixedUInt and primitive unsigned integers to use them for overflowing, wrapping, and checked shifts.

New Features:
- Add ConstOverflowingShl/Shr, ConstWrappingShl/Shr, and ConstCheckedShl/Shr traits for const-evaluable shift operations.
- Implement const shift traits for primitive unsigned integers (u8–u128) and FixedUInt types, including zero-sized FixedUInt.

Enhancements:
- Refactor FixedUInt num_traits and OverflowingShl/Shr implementations to delegate to the new const shift traits.

Tests:
- Extend test suite to cover const shift trait behavior on FixedUInt, including wrapping, overflow, zero-shift, zero-sized types, and num_traits delegation paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added constant-time shift support for left and right shifts in three variants: overflowing (value + overflow flag), wrapping (masked result), and checked (Option). Available for standard unsigned integers and the library's fixed-size unsigned integer type; existing shift wrappers now delegate to these const implementations.

* **Tests**
  * Added tests covering edge cases, zero-sized types, and integration with existing wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->