### PR TITLE
Add ConstIlog trait (ilog, ilog2, ilog10)

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -210,6 +210,52 @@ c0nst::c0nst! {
         fn checked_pow(self, exp: u32) -> Option<Self>;
     }
 
+    /// Const-compatible integer logarithm operations.
+    ///
+    /// # Unsigned types only
+    ///
+    /// This trait is designed for unsigned integer types. The logarithm of zero
+    /// is undefined and will panic (or return `None` for checked variants).
+    pub c0nst trait ConstIlog: Sized + [c0nst] ConstZero + [c0nst] ConstOne + [c0nst] core::cmp::Ord + [c0nst] core::ops::Div<Output = Self> {
+        /// Returns the base 2 logarithm of the number, rounded down.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `self` is zero.
+        fn ilog2(self) -> u32;
+
+        /// Returns the base 10 logarithm of the number, rounded down.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `self` is zero.
+        fn ilog10(self) -> u32;
+
+        /// Returns the logarithm of the number with respect to an arbitrary base,
+        /// rounded down.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `self` is zero, or if `base` is less than 2.
+        fn ilog(self, base: Self) -> u32;
+
+        /// Returns the base 2 logarithm of the number, rounded down.
+        ///
+        /// Returns `None` if `self` is zero.
+        fn checked_ilog2(self) -> Option<u32>;
+
+        /// Returns the base 10 logarithm of the number, rounded down.
+        ///
+        /// Returns `None` if `self` is zero.
+        fn checked_ilog10(self) -> Option<u32>;
+
+        /// Returns the logarithm of the number with respect to an arbitrary base,
+        /// rounded down.
+        ///
+        /// Returns `None` if `self` is zero, or if `base` is less than 2.
+        fn checked_ilog(self, base: Self) -> Option<u32>;
+    }
+
     /// Base arithmetic traits for constant primitive integers.
     ///
     /// # Implementor requirements for default methods
@@ -853,6 +899,39 @@ const_checked_pow_impl!(u16);
 const_checked_pow_impl!(u32);
 const_checked_pow_impl!(u64);
 const_checked_pow_impl!(u128);
+
+macro_rules! const_ilog_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstIlog for $t {
+                fn ilog2(self) -> u32 {
+                    self.ilog2()
+                }
+                fn ilog10(self) -> u32 {
+                    self.ilog10()
+                }
+                fn ilog(self, base: Self) -> u32 {
+                    self.ilog(base)
+                }
+                fn checked_ilog2(self) -> Option<u32> {
+                    self.checked_ilog2()
+                }
+                fn checked_ilog10(self) -> Option<u32> {
+                    self.checked_ilog10()
+                }
+                fn checked_ilog(self, base: Self) -> Option<u32> {
+                    self.checked_ilog(base)
+                }
+            }
+        }
+    };
+}
+
+const_ilog_impl!(u8);
+const_ilog_impl!(u16);
+const_ilog_impl!(u32);
+const_ilog_impl!(u64);
+const_ilog_impl!(u128);
 
 const_prim_int_impl!(u8);
 const_prim_int_impl!(u16);

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -18,7 +18,8 @@ use core::convert::TryFrom;
 use core::fmt::Write;
 
 pub use crate::const_numtrait::{
-    ConstAbsDiff, ConstBounded, ConstCheckedPow, ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero,
+    ConstAbsDiff, ConstBounded, ConstCheckedPow, ConstIlog, ConstOne, ConstPowerOfTwo,
+    ConstPrimInt, ConstZero,
 };
 use crate::machineword::{ConstMachineWord, MachineWord};
 
@@ -30,6 +31,7 @@ mod add_sub_impl;
 mod bit_ops_impl;
 mod checked_pow_impl;
 mod euclid;
+mod ilog_impl;
 mod iter_impl;
 mod mul_div_impl;
 mod num_integer_impl;

--- a/src/fixeduint/ilog_impl.rs
+++ b/src/fixeduint/ilog_impl.rs
@@ -1,0 +1,216 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integer logarithm implementations for FixedUInt.
+
+use super::{FixedUInt, MachineWord};
+use crate::const_numtrait::{ConstIlog, ConstPrimInt, ConstZero};
+use crate::machineword::ConstMachineWord;
+
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstIlog for FixedUInt<T, N> {
+        fn ilog2(self) -> u32 {
+            match self.checked_ilog2() {
+                Some(v) => v,
+                None => panic!("ilog2: argument is zero"),
+            }
+        }
+
+        fn ilog10(self) -> u32 {
+            match self.checked_ilog10() {
+                Some(v) => v,
+                None => panic!("ilog10: argument is zero"),
+            }
+        }
+
+        fn ilog(self, base: Self) -> u32 {
+            match self.checked_ilog(base) {
+                Some(v) => v,
+                None => panic!("ilog: argument is zero or base is less than 2"),
+            }
+        }
+
+        fn checked_ilog2(self) -> Option<u32> {
+            if self.is_zero() {
+                return None;
+            }
+            // ilog2 = position of highest set bit = BIT_SIZE - 1 - leading_zeros
+            let leading = ConstPrimInt::leading_zeros(self);
+            Some(Self::BIT_SIZE as u32 - 1 - leading)
+        }
+
+        fn checked_ilog10(self) -> Option<u32> {
+            if self.is_zero() {
+                return None;
+            }
+            // Count how many times we can divide by 10
+            let ten: Self = core::convert::From::from(10u8);
+            let mut n = self;
+            let mut count = 0u32;
+            while n >= ten {
+                n /= ten;
+                count += 1;
+            }
+            Some(count)
+        }
+
+        fn checked_ilog(self, base: Self) -> Option<u32> {
+            if self.is_zero() {
+                return None;
+            }
+            let two: Self = core::convert::From::from(2u8);
+            if base < two {
+                return None;
+            }
+            // Count how many times we can divide by base
+            let mut n = self;
+            let mut count = 0u32;
+            while n >= base {
+                n /= base;
+                count += 1;
+            }
+            Some(count)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ilog2() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(ConstIlog::ilog2(U16::from(1u8)), 0);
+        assert_eq!(ConstIlog::ilog2(U16::from(2u8)), 1);
+        assert_eq!(ConstIlog::ilog2(U16::from(3u8)), 1);
+        assert_eq!(ConstIlog::ilog2(U16::from(4u8)), 2);
+        assert_eq!(ConstIlog::ilog2(U16::from(7u8)), 2);
+        assert_eq!(ConstIlog::ilog2(U16::from(8u8)), 3);
+        assert_eq!(ConstIlog::ilog2(U16::from(255u8)), 7);
+        assert_eq!(ConstIlog::ilog2(U16::from(256u16)), 8);
+        assert_eq!(ConstIlog::ilog2(U16::from(32768u16)), 15);
+    }
+
+    #[test]
+    fn test_ilog10() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(ConstIlog::ilog10(U16::from(1u8)), 0);
+        assert_eq!(ConstIlog::ilog10(U16::from(9u8)), 0);
+        assert_eq!(ConstIlog::ilog10(U16::from(10u8)), 1);
+        assert_eq!(ConstIlog::ilog10(U16::from(99u8)), 1);
+        assert_eq!(ConstIlog::ilog10(U16::from(100u8)), 2);
+        assert_eq!(ConstIlog::ilog10(U16::from(999u16)), 2);
+        assert_eq!(ConstIlog::ilog10(U16::from(1000u16)), 3);
+        assert_eq!(ConstIlog::ilog10(U16::from(9999u16)), 3);
+        assert_eq!(ConstIlog::ilog10(U16::from(10000u16)), 4);
+    }
+
+    #[test]
+    fn test_ilog() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // Base 2
+        assert_eq!(ConstIlog::ilog(U16::from(8u8), U16::from(2u8)), 3);
+        assert_eq!(ConstIlog::ilog(U16::from(9u8), U16::from(2u8)), 3);
+
+        // Base 3
+        assert_eq!(ConstIlog::ilog(U16::from(1u8), U16::from(3u8)), 0);
+        assert_eq!(ConstIlog::ilog(U16::from(3u8), U16::from(3u8)), 1);
+        assert_eq!(ConstIlog::ilog(U16::from(8u8), U16::from(3u8)), 1);
+        assert_eq!(ConstIlog::ilog(U16::from(9u8), U16::from(3u8)), 2);
+        assert_eq!(ConstIlog::ilog(U16::from(27u8), U16::from(3u8)), 3);
+
+        // Base 16
+        assert_eq!(ConstIlog::ilog(U16::from(255u8), U16::from(16u8)), 1);
+        assert_eq!(ConstIlog::ilog(U16::from(256u16), U16::from(16u8)), 2);
+    }
+
+    #[test]
+    fn test_checked_ilog2() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(ConstIlog::checked_ilog2(U16::from(0u8)), None);
+        assert_eq!(ConstIlog::checked_ilog2(U16::from(1u8)), Some(0));
+        assert_eq!(ConstIlog::checked_ilog2(U16::from(8u8)), Some(3));
+    }
+
+    #[test]
+    fn test_checked_ilog10() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(ConstIlog::checked_ilog10(U16::from(0u8)), None);
+        assert_eq!(ConstIlog::checked_ilog10(U16::from(1u8)), Some(0));
+        assert_eq!(ConstIlog::checked_ilog10(U16::from(100u8)), Some(2));
+    }
+
+    #[test]
+    fn test_checked_ilog() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // Zero argument
+        assert_eq!(
+            ConstIlog::checked_ilog(U16::from(0u8), U16::from(2u8)),
+            None
+        );
+        // Invalid base
+        assert_eq!(
+            ConstIlog::checked_ilog(U16::from(10u8), U16::from(0u8)),
+            None
+        );
+        assert_eq!(
+            ConstIlog::checked_ilog(U16::from(10u8), U16::from(1u8)),
+            None
+        );
+        // Valid
+        assert_eq!(
+            ConstIlog::checked_ilog(U16::from(8u8), U16::from(2u8)),
+            Some(3)
+        );
+    }
+
+    c0nst::c0nst! {
+        pub c0nst fn const_ilog2<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            v: FixedUInt<T, N>,
+        ) -> u32 {
+            ConstIlog::ilog2(v)
+        }
+
+        pub c0nst fn const_ilog10<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            v: FixedUInt<T, N>,
+        ) -> u32 {
+            ConstIlog::ilog10(v)
+        }
+    }
+
+    #[test]
+    fn test_const_ilog() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(const_ilog2(U16::from(8u8)), 3);
+        assert_eq!(const_ilog10(U16::from(100u8)), 2);
+
+        #[cfg(feature = "nightly")]
+        {
+            const EIGHT: U16 = FixedUInt { array: [8, 0] };
+            const HUNDRED: U16 = FixedUInt { array: [100, 0] };
+            const LOG2_RESULT: u32 = const_ilog2(EIGHT);
+            const LOG10_RESULT: u32 = const_ilog10(HUNDRED);
+            assert_eq!(LOG2_RESULT, 3);
+            assert_eq!(LOG10_RESULT, 2);
+        }
+    }
+}


### PR DESCRIPTION
More const #58

## Summary by Sourcery

Add a new const-compatible integer logarithm trait and implementations for primitive unsigned integers and FixedUInt, including both panicking and checked variants for bases 2, 10, and arbitrary bases.

New Features:
- Introduce the ConstIlog trait providing ilog2, ilog10, ilog, and their checked counterparts for const contexts on unsigned integer types.
- Implement ConstIlog for primitive unsigned integer types (u8, u16, u32, u64, u128) via a shared macro.
- Implement ConstIlog for FixedUInt, enabling const evaluable integer logarithm operations over generic fixed-width unsigned integers.

Tests:
- Add unit tests covering ilog2, ilog10, ilog, and checked variants for FixedUInt, including const-evaluable helper functions used in nightly-only const tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compile-time integer logarithm operations (ilog2, ilog10, ilog) for unsigned integer types and FixedUInt.
  * Provided both panicking and checked (Option-returning) variants for integer logarithm calculations.
  * Enabled const-evaluation of logarithmic operations for compile-time computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->