### PR TITLE
Add ConstCheckedPow trait

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -201,6 +201,15 @@ c0nst::c0nst! {
         fn abs_diff(self, other: Self) -> Self;
     }
 
+    /// Const-compatible checked exponentiation.
+    ///
+    /// Returns `None` if the result would overflow.
+    pub c0nst trait ConstCheckedPow: Sized + [c0nst] ConstOne + [c0nst] ConstCheckedMul {
+        /// Checked exponentiation. Computes `self.pow(exp)`, returning `None`
+        /// if overflow occurred.
+        fn checked_pow(self, exp: u32) -> Option<Self>;
+    }
+
     /// Base arithmetic traits for constant primitive integers.
     ///
     /// # Implementor requirements for default methods
@@ -826,6 +835,24 @@ const_abs_diff_impl!(u16);
 const_abs_diff_impl!(u32);
 const_abs_diff_impl!(u64);
 const_abs_diff_impl!(u128);
+
+macro_rules! const_checked_pow_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstCheckedPow for $t {
+                fn checked_pow(self, exp: u32) -> Option<Self> {
+                    self.checked_pow(exp)
+                }
+            }
+        }
+    };
+}
+
+const_checked_pow_impl!(u8);
+const_checked_pow_impl!(u16);
+const_checked_pow_impl!(u32);
+const_checked_pow_impl!(u64);
+const_checked_pow_impl!(u128);
 
 const_prim_int_impl!(u8);
 const_prim_int_impl!(u16);

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -18,7 +18,7 @@ use core::convert::TryFrom;
 use core::fmt::Write;
 
 pub use crate::const_numtrait::{
-    ConstAbsDiff, ConstBounded, ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero,
+    ConstAbsDiff, ConstBounded, ConstCheckedPow, ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero,
 };
 use crate::machineword::{ConstMachineWord, MachineWord};
 
@@ -28,6 +28,7 @@ use num_traits::{FromPrimitive, Num};
 mod abs_diff_impl;
 mod add_sub_impl;
 mod bit_ops_impl;
+mod checked_pow_impl;
 mod euclid;
 mod iter_impl;
 mod mul_div_impl;

--- a/src/fixeduint/checked_pow_impl.rs
+++ b/src/fixeduint/checked_pow_impl.rs
@@ -1,0 +1,131 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Checked power implementation for FixedUInt.
+
+use super::{FixedUInt, MachineWord};
+use crate::const_numtrait::{ConstCheckedMul, ConstCheckedPow, ConstOne};
+use crate::machineword::ConstMachineWord;
+
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedPow for FixedUInt<T, N> {
+        fn checked_pow(self, exp: u32) -> Option<Self> {
+            if exp == 0 {
+                return Some(Self::one());
+            }
+            // Exponentiation by squaring with overflow checking
+            let mut result = Self::one();
+            let mut base = self;
+            let mut e = exp;
+            while e > 0 {
+                if (e & 1) == 1 {
+                    result = match ConstCheckedMul::checked_mul(&result, &base) {
+                        Some(v) => v,
+                        None => return None,
+                    };
+                }
+                e >>= 1;
+                if e > 0 {
+                    base = match ConstCheckedMul::checked_mul(&base, &base) {
+                        Some(v) => v,
+                        None => return None,
+                    };
+                }
+            }
+            Some(result)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_checked_pow() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // Basic cases
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(2u8), 0),
+            Some(U16::from(1u8))
+        );
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(2u8), 1),
+            Some(U16::from(2u8))
+        );
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(2u8), 2),
+            Some(U16::from(4u8))
+        );
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(2u8), 8),
+            Some(U16::from(256u16))
+        );
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(3u8), 3),
+            Some(U16::from(27u8))
+        );
+
+        // Edge cases
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(0u8), 0),
+            Some(U16::from(1u8))
+        );
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(0u8), 5),
+            Some(U16::from(0u8))
+        );
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(1u8), 100),
+            Some(U16::from(1u8))
+        );
+
+        // Overflow cases
+        assert_eq!(ConstCheckedPow::checked_pow(U16::from(2u8), 16), None); // 2^16 = 65536 > 65535
+        assert_eq!(ConstCheckedPow::checked_pow(U16::from(256u16), 2), None); // 256^2 = 65536 > 65535
+
+        // Just fits
+        assert_eq!(
+            ConstCheckedPow::checked_pow(U16::from(2u8), 15),
+            Some(U16::from(32768u16))
+        );
+    }
+
+    c0nst::c0nst! {
+        pub c0nst fn const_checked_pow<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            base: FixedUInt<T, N>,
+            exp: u32,
+        ) -> Option<FixedUInt<T, N>> {
+            ConstCheckedPow::checked_pow(base, exp)
+        }
+    }
+
+    #[test]
+    fn test_const_checked_pow() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(
+            const_checked_pow(U16::from(2u8), 8),
+            Some(U16::from(256u16))
+        );
+
+        #[cfg(feature = "nightly")]
+        {
+            const BASE: U16 = FixedUInt { array: [2, 0] };
+            const POW_RESULT: Option<U16> = const_checked_pow(BASE, 8);
+            assert_eq!(POW_RESULT, Some(FixedUInt { array: [0, 1] })); // 256 = [0, 1] in little-endian
+        }
+    }
+}

--- a/src/fixeduint/checked_pow_impl.rs
+++ b/src/fixeduint/checked_pow_impl.rs
@@ -30,11 +30,17 @@ c0nst::c0nst! {
             let mut e = exp;
             while e > 0 {
                 if (e & 1) == 1 {
-                    result = ConstCheckedMul::checked_mul(&result, &base)?;
+                    result = match ConstCheckedMul::checked_mul(&result, &base) {
+                        Some(v) => v,
+                        None => return None,
+                    };
                 }
                 e >>= 1;
                 if e > 0 {
-                    base = ConstCheckedMul::checked_mul(&base, &base)?;
+                    base = match ConstCheckedMul::checked_mul(&base, &base) {
+                        Some(v) => v,
+                        None => return None,
+                    };
                 }
             }
             Some(result)

--- a/src/fixeduint/checked_pow_impl.rs
+++ b/src/fixeduint/checked_pow_impl.rs
@@ -30,17 +30,11 @@ c0nst::c0nst! {
             let mut e = exp;
             while e > 0 {
                 if (e & 1) == 1 {
-                    result = match ConstCheckedMul::checked_mul(&result, &base) {
-                        Some(v) => v,
-                        None => return None,
-                    };
+                    result = ConstCheckedMul::checked_mul(&result, &base)?;
                 }
                 e >>= 1;
                 if e > 0 {
-                    base = match ConstCheckedMul::checked_mul(&base, &base) {
-                        Some(v) => v,
-                        None => return None,
-                    };
+                    base = ConstCheckedMul::checked_mul(&base, &base)?;
                 }
             }
             Some(result)


### PR DESCRIPTION
More const #58

## Summary by Sourcery

Introduce a const-compatible checked exponentiation capability and apply it to primitive integers and FixedUInt types.

New Features:
- Add the ConstCheckedPow trait for const-compatible checked exponentiation with overflow detection.
- Implement ConstCheckedPow for unsigned primitive integer types (u8, u16, u32, u64, u128).
- Provide a ConstCheckedPow implementation for FixedUInt using exponentiation by squaring with checked multiplication.
- Expose a const function wrapper const_checked_pow for FixedUInt to enable compile-time checked exponentiation.

Tests:
- Add runtime and const-evaluated tests verifying FixedUInt checked_pow behavior, including edge, overflow, and just-fitting cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added const-compatible checked exponentiation: public checked_pow API for unsigned primitives (u8–u128) and fixed-size big integers, returning None on overflow and usable in const contexts.

* **Tests**
  * Added unit and const-evaluation tests covering edge cases, overflow scenarios, and a nightly-guarded compile-time evaluation path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->