### PR TITLE
Add ConstAbsDiff trait

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -187,8 +187,15 @@ c0nst::c0nst! {
 
     /// Const-compatible absolute difference.
     ///
-    /// Computes the absolute difference between two values without risk of
-    /// overflow. For unsigned types, this is `max(a, b) - min(a, b)`.
+    /// Computes the absolute difference between two values. For unsigned types,
+    /// this is `max(a, b) - min(a, b)`.
+    ///
+    /// # Unsigned types only
+    ///
+    /// This trait is designed for unsigned integer types where `abs_diff` cannot
+    /// overflow. Implementors for signed types must ensure overflow is handled
+    /// correctly (e.g., by returning an unsigned result type or using checked
+    /// arithmetic), as the trait bounds do not enforce this.
     pub c0nst trait ConstAbsDiff: Sized + [c0nst] core::cmp::Ord + [c0nst] core::ops::Sub<Output = Self> {
         /// Computes the absolute difference between `self` and `other`.
         fn abs_diff(self, other: Self) -> Self;

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -185,6 +185,15 @@ c0nst::c0nst! {
         fn checked_next_power_of_two(self) -> Option<Self>;
     }
 
+    /// Const-compatible absolute difference.
+    ///
+    /// Computes the absolute difference between two values without risk of
+    /// overflow. For unsigned types, this is `max(a, b) - min(a, b)`.
+    pub c0nst trait ConstAbsDiff: Sized + [c0nst] core::cmp::Ord + [c0nst] core::ops::Sub<Output = Self> {
+        /// Computes the absolute difference between `self` and `other`.
+        fn abs_diff(self, other: Self) -> Self;
+    }
+
     /// Base arithmetic traits for constant primitive integers.
     ///
     /// # Implementor requirements for default methods
@@ -788,6 +797,28 @@ const_power_of_two_impl!(u16);
 const_power_of_two_impl!(u32);
 const_power_of_two_impl!(u64);
 const_power_of_two_impl!(u128);
+
+macro_rules! const_abs_diff_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstAbsDiff for $t {
+                fn abs_diff(self, other: Self) -> Self {
+                    if self >= other {
+                        self - other
+                    } else {
+                        other - self
+                    }
+                }
+            }
+        }
+    };
+}
+
+const_abs_diff_impl!(u8);
+const_abs_diff_impl!(u16);
+const_abs_diff_impl!(u32);
+const_abs_diff_impl!(u64);
+const_abs_diff_impl!(u128);
 
 const_prim_int_impl!(u8);
 const_prim_int_impl!(u16);

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -17,12 +17,15 @@ use num_traits::{ToPrimitive, Zero};
 use core::convert::TryFrom;
 use core::fmt::Write;
 
-pub use crate::const_numtrait::{ConstBounded, ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero};
+pub use crate::const_numtrait::{
+    ConstAbsDiff, ConstBounded, ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero,
+};
 use crate::machineword::{ConstMachineWord, MachineWord};
 
 #[allow(unused_imports)]
 use num_traits::{FromPrimitive, Num};
 
+mod abs_diff_impl;
 mod add_sub_impl;
 mod bit_ops_impl;
 mod euclid;

--- a/src/fixeduint/abs_diff_impl.rs
+++ b/src/fixeduint/abs_diff_impl.rs
@@ -1,0 +1,89 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Absolute difference implementation for FixedUInt.
+
+use super::{FixedUInt, MachineWord};
+use crate::const_numtrait::ConstAbsDiff;
+use crate::machineword::ConstMachineWord;
+
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstAbsDiff for FixedUInt<T, N> {
+        fn abs_diff(self, other: Self) -> Self {
+            if self >= other {
+                self - other
+            } else {
+                other - self
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_abs_diff() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(
+            ConstAbsDiff::abs_diff(U16::from(10u8), U16::from(3u8)),
+            U16::from(7u8)
+        );
+        assert_eq!(
+            ConstAbsDiff::abs_diff(U16::from(3u8), U16::from(10u8)),
+            U16::from(7u8)
+        );
+        assert_eq!(
+            ConstAbsDiff::abs_diff(U16::from(5u8), U16::from(5u8)),
+            U16::from(0u8)
+        );
+        assert_eq!(
+            ConstAbsDiff::abs_diff(U16::from(0u8), U16::from(100u8)),
+            U16::from(100u8)
+        );
+        assert_eq!(
+            ConstAbsDiff::abs_diff(U16::from(255u8), U16::from(0u8)),
+            U16::from(255u8)
+        );
+    }
+
+    c0nst::c0nst! {
+        pub c0nst fn const_abs_diff<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            a: FixedUInt<T, N>,
+            b: FixedUInt<T, N>,
+        ) -> FixedUInt<T, N> {
+            ConstAbsDiff::abs_diff(a, b)
+        }
+    }
+
+    #[test]
+    fn test_const_abs_diff() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(
+            const_abs_diff(U16::from(10u8), U16::from(3u8)),
+            U16::from(7u8)
+        );
+
+        #[cfg(feature = "nightly")]
+        {
+            const A: U16 = FixedUInt { array: [10, 0] };
+            const B: U16 = FixedUInt { array: [3, 0] };
+            const DIFF: U16 = const_abs_diff(A, B);
+            assert_eq!(DIFF, FixedUInt { array: [7, 0] });
+        }
+    }
+}


### PR DESCRIPTION
ConstAbsDiff trait #58 

## Summary by Sourcery

Introduce a const-compatible absolute difference operation across primitive unsigned integers and FixedUInt types.

New Features:
- Add ConstAbsDiff trait providing a const-compatible abs_diff method.
- Implement ConstAbsDiff for unsigned integer primitives (u8, u16, u32, u64, u128).
- Expose and implement ConstAbsDiff for FixedUInt types, including a const wrapper function.

Tests:
- Add runtime and const-evaluated tests verifying FixedUInt ConstAbsDiff behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added absolute-difference operation for unsigned integer types (u8, u16, u32, u64, u128).
  * Extended absolute-difference support to fixed-width unsigned integers with const-evaluable API.

* **Tests**
  * Added unit tests covering runtime behavior and compile-time evaluation of absolute-difference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->