### PR TITLE
Add ConstEuclid and ConstCheckedEuclid traits

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -103,6 +103,20 @@ c0nst::c0nst! {
         fn checked_rem(&self, v: &Self) -> Option<Self>;
     }
 
+    pub c0nst trait ConstEuclid: Sized + [c0nst] core::ops::Div<Output = Self> + [c0nst] core::ops::Rem<Output = Self> {
+        /// Euclidean division. For unsigned integers, same as regular division.
+        fn div_euclid(&self, v: &Self) -> Self;
+        /// Euclidean remainder. For unsigned integers, same as regular remainder.
+        fn rem_euclid(&self, v: &Self) -> Self;
+    }
+
+    pub c0nst trait ConstCheckedEuclid: Sized + [c0nst] ConstEuclid + [c0nst] ConstZero {
+        /// Checked Euclidean division. Returns `None` if the divisor is zero.
+        fn checked_div_euclid(&self, v: &Self) -> Option<Self>;
+        /// Checked Euclidean remainder. Returns `None` if the divisor is zero.
+        fn checked_rem_euclid(&self, v: &Self) -> Option<Self>;
+    }
+
     pub c0nst trait ConstOverflowingShl: Sized + [c0nst] core::ops::Shl<u32, Output = Self> {
         /// Shift left with overflow detection.
         /// Returns the shifted value and whether the shift amount exceeded the bit width.
@@ -548,6 +562,50 @@ const_checked_rem_impl!(u16);
 const_checked_rem_impl!(u32);
 const_checked_rem_impl!(u64);
 const_checked_rem_impl!(u128);
+
+macro_rules! const_euclid_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstEuclid for $t {
+                fn div_euclid(&self, v: &Self) -> Self {
+                    // For unsigned integers, Euclidean division is the same as regular division
+                    *self / *v
+                }
+                fn rem_euclid(&self, v: &Self) -> Self {
+                    // For unsigned integers, Euclidean remainder is the same as regular remainder
+                    *self % *v
+                }
+            }
+        }
+    };
+}
+
+macro_rules! const_checked_euclid_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstCheckedEuclid for $t {
+                fn checked_div_euclid(&self, v: &Self) -> Option<Self> {
+                    if v.is_zero() { None } else { Some(*self / *v) }
+                }
+                fn checked_rem_euclid(&self, v: &Self) -> Option<Self> {
+                    if v.is_zero() { None } else { Some(*self % *v) }
+                }
+            }
+        }
+    };
+}
+
+const_euclid_impl!(u8);
+const_euclid_impl!(u16);
+const_euclid_impl!(u32);
+const_euclid_impl!(u64);
+const_euclid_impl!(u128);
+
+const_checked_euclid_impl!(u8);
+const_checked_euclid_impl!(u16);
+const_checked_euclid_impl!(u32);
+const_checked_euclid_impl!(u64);
+const_checked_euclid_impl!(u128);
 
 macro_rules! const_overflowing_shl_impl {
     ($t:ty) => {

--- a/src/fixeduint/euclid.rs
+++ b/src/fixeduint/euclid.rs
@@ -1,45 +1,114 @@
 use num_traits::{CheckedEuclid, Euclid};
 
 use super::{FixedUInt, MachineWord};
-use num_traits::{CheckedDiv, CheckedRem};
+use crate::const_numtrait::{ConstCheckedDiv, ConstCheckedEuclid, ConstCheckedRem, ConstEuclid};
+use crate::machineword::ConstMachineWord;
 
-impl<T: MachineWord, const N: usize> Euclid for FixedUInt<T, N> {
-    fn div_euclid(&self, v: &Self) -> Self {
-        self / v
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstEuclid for FixedUInt<T, N> {
+        fn div_euclid(&self, v: &Self) -> Self {
+            // For unsigned integers, Euclidean division is the same as regular division
+            *self / *v
+        }
+
+        fn rem_euclid(&self, v: &Self) -> Self {
+            // For unsigned integers, Euclidean remainder is the same as regular remainder
+            *self % *v
+        }
     }
 
-    fn rem_euclid(&self, v: &Self) -> Self {
-        self % v
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedEuclid for FixedUInt<T, N> {
+        fn checked_div_euclid(&self, v: &Self) -> Option<Self> {
+            ConstCheckedDiv::checked_div(self, v)
+        }
+
+        fn checked_rem_euclid(&self, v: &Self) -> Option<Self> {
+            ConstCheckedRem::checked_rem(self, v)
+        }
     }
 }
 
+// num_traits::Euclid - delegates to ConstEuclid
+impl<T: MachineWord, const N: usize> Euclid for FixedUInt<T, N> {
+    fn div_euclid(&self, v: &Self) -> Self {
+        ConstEuclid::div_euclid(self, v)
+    }
+
+    fn rem_euclid(&self, v: &Self) -> Self {
+        ConstEuclid::rem_euclid(self, v)
+    }
+}
+
+// num_traits::CheckedEuclid - delegates to ConstCheckedEuclid
 impl<T: MachineWord, const N: usize> CheckedEuclid for FixedUInt<T, N> {
     fn checked_div_euclid(&self, v: &Self) -> Option<Self> {
-        self.checked_div(v)
+        ConstCheckedEuclid::checked_div_euclid(self, v)
     }
 
     fn checked_rem_euclid(&self, v: &Self) -> Option<Self> {
-        self.checked_rem(v)
+        ConstCheckedEuclid::checked_rem_euclid(self, v)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::machineword::ConstMachineWord;
 
     #[test]
     fn test_div_euclid() {
+        use num_traits::Euclid;
         let a = FixedUInt::<u8, 2>::from(100u8);
         let b = FixedUInt::<u8, 2>::from(30u8);
-        assert_eq!(a.div_euclid(&b), 3u8.into());
-        assert_eq!(a.rem_euclid(&b), 10u8.into());
+        assert_eq!(Euclid::div_euclid(&a, &b), 3u8.into());
+        assert_eq!(Euclid::rem_euclid(&a, &b), 10u8.into());
     }
 
     #[test]
     fn test_checked_div_euclid() {
+        use num_traits::CheckedEuclid;
         let a = FixedUInt::<u8, 2>::from(100u8);
         let b = FixedUInt::<u8, 2>::from(30u8);
-        assert_eq!(a.checked_div_euclid(&b), Some(3u8.into()));
-        assert_eq!(a.checked_rem_euclid(&b), Some(10u8.into()));
+        assert_eq!(CheckedEuclid::checked_div_euclid(&a, &b), Some(3u8.into()));
+        assert_eq!(CheckedEuclid::checked_rem_euclid(&a, &b), Some(10u8.into()));
+
+        // Test division by zero
+        let zero = FixedUInt::<u8, 2>::from(0u8);
+        assert_eq!(CheckedEuclid::checked_div_euclid(&a, &zero), None);
+        assert_eq!(CheckedEuclid::checked_rem_euclid(&a, &zero), None);
+    }
+
+    c0nst::c0nst! {
+        pub c0nst fn const_div_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            a: &FixedUInt<T, N>,
+            b: &FixedUInt<T, N>,
+        ) -> FixedUInt<T, N> {
+            ConstEuclid::div_euclid(a, b)
+        }
+
+        pub c0nst fn const_checked_div_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            a: &FixedUInt<T, N>,
+            b: &FixedUInt<T, N>,
+        ) -> Option<FixedUInt<T, N>> {
+            ConstCheckedEuclid::checked_div_euclid(a, b)
+        }
+    }
+
+    #[test]
+    fn test_const_euclid() {
+        let a = FixedUInt::<u8, 2>::from(100u8);
+        let b = FixedUInt::<u8, 2>::from(30u8);
+        assert_eq!(const_div_euclid(&a, &b), 3u8.into());
+        assert_eq!(const_checked_div_euclid(&a, &b), Some(3u8.into()));
+
+        #[cfg(feature = "nightly")]
+        {
+            const A: FixedUInt<u8, 2> = FixedUInt { array: [100, 0] };
+            const B: FixedUInt<u8, 2> = FixedUInt { array: [30, 0] };
+            const DIV_RESULT: FixedUInt<u8, 2> = const_div_euclid(&A, &B);
+            const CHECKED_RESULT: Option<FixedUInt<u8, 2>> = const_checked_div_euclid(&A, &B);
+            assert_eq!(DIV_RESULT, FixedUInt { array: [3, 0] });
+            assert_eq!(CHECKED_RESULT, Some(FixedUInt { array: [3, 0] }));
+        }
     }
 }

--- a/src/fixeduint/euclid.rs
+++ b/src/fixeduint/euclid.rs
@@ -1,7 +1,7 @@
 use num_traits::{CheckedEuclid, Euclid};
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstCheckedDiv, ConstCheckedEuclid, ConstCheckedRem, ConstEuclid};
+use crate::const_numtrait::{ConstCheckedEuclid, ConstEuclid, ConstZero};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {
@@ -19,34 +19,42 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedEuclid for FixedUInt<T, N> {
         fn checked_div_euclid(&self, v: &Self) -> Option<Self> {
-            ConstCheckedDiv::checked_div(self, v)
+            if v.is_zero() {
+                None
+            } else {
+                Some(*self / *v)
+            }
         }
 
         fn checked_rem_euclid(&self, v: &Self) -> Option<Self> {
-            ConstCheckedRem::checked_rem(self, v)
+            if v.is_zero() {
+                None
+            } else {
+                Some(*self % *v)
+            }
         }
     }
 }
 
-// num_traits::Euclid - delegates to ConstEuclid
+// num_traits::Euclid - uses direct operators (no const bounds needed)
 impl<T: MachineWord, const N: usize> Euclid for FixedUInt<T, N> {
     fn div_euclid(&self, v: &Self) -> Self {
-        ConstEuclid::div_euclid(self, v)
+        self / v
     }
 
     fn rem_euclid(&self, v: &Self) -> Self {
-        ConstEuclid::rem_euclid(self, v)
+        self % v
     }
 }
 
-// num_traits::CheckedEuclid - delegates to ConstCheckedEuclid
+// num_traits::CheckedEuclid - uses direct checked calls (no const bounds needed)
 impl<T: MachineWord, const N: usize> CheckedEuclid for FixedUInt<T, N> {
     fn checked_div_euclid(&self, v: &Self) -> Option<Self> {
-        ConstCheckedEuclid::checked_div_euclid(self, v)
+        num_traits::CheckedDiv::checked_div(self, v)
     }
 
     fn checked_rem_euclid(&self, v: &Self) -> Option<Self> {
-        ConstCheckedEuclid::checked_rem_euclid(self, v)
+        num_traits::CheckedRem::checked_rem(self, v)
     }
 }
 
@@ -86,11 +94,25 @@ mod tests {
             ConstEuclid::div_euclid(a, b)
         }
 
+        pub c0nst fn const_rem_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            a: &FixedUInt<T, N>,
+            b: &FixedUInt<T, N>,
+        ) -> FixedUInt<T, N> {
+            ConstEuclid::rem_euclid(a, b)
+        }
+
         pub c0nst fn const_checked_div_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
             a: &FixedUInt<T, N>,
             b: &FixedUInt<T, N>,
         ) -> Option<FixedUInt<T, N>> {
             ConstCheckedEuclid::checked_div_euclid(a, b)
+        }
+
+        pub c0nst fn const_checked_rem_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            a: &FixedUInt<T, N>,
+            b: &FixedUInt<T, N>,
+        ) -> Option<FixedUInt<T, N>> {
+            ConstCheckedEuclid::checked_rem_euclid(a, b)
         }
     }
 
@@ -99,16 +121,22 @@ mod tests {
         let a = FixedUInt::<u8, 2>::from(100u8);
         let b = FixedUInt::<u8, 2>::from(30u8);
         assert_eq!(const_div_euclid(&a, &b), 3u8.into());
+        assert_eq!(const_rem_euclid(&a, &b), 10u8.into());
         assert_eq!(const_checked_div_euclid(&a, &b), Some(3u8.into()));
+        assert_eq!(const_checked_rem_euclid(&a, &b), Some(10u8.into()));
 
         #[cfg(feature = "nightly")]
         {
             const A: FixedUInt<u8, 2> = FixedUInt { array: [100, 0] };
             const B: FixedUInt<u8, 2> = FixedUInt { array: [30, 0] };
             const DIV_RESULT: FixedUInt<u8, 2> = const_div_euclid(&A, &B);
-            const CHECKED_RESULT: Option<FixedUInt<u8, 2>> = const_checked_div_euclid(&A, &B);
+            const REM_RESULT: FixedUInt<u8, 2> = const_rem_euclid(&A, &B);
+            const CHECKED_DIV: Option<FixedUInt<u8, 2>> = const_checked_div_euclid(&A, &B);
+            const CHECKED_REM: Option<FixedUInt<u8, 2>> = const_checked_rem_euclid(&A, &B);
             assert_eq!(DIV_RESULT, FixedUInt { array: [3, 0] });
-            assert_eq!(CHECKED_RESULT, Some(FixedUInt { array: [3, 0] }));
+            assert_eq!(REM_RESULT, FixedUInt { array: [10, 0] });
+            assert_eq!(CHECKED_DIV, Some(FixedUInt { array: [3, 0] }));
+            assert_eq!(CHECKED_REM, Some(FixedUInt { array: [10, 0] }));
         }
     }
 }


### PR DESCRIPTION
Add ConstEuclid and ConstCheckedEuclid traits #58

## Summary by Sourcery

Add const-evaluable Euclidean division and remainder support for unsigned integers and FixedUInt, and wire it into existing num_traits implementations.

New Features:
- Introduce ConstEuclid and ConstCheckedEuclid traits for const-capable Euclidean division and remainder operations.
- Provide ConstEuclid and ConstCheckedEuclid implementations for primitive unsigned integer types and FixedUInt, including safe handling of division by zero.
- Expose const helper functions for performing (checked) Euclidean division on FixedUInt, usable in const contexts when the nightly feature is enabled.

Tests:
- Extend Euclidean division tests for FixedUInt to cover trait-based calls, checked division by zero behavior, and new const-evaluable helpers including compile-time evaluations under the nightly feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added constant-evaluable Euclidean division and remainder operations with checked variants that handle division-by-zero.
  * Extended support across 8/16/32/64/128-bit unsigned integers and fixed-size integer types.
* **Tests**
  * Added unit and compile-time tests, including constant-evaluation paths and division-by-zero checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->