### PR TITLE
Add ConstDivCeil trait (div_ceil, checked_div_ceil)

### DIFF
--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -285,7 +285,7 @@ c0nst::c0nst! {
     /// Const-compatible ceiling division.
     ///
     /// Returns the smallest integer greater than or equal to the exact quotient.
-    pub c0nst trait ConstDivCeil: Sized + [c0nst] ConstZero + [c0nst] core::ops::Div<Output = Self> + [c0nst] core::ops::Rem<Output = Self> + [c0nst] ConstOne + [c0nst] core::ops::Add<Output = Self> + [c0nst] core::cmp::Eq {
+    pub c0nst trait ConstDivCeil: Sized + [c0nst] ConstZero + [c0nst] ConstOne + [c0nst] ConstCheckedAdd {
         /// Calculates the quotient of `self` and `rhs`, rounding up.
         ///
         /// # Panics

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -282,6 +282,23 @@ c0nst::c0nst! {
         fn checked_next_multiple_of(self, rhs: Self) -> Option<Self>;
     }
 
+    /// Const-compatible ceiling division.
+    ///
+    /// Returns the smallest integer greater than or equal to the exact quotient.
+    pub c0nst trait ConstDivCeil: Sized + [c0nst] ConstZero + [c0nst] core::ops::Div<Output = Self> + [c0nst] core::ops::Rem<Output = Self> + [c0nst] ConstOne + [c0nst] core::cmp::Eq {
+        /// Calculates the quotient of `self` and `rhs`, rounding up.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `rhs` is zero.
+        fn div_ceil(self, rhs: Self) -> Self;
+
+        /// Calculates the quotient of `self` and `rhs`, rounding up.
+        ///
+        /// Returns `None` if `rhs` is zero.
+        fn checked_div_ceil(self, rhs: Self) -> Option<Self>;
+    }
+
     /// Base arithmetic traits for constant primitive integers.
     ///
     /// # Implementor requirements for default methods
@@ -986,6 +1003,31 @@ const_multiple_impl!(u16);
 const_multiple_impl!(u32);
 const_multiple_impl!(u64);
 const_multiple_impl!(u128);
+
+macro_rules! const_div_ceil_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstDivCeil for $t {
+                fn div_ceil(self, rhs: Self) -> Self {
+                    <$t>::div_ceil(self, rhs)
+                }
+                fn checked_div_ceil(self, rhs: Self) -> Option<Self> {
+                    if rhs == 0 {
+                        None
+                    } else {
+                        Some(<$t>::div_ceil(self, rhs))
+                    }
+                }
+            }
+        }
+    };
+}
+
+const_div_ceil_impl!(u8);
+const_div_ceil_impl!(u16);
+const_div_ceil_impl!(u32);
+const_div_ceil_impl!(u64);
+const_div_ceil_impl!(u128);
 
 const_prim_int_impl!(u8);
 const_prim_int_impl!(u16);

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -981,7 +981,7 @@ macro_rules! const_multiple_impl {
         c0nst::c0nst! {
             impl c0nst ConstMultiple for $t {
                 fn is_multiple_of(&self, rhs: &Self) -> bool {
-                    if *rhs == 0 {
+                    if rhs.is_zero() {
                         false
                     } else {
                         *self % *rhs == 0
@@ -1012,7 +1012,7 @@ macro_rules! const_div_ceil_impl {
                     <$t>::div_ceil(self, rhs)
                 }
                 fn checked_div_ceil(self, rhs: Self) -> Option<Self> {
-                    if rhs == 0 {
+                    if rhs.is_zero() {
                         None
                     } else {
                         Some(<$t>::div_ceil(self, rhs))

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -285,7 +285,7 @@ c0nst::c0nst! {
     /// Const-compatible ceiling division.
     ///
     /// Returns the smallest integer greater than or equal to the exact quotient.
-    pub c0nst trait ConstDivCeil: Sized + [c0nst] ConstZero + [c0nst] core::ops::Div<Output = Self> + [c0nst] core::ops::Rem<Output = Self> + [c0nst] ConstOne + [c0nst] core::cmp::Eq {
+    pub c0nst trait ConstDivCeil: Sized + [c0nst] ConstZero + [c0nst] core::ops::Div<Output = Self> + [c0nst] core::ops::Rem<Output = Self> + [c0nst] ConstOne + [c0nst] core::ops::Add<Output = Self> + [c0nst] core::cmp::Eq {
         /// Calculates the quotient of `self` and `rhs`, rounding up.
         ///
         /// # Panics

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -18,7 +18,7 @@ use core::convert::TryFrom;
 use core::fmt::Write;
 
 pub use crate::const_numtrait::{
-    ConstAbsDiff, ConstBounded, ConstCheckedPow, ConstIlog, ConstMultiple, ConstOne,
+    ConstAbsDiff, ConstBounded, ConstCheckedPow, ConstDivCeil, ConstIlog, ConstMultiple, ConstOne,
     ConstPowerOfTwo, ConstPrimInt, ConstZero,
 };
 use crate::machineword::{ConstMachineWord, MachineWord};
@@ -30,6 +30,7 @@ mod abs_diff_impl;
 mod add_sub_impl;
 mod bit_ops_impl;
 mod checked_pow_impl;
+mod div_ceil_impl;
 mod euclid;
 mod ilog_impl;
 mod iter_impl;

--- a/src/fixeduint/div_ceil_impl.rs
+++ b/src/fixeduint/div_ceil_impl.rs
@@ -1,0 +1,134 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Ceiling division for FixedUInt.
+
+use super::{FixedUInt, MachineWord};
+use crate::const_numtrait::{ConstDivCeil, ConstOne, ConstZero};
+use crate::machineword::ConstMachineWord;
+
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstDivCeil for FixedUInt<T, N> {
+        fn div_ceil(self, rhs: Self) -> Self {
+            match self.checked_div_ceil(rhs) {
+                Some(v) => v,
+                None => panic!("div_ceil: division by zero"),
+            }
+        }
+
+        fn checked_div_ceil(self, rhs: Self) -> Option<Self> {
+            if rhs.is_zero() {
+                return None;
+            }
+            let q = self / rhs;
+            let r = self % rhs;
+            if r.is_zero() {
+                Some(q)
+            } else {
+                Some(q + Self::one())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_div_ceil() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // Exact division
+        assert_eq!(
+            ConstDivCeil::div_ceil(U16::from(10u8), U16::from(5u8)),
+            U16::from(2u8)
+        );
+        assert_eq!(
+            ConstDivCeil::div_ceil(U16::from(10u8), U16::from(2u8)),
+            U16::from(5u8)
+        );
+
+        // Rounds up
+        assert_eq!(
+            ConstDivCeil::div_ceil(U16::from(10u8), U16::from(3u8)),
+            U16::from(4u8)
+        ); // 10/3 = 3.33... -> 4
+        assert_eq!(
+            ConstDivCeil::div_ceil(U16::from(11u8), U16::from(3u8)),
+            U16::from(4u8)
+        ); // 11/3 = 3.66... -> 4
+        assert_eq!(
+            ConstDivCeil::div_ceil(U16::from(12u8), U16::from(3u8)),
+            U16::from(4u8)
+        ); // 12/3 = 4 exact
+
+        // Edge cases
+        assert_eq!(
+            ConstDivCeil::div_ceil(U16::from(0u8), U16::from(5u8)),
+            U16::from(0u8)
+        );
+        assert_eq!(
+            ConstDivCeil::div_ceil(U16::from(1u8), U16::from(5u8)),
+            U16::from(1u8)
+        ); // 1/5 = 0.2 -> 1
+        assert_eq!(
+            ConstDivCeil::div_ceil(U16::from(1u8), U16::from(1u8)),
+            U16::from(1u8)
+        );
+    }
+
+    #[test]
+    fn test_checked_div_ceil() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(
+            ConstDivCeil::checked_div_ceil(U16::from(10u8), U16::from(3u8)),
+            Some(U16::from(4u8))
+        );
+
+        // Division by zero
+        assert_eq!(
+            ConstDivCeil::checked_div_ceil(U16::from(10u8), U16::from(0u8)),
+            None
+        );
+    }
+
+    c0nst::c0nst! {
+        pub c0nst fn const_div_ceil<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            a: FixedUInt<T, N>,
+            b: FixedUInt<T, N>,
+        ) -> FixedUInt<T, N> {
+            ConstDivCeil::div_ceil(a, b)
+        }
+    }
+
+    #[test]
+    fn test_const_div_ceil() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(
+            const_div_ceil(U16::from(10u8), U16::from(3u8)),
+            U16::from(4u8)
+        );
+
+        #[cfg(feature = "nightly")]
+        {
+            const TEN: U16 = FixedUInt { array: [10, 0] };
+            const THREE: U16 = FixedUInt { array: [3, 0] };
+            const RESULT: U16 = const_div_ceil(TEN, THREE);
+            assert_eq!(RESULT, FixedUInt { array: [4, 0] });
+        }
+    }
+}

--- a/src/fixeduint/div_ceil_impl.rs
+++ b/src/fixeduint/div_ceil_impl.rs
@@ -14,8 +14,8 @@
 
 //! Ceiling division for FixedUInt.
 
-use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstDivCeil, ConstOne, ConstZero};
+use super::{const_div, const_is_zero, FixedUInt, MachineWord};
+use crate::const_numtrait::{ConstDivCeil, ConstOne};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {
@@ -28,15 +28,16 @@ c0nst::c0nst! {
         }
 
         fn checked_div_ceil(self, rhs: Self) -> Option<Self> {
-            if rhs.is_zero() {
+            if const_is_zero(&rhs.array) {
                 return None;
             }
-            let q = self / rhs;
-            let r = self % rhs;
-            if r.is_zero() {
-                Some(q)
+            // Use const_div which computes both quotient and remainder in one pass
+            let mut quotient = self.array;
+            let remainder = const_div(&mut quotient, &rhs.array);
+            if const_is_zero(&remainder) {
+                Some(Self { array: quotient })
             } else {
-                Some(q + Self::one())
+                Some(Self { array: quotient } + Self::one())
             }
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a const-compatible ceiling-division abstraction and implement it for primitive unsigned integers and FixedUInt.

New Features:
- Add a ConstDivCeil trait providing div_ceil and checked_div_ceil for const contexts.
- Implement ConstDivCeil for primitive unsigned integer types u8, u16, u32, u64, and u128.
- Implement ConstDivCeil for FixedUInt, including a const wrapper function and usage in const contexts.

Tests:
- Add unit tests for FixedUInt ceiling division behavior, including checked and const-evaluated variants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ceiling-division (round-up) operations with both checked and unchecked variants.
  * Ceiling-division is available for primitive unsigned integers and for fixed-size unsigned types, including const-evaluable variants usable at compile time.
* **Tests**
  * Added runtime and compile-time tests covering exact division, rounding-up, zero/edge cases, and overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->