### PR TITLE
Add const ToBytes/FromBytes impl for nightly

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -136,7 +136,7 @@ c0nst::c0nst! {
     }
 
     pub c0nst trait ConstToBytes {
-        type Bytes: Copy + AsRef<[u8]> + AsMut<[u8]>;
+        type Bytes: Copy + [c0nst] AsRef<[u8]> + [c0nst] AsMut<[u8]>;
         fn to_le_bytes(&self) -> Self::Bytes;
         fn to_be_bytes(&self) -> Self::Bytes;
     }

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -34,7 +34,10 @@ mod num_traits_identity;
 mod prim_int_impl;
 mod roots_impl;
 mod string_conversion;
-#[cfg(feature = "use-unsafe")]
+// Prefer nightly (safe const impl) over use-unsafe when both are enabled
+#[cfg(feature = "nightly")]
+mod const_to_from_bytes;
+#[cfg(all(feature = "use-unsafe", not(feature = "nightly")))]
 mod to_from_bytes;
 
 #[cfg(feature = "zeroize")]

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -1,0 +1,194 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Const-compatible ToBytes/FromBytes implementation for FixedUInt.
+//!
+//! This module requires the `nightly` feature and uses `generic_const_exprs`
+//! to compute byte array sizes at compile time without unsafe code.
+
+use super::{FixedUInt, MachineWord};
+use crate::const_numtrait::ConstToBytes;
+use crate::machineword::ConstMachineWord;
+use core::mem::size_of;
+
+/// Byte array type for FixedUInt<T, N> with computed size.
+/// Size = N * size_of::<T>() bytes.
+#[derive(Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Debug)]
+pub struct ConstBytesHolder<const SIZE: usize> {
+    bytes: [u8; SIZE],
+}
+
+impl<const SIZE: usize> Default for ConstBytesHolder<SIZE> {
+    fn default() -> Self {
+        Self { bytes: [0u8; SIZE] }
+    }
+}
+
+impl<const SIZE: usize> const AsRef<[u8]> for ConstBytesHolder<SIZE> {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl<const SIZE: usize> const AsMut<[u8]> for ConstBytesHolder<SIZE> {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+}
+
+impl<const SIZE: usize> core::borrow::Borrow<[u8]> for ConstBytesHolder<SIZE> {
+    fn borrow(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+impl<const SIZE: usize> core::borrow::BorrowMut<[u8]> for ConstBytesHolder<SIZE> {
+    fn borrow_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+}
+
+impl<const SIZE: usize> core::hash::Hash for ConstBytesHolder<SIZE> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.bytes.hash(state)
+    }
+}
+
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstToBytes for FixedUInt<T, N>
+    where
+        [(); N * size_of::<T>()]:,
+    {
+        type Bytes = ConstBytesHolder<{ N * size_of::<T>() }>;
+
+        fn to_le_bytes(&self) -> Self::Bytes {
+            let mut result = ConstBytesHolder { bytes: [0u8; N * size_of::<T>()] };
+            let word_size = size_of::<T>();
+            let mut i = 0;
+            while i < N {
+                let word_bytes = ConstToBytes::to_le_bytes(&self.array[i]);
+                let src = word_bytes.as_ref();
+                let mut j = 0;
+                while j < word_size {
+                    result.bytes[i * word_size + j] = src[j];
+                    j += 1;
+                }
+                i += 1;
+            }
+            result
+        }
+
+        fn to_be_bytes(&self) -> Self::Bytes {
+            let mut result = ConstBytesHolder { bytes: [0u8; N * size_of::<T>()] };
+            let word_size = size_of::<T>();
+            let mut i = 0;
+            while i < N {
+                // For big-endian, reverse word order: highest word first
+                let word_idx = N - 1 - i;
+                let word_bytes = ConstToBytes::to_be_bytes(&self.array[word_idx]);
+                let src = word_bytes.as_ref();
+                let mut j = 0;
+                while j < word_size {
+                    result.bytes[i * word_size + j] = src[j];
+                    j += 1;
+                }
+                i += 1;
+            }
+            result
+        }
+    }
+}
+
+// num_traits::ToBytes implementation - delegates to ConstToBytes
+impl<T: MachineWord, const N: usize> num_traits::ToBytes for FixedUInt<T, N>
+where
+    [(); N * size_of::<T>()]:,
+{
+    type Bytes = ConstBytesHolder<{ N * size_of::<T>() }>;
+
+    fn to_be_bytes(&self) -> Self::Bytes {
+        ConstToBytes::to_be_bytes(self)
+    }
+
+    fn to_le_bytes(&self) -> Self::Bytes {
+        ConstToBytes::to_le_bytes(self)
+    }
+}
+
+// num_traits::FromBytes implementation
+impl<T: MachineWord, const N: usize> num_traits::FromBytes for FixedUInt<T, N>
+where
+    [(); N * size_of::<T>()]:,
+{
+    type Bytes = ConstBytesHolder<{ N * size_of::<T>() }>;
+
+    fn from_be_bytes(bytes: &Self::Bytes) -> Self {
+        Self::from_be_bytes(&bytes.bytes)
+    }
+
+    fn from_le_bytes(bytes: &Self::Bytes) -> Self {
+        Self::from_le_bytes(&bytes.bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_const_to_le_bytes() {
+        let val: FixedUInt<u8, 4> = FixedUInt::from(0x04030201u32);
+        let bytes = ConstToBytes::to_le_bytes(&val);
+        assert_eq!(bytes.as_ref(), &[0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn test_const_to_be_bytes() {
+        let val: FixedUInt<u8, 4> = FixedUInt::from(0x04030201u32);
+        let bytes = ConstToBytes::to_be_bytes(&val);
+        assert_eq!(bytes.as_ref(), &[0x04, 0x03, 0x02, 0x01]);
+    }
+
+    #[test]
+    fn test_const_to_bytes_u32_words() {
+        let val: FixedUInt<u32, 2> = FixedUInt {
+            array: [0x04030201, 0x08070605],
+        };
+        let le_bytes = ConstToBytes::to_le_bytes(&val);
+        assert_eq!(
+            le_bytes.as_ref(),
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+        );
+
+        let be_bytes = ConstToBytes::to_be_bytes(&val);
+        assert_eq!(
+            be_bytes.as_ref(),
+            &[0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]
+        );
+    }
+
+    // Test that it works in const context
+    const CONST_LE_BYTES: [u8; 4] = {
+        let val: FixedUInt<u8, 4> = FixedUInt {
+            array: [0x01, 0x02, 0x03, 0x04],
+        };
+        let holder = ConstToBytes::to_le_bytes(&val);
+        holder.bytes
+    };
+
+    #[test]
+    fn test_const_context() {
+        assert_eq!(CONST_LE_BYTES, [0x01, 0x02, 0x03, 0x04]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,11 @@
         const_cmp,
         const_convert,
         const_default,
-        const_clone
+        const_clone,
+        generic_const_exprs
     )
 )]
+#![cfg_attr(feature = "nightly", allow(incomplete_features))]
 
 //! A fixed-size big integer implementation, unsigned only.
 //! [FixedUInt] implements a [num_traits::PrimInt] trait, mimicking built-in `u8`, `u16` and `u32` types.


### PR DESCRIPTION
ToByte/FromBytes on nightly #58

## Summary by Sourcery

Add a nightly-only, const-compatible ToBytes/FromBytes implementation for FixedUInt using generic_const_exprs and make it take precedence over the unsafe implementation when both features are enabled.

New Features:
- Introduce a ConstBytesHolder type and const-compatible ConstToBytes implementation for FixedUInt behind the nightly feature.
- Implement num_traits::ToBytes and num_traits::FromBytes for FixedUInt using the new const-compatible byte representation on nightly.

Enhancements:
- Prefer the nightly const ToBytes/FromBytes implementation over the unsafe implementation when both features are enabled.
- Extend the nightly feature gate configuration to enable generic_const_exprs and allow incomplete_features for const byte conversion support.

Tests:
- Add unit tests validating little-endian and big-endian const byte conversions for FixedUInt, including use in const contexts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Const-time byte conversion for fixed-size integer types with compile-time little-/big-endian byte outputs and exposed conversions to/from byte arrays.

* **Chores**
  * Updated feature flags and nightly configuration to enable new const capabilities.
  * Tightened public trait bounds for byte-conversion types (may affect downstream compatibility).

* **Tests**
  * Added compile-time tests validating endianness and multi-word behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->