### PR TITLE
Add ConstIsqrt trait (isqrt, checked_isqrt)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.17"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2018"
+rust-version = "1.84"
 description = """
 Fixed-size big integer implementation for Rust
 """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.17"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2018"
-rust-version = "1.84"
+rust-version = "1.73"
 description = """
 Fixed-size big integer implementation for Rust
 """

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![crate](https://img.shields.io/crates/v/fixed-bigint.svg)](https://crates.io/crates/fixed-bigint)
 [![documentation](https://docs.rs/fixed-bigint/badge.svg)](https://docs.rs/fixed-bigint/)
-[![minimum rustc 1.51](https://img.shields.io/badge/rustc-1.51+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.84](https://img.shields.io/badge/rustc-1.84+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/kaidokert/fixed-bigint-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/kaidokert/fixed-bigint-rs/actions)
 [![Coverage Status](https://coveralls.io/repos/github/kaidokert/fixed-bigint-rs/badge.svg?branch=main)](https://coveralls.io/github/kaidokert/fixed-bigint-rs?branch=main)
 
 Unsigned BigInt implementation, backed by a fixed-size array.
 
-***Important***: Requires at least Rust 1.51 stable, as it uses `min_const_generics`
+***Important***: Requires at least Rust 1.84 stable
 
 `FixedUInt<u8,4>`,`FixedUInt<u16,2>` or `FixedUInt<u32,1>` all create a 32-bit unsigned integer, that behaves mostly the same as builtin `u32`.
 `FixedUInt<u32, 64>` creates a 2048-bit value, that uses native 32-bit math. If running on 8-bit CPU, `FixedUInt<u8, 2048>` would work the same, just very much slower.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![crate](https://img.shields.io/crates/v/fixed-bigint.svg)](https://crates.io/crates/fixed-bigint)
 [![documentation](https://docs.rs/fixed-bigint/badge.svg)](https://docs.rs/fixed-bigint/)
-[![minimum rustc 1.84](https://img.shields.io/badge/rustc-1.84+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.73](https://img.shields.io/badge/rustc-1.73+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/kaidokert/fixed-bigint-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/kaidokert/fixed-bigint-rs/actions)
 [![Coverage Status](https://coveralls.io/repos/github/kaidokert/fixed-bigint-rs/badge.svg?branch=main)](https://coveralls.io/github/kaidokert/fixed-bigint-rs?branch=main)
 
 Unsigned BigInt implementation, backed by a fixed-size array.
 
-***Important***: Requires at least Rust 1.84 stable
+***Important***: Requires at least Rust 1.73 stable
 
 `FixedUInt<u8,4>`,`FixedUInt<u16,2>` or `FixedUInt<u32,1>` all create a 32-bit unsigned integer, that behaves mostly the same as builtin `u32`.
 `FixedUInt<u32, 64>` creates a 2048-bit value, that uses native 32-bit math. If running on 8-bit CPU, `FixedUInt<u8, 2048>` would work the same, just very much slower.

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -1044,6 +1044,8 @@ const_div_ceil_impl!(u32);
 const_div_ceil_impl!(u64);
 const_div_ceil_impl!(u128);
 
+// Primitive isqrt requires Rust 1.84+, gate behind nightly
+#[cfg(feature = "nightly")]
 macro_rules! const_isqrt_impl {
     ($t:ty) => {
         c0nst::c0nst! {
@@ -1060,10 +1062,15 @@ macro_rules! const_isqrt_impl {
     };
 }
 
+#[cfg(feature = "nightly")]
 const_isqrt_impl!(u8);
+#[cfg(feature = "nightly")]
 const_isqrt_impl!(u16);
+#[cfg(feature = "nightly")]
 const_isqrt_impl!(u32);
+#[cfg(feature = "nightly")]
 const_isqrt_impl!(u64);
+#[cfg(feature = "nightly")]
 const_isqrt_impl!(u128);
 
 const_prim_int_impl!(u8);

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -299,18 +299,18 @@ c0nst::c0nst! {
         fn checked_div_ceil(self, rhs: Self) -> Option<Self>;
     }
 
-    /// Const-compatible integer square root.
+    /// Const-compatible integer square root for unsigned integers.
     ///
     /// Returns the largest integer `r` such that `r * r <= self`.
     pub c0nst trait ConstIsqrt: Sized + [c0nst] ConstZero {
         /// Returns the integer square root of `self`.
-        ///
-        /// # Panics
-        ///
-        /// Panics if `self` is negative (for signed types).
         fn isqrt(self) -> Self;
 
-        /// Returns the integer square root of `self`, or `None` if `self` is negative.
+        /// Returns the integer square root of `self`.
+        ///
+        /// For unsigned types, this always returns `Some`. The checked variant
+        /// exists for API consistency with signed types where negative values
+        /// would return `None`.
         fn checked_isqrt(self) -> Option<Self>;
     }
 

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -299,6 +299,21 @@ c0nst::c0nst! {
         fn checked_div_ceil(self, rhs: Self) -> Option<Self>;
     }
 
+    /// Const-compatible integer square root.
+    ///
+    /// Returns the largest integer `r` such that `r * r <= self`.
+    pub c0nst trait ConstIsqrt: Sized + [c0nst] ConstZero {
+        /// Returns the integer square root of `self`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `self` is negative (for signed types).
+        fn isqrt(self) -> Self;
+
+        /// Returns the integer square root of `self`, or `None` if `self` is negative.
+        fn checked_isqrt(self) -> Option<Self>;
+    }
+
     /// Base arithmetic traits for constant primitive integers.
     ///
     /// # Implementor requirements for default methods
@@ -1028,6 +1043,28 @@ const_div_ceil_impl!(u16);
 const_div_ceil_impl!(u32);
 const_div_ceil_impl!(u64);
 const_div_ceil_impl!(u128);
+
+macro_rules! const_isqrt_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstIsqrt for $t {
+                fn isqrt(self) -> Self {
+                    <$t>::isqrt(self)
+                }
+                fn checked_isqrt(self) -> Option<Self> {
+                    // For unsigned types, isqrt always succeeds
+                    Some(<$t>::isqrt(self))
+                }
+            }
+        }
+    };
+}
+
+const_isqrt_impl!(u8);
+const_isqrt_impl!(u16);
+const_isqrt_impl!(u32);
+const_isqrt_impl!(u64);
+const_isqrt_impl!(u128);
 
 const_prim_int_impl!(u8);
 const_prim_int_impl!(u16);

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -18,8 +18,8 @@ use core::convert::TryFrom;
 use core::fmt::Write;
 
 pub use crate::const_numtrait::{
-    ConstAbsDiff, ConstBounded, ConstCheckedPow, ConstDivCeil, ConstIlog, ConstMultiple, ConstOne,
-    ConstPowerOfTwo, ConstPrimInt, ConstZero,
+    ConstAbsDiff, ConstBounded, ConstCheckedPow, ConstDivCeil, ConstIlog, ConstIsqrt,
+    ConstMultiple, ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero,
 };
 use crate::machineword::{ConstMachineWord, MachineWord};
 
@@ -33,6 +33,7 @@ mod checked_pow_impl;
 mod div_ceil_impl;
 mod euclid;
 mod ilog_impl;
+mod isqrt_impl;
 mod iter_impl;
 mod mul_div_impl;
 mod multiple_impl;

--- a/src/fixeduint/isqrt_impl.rs
+++ b/src/fixeduint/isqrt_impl.rs
@@ -1,0 +1,173 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integer square root for FixedUInt.
+
+use super::{FixedUInt, MachineWord};
+use crate::const_numtrait::{ConstIsqrt, ConstPrimInt, ConstZero};
+use crate::machineword::ConstMachineWord;
+
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstIsqrt for FixedUInt<T, N> {
+        fn isqrt(self) -> Self {
+            // For unsigned types, isqrt always succeeds
+            match ConstIsqrt::checked_isqrt(self) {
+                Some(v) => v,
+                None => unreachable!(),
+            }
+        }
+
+        fn checked_isqrt(self) -> Option<Self> {
+            // Bit-by-bit algorithm for integer square root
+            // Returns the largest r such that r * r <= self
+            if self.is_zero() {
+                return Some(Self::zero());
+            }
+
+            // Start with the highest bit position that could be set in the result
+            // For sqrt, the result has at most half the bits of the input
+            let mut result = Self::zero();
+
+            // Find starting bit position: half of the bit length of self
+            let bit_len = Self::BIT_SIZE - ConstPrimInt::leading_zeros(self) as usize;
+            let start_bit = bit_len.div_ceil(2);
+
+            let mut bit_pos = start_bit;
+            while bit_pos > 0 {
+                bit_pos -= 1;
+
+                // Try setting this bit in the result
+                let mut candidate = result;
+                candidate.array[bit_pos / Self::WORD_BITS] |=
+                    T::one().shl(bit_pos % Self::WORD_BITS);
+
+                // Check if candidate * candidate <= self
+                // To avoid overflow, we check if candidate <= self / candidate
+                // But division is expensive, so we compute candidate * candidate directly
+                // and compare. Since candidate has at most half the bits of self,
+                // candidate * candidate won't overflow.
+                let square = candidate * candidate;
+                if square <= self {
+                    result = candidate;
+                }
+            }
+
+            Some(result)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_isqrt() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // Perfect squares
+        assert_eq!(ConstIsqrt::isqrt(U16::from(0u8)), U16::from(0u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(1u8)), U16::from(1u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(4u8)), U16::from(2u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(9u8)), U16::from(3u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(16u8)), U16::from(4u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(25u8)), U16::from(5u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(100u8)), U16::from(10u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(144u8)), U16::from(12u8));
+
+        // Non-perfect squares (floor)
+        assert_eq!(ConstIsqrt::isqrt(U16::from(2u8)), U16::from(1u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(3u8)), U16::from(1u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(5u8)), U16::from(2u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(8u8)), U16::from(2u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(10u8)), U16::from(3u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(15u8)), U16::from(3u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(24u8)), U16::from(4u8));
+    }
+
+    #[test]
+    fn test_isqrt_larger_values() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // Larger values
+        assert_eq!(ConstIsqrt::isqrt(U16::from(10000u16)), U16::from(100u8));
+        assert_eq!(ConstIsqrt::isqrt(U16::from(65535u16)), U16::from(255u8)); // sqrt(65535) = 255.998...
+        assert_eq!(ConstIsqrt::isqrt(U16::from(65025u16)), U16::from(255u8)); // 255^2 = 65025
+    }
+
+    #[test]
+    fn test_checked_isqrt() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // For unsigned, checked_isqrt always returns Some
+        assert_eq!(
+            ConstIsqrt::checked_isqrt(U16::from(0u8)),
+            Some(U16::from(0u8))
+        );
+        assert_eq!(
+            ConstIsqrt::checked_isqrt(U16::from(16u8)),
+            Some(U16::from(4u8))
+        );
+        assert_eq!(
+            ConstIsqrt::checked_isqrt(U16::from(17u8)),
+            Some(U16::from(4u8))
+        );
+    }
+
+    #[test]
+    fn test_isqrt_correctness() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // Verify r^2 <= n < (r+1)^2 for various values
+        for n in 0..=1000u16 {
+            let n_int = U16::from(n);
+            let r = ConstIsqrt::isqrt(n_int);
+
+            // r^2 <= n
+            assert!(r * r <= n_int, "Failed: {}^2 > {}", r, n);
+
+            // (r+1)^2 > n (unless r+1 would overflow, but won't happen for small n)
+            let r_plus_1 = r + U16::from(1u8);
+            assert!(
+                r_plus_1 * r_plus_1 > n_int,
+                "Failed: {}^2 <= {}",
+                r_plus_1,
+                n
+            );
+        }
+    }
+
+    c0nst::c0nst! {
+        pub c0nst fn const_isqrt<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            v: FixedUInt<T, N>,
+        ) -> FixedUInt<T, N> {
+            ConstIsqrt::isqrt(v)
+        }
+    }
+
+    #[test]
+    fn test_const_isqrt() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(const_isqrt(U16::from(16u8)), U16::from(4u8));
+        assert_eq!(const_isqrt(U16::from(100u8)), U16::from(10u8));
+
+        #[cfg(feature = "nightly")]
+        {
+            const SIXTEEN: U16 = FixedUInt { array: [16, 0] };
+            const RESULT: U16 = const_isqrt(SIXTEEN);
+            assert_eq!(RESULT, FixedUInt { array: [4, 0] });
+        }
+    }
+}


### PR DESCRIPTION
More c0nst

## Summary by Sourcery

Add a const-compatible integer square root API and implement it for primitive unsigned integers and FixedUInt types.

New Features:
- Introduce the ConstIsqrt trait providing isqrt and checked_isqrt for const contexts.
- Implement ConstIsqrt for unsigned primitive integer types via a shared macro.
- Add a ConstIsqrt implementation and const helper for FixedUInt using a bit-by-bit integer square root algorithm.

Tests:
- Add unit tests verifying ConstIsqrt behavior for FixedUInt across perfect squares, non-squares, larger values, checked_isqrt semantics, and general correctness including const evaluation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added compile-time integer square-root for unsigned primitives and fixed-size integers, with const-compatible and safe checked variants.

* **Tests**
  * Added unit tests covering correctness, edge cases, larger values, and const-evaluation paths.

* **Chores / Documentation**
  * Bumped minimum Rust toolchain to 1.73 and updated the README badge accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->