### PR TITLE
Add ConstPowerOfTwo trait

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -159,6 +159,13 @@ c0nst::c0nst! {
     ///
     /// These methods mirror the inherent methods on primitive integers
     /// but are not part of num_traits.
+    ///
+    /// # Unsigned types only
+    ///
+    /// This trait is designed for unsigned integer types. Implementing it for
+    /// signed types may produce unexpected results (e.g., negative values are
+    /// never powers of two, and `next_power_of_two` behavior is undefined for
+    /// negative inputs).
     pub c0nst trait ConstPowerOfTwo: Sized + [c0nst] ConstZero + [c0nst] ConstOne {
         /// Returns `true` if `self` is a power of two.
         ///

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -155,6 +155,29 @@ c0nst::c0nst! {
         fn to_be_bytes(&self) -> Self::Bytes;
     }
 
+    /// Const-compatible power-of-two operations.
+    ///
+    /// These methods mirror the inherent methods on primitive integers
+    /// but are not part of num_traits.
+    pub c0nst trait ConstPowerOfTwo: Sized + [c0nst] ConstZero + [c0nst] ConstOne + [c0nst] ConstBounded {
+        /// Returns `true` if `self` is a power of two.
+        ///
+        /// Zero is not a power of two.
+        fn is_power_of_two(&self) -> bool;
+
+        /// Returns the smallest power of two greater than or equal to `self`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if the result overflows (i.e., `self > (1 << (bits-1))`).
+        fn next_power_of_two(self) -> Self;
+
+        /// Returns the smallest power of two greater than or equal to `self`.
+        ///
+        /// Returns `None` if the result would overflow.
+        fn checked_next_power_of_two(self) -> Option<Self>;
+    }
+
     /// Base arithmetic traits for constant primitive integers.
     ///
     /// # Implementor requirements for default methods
@@ -734,6 +757,30 @@ const_to_bytes_impl!(u16, 2);
 const_to_bytes_impl!(u32, 4);
 const_to_bytes_impl!(u64, 8);
 const_to_bytes_impl!(u128, 16);
+
+macro_rules! const_power_of_two_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstPowerOfTwo for $t {
+                fn is_power_of_two(&self) -> bool {
+                    (*self).is_power_of_two()
+                }
+                fn next_power_of_two(self) -> Self {
+                    self.next_power_of_two()
+                }
+                fn checked_next_power_of_two(self) -> Option<Self> {
+                    self.checked_next_power_of_two()
+                }
+            }
+        }
+    };
+}
+
+const_power_of_two_impl!(u8);
+const_power_of_two_impl!(u16);
+const_power_of_two_impl!(u32);
+const_power_of_two_impl!(u64);
+const_power_of_two_impl!(u128);
 
 const_prim_int_impl!(u8);
 const_prim_int_impl!(u16);

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -159,7 +159,7 @@ c0nst::c0nst! {
     ///
     /// These methods mirror the inherent methods on primitive integers
     /// but are not part of num_traits.
-    pub c0nst trait ConstPowerOfTwo: Sized + [c0nst] ConstZero + [c0nst] ConstOne + [c0nst] ConstBounded {
+    pub c0nst trait ConstPowerOfTwo: Sized + [c0nst] ConstZero + [c0nst] ConstOne {
         /// Returns `true` if `self` is a power of two.
         ///
         /// Zero is not a power of two.

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -17,7 +17,7 @@ use num_traits::{ToPrimitive, Zero};
 use core::convert::TryFrom;
 use core::fmt::Write;
 
-pub use crate::const_numtrait::{ConstBounded, ConstOne, ConstPrimInt, ConstZero};
+pub use crate::const_numtrait::{ConstBounded, ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero};
 use crate::machineword::{ConstMachineWord, MachineWord};
 
 #[allow(unused_imports)]
@@ -31,6 +31,7 @@ mod mul_div_impl;
 mod num_integer_impl;
 mod num_traits_casts;
 mod num_traits_identity;
+mod power_of_two_impl;
 mod prim_int_impl;
 mod roots_impl;
 mod string_conversion;

--- a/src/fixeduint/power_of_two_impl.rs
+++ b/src/fixeduint/power_of_two_impl.rs
@@ -1,0 +1,196 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Power-of-two operations for FixedUInt.
+
+use super::{FixedUInt, MachineWord};
+use crate::const_numtrait::{ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero};
+use crate::machineword::ConstMachineWord;
+
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstPowerOfTwo for FixedUInt<T, N> {
+        fn is_power_of_two(&self) -> bool {
+            // A number is a power of two if it has exactly one bit set
+            // and is not zero
+            if self.is_zero() {
+                return false;
+            }
+            ConstPrimInt::count_ones(*self) == 1u32
+        }
+
+        fn next_power_of_two(self) -> Self {
+            match self.checked_next_power_of_two() {
+                Some(v) => v,
+                None => panic!("next_power_of_two overflow"),
+            }
+        }
+
+        fn checked_next_power_of_two(self) -> Option<Self> {
+            if self.is_zero() {
+                return Some(Self::one());
+            }
+            if self.is_power_of_two() {
+                return Some(self);
+            }
+            // Find the position of the highest set bit using leading_zeros
+            // bit_length = total_bits - leading_zeros
+            let total_bits = (N * core::mem::size_of::<T>() * 8) as u32;
+            let leading = ConstPrimInt::leading_zeros(self);
+            let bits = total_bits - leading;
+            // Check if we can shift 1 left by that many bits
+            if bits >= total_bits {
+                return None;
+            }
+            Some(Self::one() << (bits as usize))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_power_of_two() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert!(!ConstPowerOfTwo::is_power_of_two(&U16::from(0u8)));
+        assert!(ConstPowerOfTwo::is_power_of_two(&U16::from(1u8)));
+        assert!(ConstPowerOfTwo::is_power_of_two(&U16::from(2u8)));
+        assert!(!ConstPowerOfTwo::is_power_of_two(&U16::from(3u8)));
+        assert!(ConstPowerOfTwo::is_power_of_two(&U16::from(4u8)));
+        assert!(!ConstPowerOfTwo::is_power_of_two(&U16::from(5u8)));
+        assert!(ConstPowerOfTwo::is_power_of_two(&U16::from(8u8)));
+        assert!(ConstPowerOfTwo::is_power_of_two(&U16::from(16u8)));
+        assert!(ConstPowerOfTwo::is_power_of_two(&U16::from(128u8)));
+        assert!(ConstPowerOfTwo::is_power_of_two(&U16::from(256u16)));
+        assert!(!ConstPowerOfTwo::is_power_of_two(&U16::from(255u8)));
+    }
+
+    #[test]
+    fn test_next_power_of_two() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(0u8)),
+            U16::from(1u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(1u8)),
+            U16::from(1u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(2u8)),
+            U16::from(2u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(3u8)),
+            U16::from(4u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(4u8)),
+            U16::from(4u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(5u8)),
+            U16::from(8u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(7u8)),
+            U16::from(8u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(8u8)),
+            U16::from(8u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(9u8)),
+            U16::from(16u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(100u8)),
+            U16::from(128u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(128u8)),
+            U16::from(128u8)
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(U16::from(129u8)),
+            U16::from(256u16)
+        );
+    }
+
+    #[test]
+    fn test_checked_next_power_of_two() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(
+            ConstPowerOfTwo::checked_next_power_of_two(U16::from(0u8)),
+            Some(U16::from(1u8))
+        );
+        assert_eq!(
+            ConstPowerOfTwo::checked_next_power_of_two(U16::from(1u8)),
+            Some(U16::from(1u8))
+        );
+        assert_eq!(
+            ConstPowerOfTwo::checked_next_power_of_two(U16::from(100u8)),
+            Some(U16::from(128u8))
+        );
+
+        // Test overflow case - 32769 needs next power of 2 = 65536 which overflows u16
+        let large = U16::from(32769u16);
+        assert_eq!(ConstPowerOfTwo::checked_next_power_of_two(large), None);
+
+        // But 32768 is already a power of two
+        let pow2 = U16::from(32768u16);
+        assert_eq!(ConstPowerOfTwo::checked_next_power_of_two(pow2), Some(pow2));
+    }
+
+    c0nst::c0nst! {
+        pub c0nst fn const_is_power_of_two<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            v: &FixedUInt<T, N>,
+        ) -> bool {
+            ConstPowerOfTwo::is_power_of_two(v)
+        }
+
+        pub c0nst fn const_next_power_of_two<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            v: FixedUInt<T, N>,
+        ) -> FixedUInt<T, N> {
+            ConstPowerOfTwo::next_power_of_two(v)
+        }
+    }
+
+    #[test]
+    fn test_const_power_of_two() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert!(const_is_power_of_two(&U16::from(4u8)));
+        assert!(!const_is_power_of_two(&U16::from(5u8)));
+        assert_eq!(const_next_power_of_two(U16::from(5u8)), U16::from(8u8));
+
+        #[cfg(feature = "nightly")]
+        {
+            const FOUR: U16 = FixedUInt { array: [4, 0] };
+            const FIVE: U16 = FixedUInt { array: [5, 0] };
+            const IS_POW2_TRUE: bool = const_is_power_of_two(&FOUR);
+            const IS_POW2_FALSE: bool = const_is_power_of_two(&FIVE);
+            const NEXT_POW2: U16 = const_next_power_of_two(FIVE);
+
+            assert!(IS_POW2_TRUE);
+            assert!(!IS_POW2_FALSE);
+            assert_eq!(NEXT_POW2, FixedUInt { array: [8, 0] });
+        }
+    }
+}

--- a/src/fixeduint/power_of_two_impl.rs
+++ b/src/fixeduint/power_of_two_impl.rs
@@ -30,7 +30,7 @@ c0nst::c0nst! {
         fn next_power_of_two(self) -> Self {
             match self.checked_next_power_of_two() {
                 Some(v) => v,
-                None => panic!("next_power_of_two overflow"),
+                None => panic!("FixedUInt::next_power_of_two overflow: result exceeds type capacity"),
             }
         }
 

--- a/src/fixeduint/power_of_two_impl.rs
+++ b/src/fixeduint/power_of_two_impl.rs
@@ -38,16 +38,15 @@ c0nst::c0nst! {
             if self.is_zero() {
                 return Some(Self::one());
             }
-            if self.is_power_of_two() {
-                return Some(self);
-            }
-            // Find the position of the highest set bit using leading_zeros
-            // bit_length = BIT_SIZE - leading_zeros
-            let total_bits = Self::BIT_SIZE as u32;
-            let leading = ConstPrimInt::leading_zeros(self);
-            let bits = total_bits - leading;
-            // Check if we can shift 1 left by that many bits
-            if bits >= total_bits {
+            // Bit manipulation trick: (n-1).leading_zeros() gives the bit position
+            // needed for the next power of two, handling both power-of-two and
+            // non-power-of-two inputs correctly.
+            let m_one = self - Self::one();
+            let leading = ConstPrimInt::leading_zeros(m_one);
+            let bits = Self::BIT_SIZE as u32 - leading;
+
+            // Check for overflow
+            if bits >= Self::BIT_SIZE as u32 {
                 return None;
             }
             Some(Self::one() << (bits as usize))

--- a/src/fixeduint/power_of_two_impl.rs
+++ b/src/fixeduint/power_of_two_impl.rs
@@ -21,12 +21,10 @@ use crate::machineword::ConstMachineWord;
 c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstPowerOfTwo for FixedUInt<T, N> {
         fn is_power_of_two(&self) -> bool {
-            // A number is a power of two if it has exactly one bit set
-            // and is not zero
-            if self.is_zero() {
-                return false;
-            }
-            ConstPrimInt::count_ones(*self) == 1u32
+            // Standard bitwise trick: n is power of two iff n != 0 && (n & (n-1)) == 0
+            // This works because a power of two has exactly one bit set,
+            // and subtracting 1 flips all lower bits, so AND gives zero.
+            !self.is_zero() && (*self & (*self - Self::one())).is_zero()
         }
 
         fn next_power_of_two(self) -> Self {
@@ -44,8 +42,8 @@ c0nst::c0nst! {
                 return Some(self);
             }
             // Find the position of the highest set bit using leading_zeros
-            // bit_length = total_bits - leading_zeros
-            let total_bits = (N * core::mem::size_of::<T>() * 8) as u32;
+            // bit_length = BIT_SIZE - leading_zeros
+            let total_bits = Self::BIT_SIZE as u32;
             let leading = ConstPrimInt::leading_zeros(self);
             let bits = total_bits - leading;
             // Check if we can shift 1 left by that many bits


### PR DESCRIPTION
More c0nstify #58

## Summary by Sourcery

Add a const-compatible power-of-two trait and implement it for primitive integers and FixedUInt, including associated tests and const helper functions.

New Features:
- Introduce a ConstPowerOfTwo trait providing const-friendly power-of-two queries and next-power-of-two operations.
- Implement ConstPowerOfTwo for unsigned primitive integer types and FixedUInt, enabling these operations in const contexts.

Tests:
- Add unit tests for FixedUInt power-of-two detection and next-power-of-two behavior, including overflow handling and const-evaluated usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public power-of-two trait with const-compatible and runtime methods to detect powers of two and compute the next power-of-two (with defined overflow behavior).
  * Implementations provided for primitive unsigned integers and the library's fixed-size unsigned type, plus const-enabled wrappers for compile-time use.
* **Tests**
  * Added comprehensive tests covering edge cases, zero handling, overflow, and const/gated scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->