### PR TITLE
Add ConstMidpoint and ConstUnboundedShift traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,6 @@ codegen-units = 16
 
 [features]
 use-unsafe = []
-nightly = ["c0nst/nightly"]
+1_87 = []
+nightly = ["c0nst/nightly", "1_87"]
 default = []

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -368,7 +368,7 @@ c0nst::c0nst! {
     /// Const-compatible midpoint calculation.
     ///
     /// Computes the average of two values, rounded down, without overflow.
-    /// Stable since Rust 1.61.0.
+    /// Stable since Rust 1.85.0.
     pub c0nst trait ConstMidpoint: Sized {
         /// Calculates the midpoint (average) of `self` and `rhs`, rounded down.
         ///

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -368,7 +368,7 @@ c0nst::c0nst! {
     /// Const-compatible midpoint calculation.
     ///
     /// Computes the average of two values, rounded down, without overflow.
-    /// Stable since Rust 1.85.0.
+    /// Stable since Rust 1.61.0.
     pub c0nst trait ConstMidpoint: Sized {
         /// Calculates the midpoint (average) of `self` and `rhs`, rounded down.
         ///
@@ -383,10 +383,10 @@ c0nst::c0nst! {
     /// - `unbounded_shl(n)` returns 0 when n >= BITS (all bits shifted out)
     /// - `unbounded_shr(n)` returns 0 when n >= BITS (all bits shifted out)
     pub c0nst trait ConstUnboundedShift: Sized {
-        /// Unbounded shift left. Returns 0 if `rhs >= Self::BITS`.
+        /// Unbounded shift left. Returns 0 if `rhs` is greater than or equal to the bit width of the type.
         fn unbounded_shl(self, rhs: u32) -> Self;
 
-        /// Unbounded shift right. Returns 0 if `rhs >= Self::BITS`.
+        /// Unbounded shift right. Returns 0 if `rhs` is greater than or equal to the bit width of the type.
         fn unbounded_shr(self, rhs: u32) -> Self;
     }
 

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -365,6 +365,31 @@ c0nst::c0nst! {
         fn carrying_mul_add(self, rhs: Self, addend: Self, carry: Self) -> (Self, Self);
     }
 
+    /// Const-compatible midpoint calculation.
+    ///
+    /// Computes the average of two values, rounded down, without overflow.
+    /// Stable since Rust 1.85.0.
+    pub c0nst trait ConstMidpoint: Sized {
+        /// Calculates the midpoint (average) of `self` and `rhs`, rounded down.
+        ///
+        /// This never overflows, even for values close to the maximum.
+        fn midpoint(self, rhs: Self) -> Self;
+    }
+
+    /// Const-compatible unbounded shift operations.
+    ///
+    /// Unlike regular shifts, unbounded shifts don't panic when the shift
+    /// amount exceeds the bit width. Instead:
+    /// - `unbounded_shl(n)` returns 0 when n >= BITS (all bits shifted out)
+    /// - `unbounded_shr(n)` returns 0 when n >= BITS (all bits shifted out)
+    pub c0nst trait ConstUnboundedShift: Sized {
+        /// Unbounded shift left. Returns 0 if `rhs >= Self::BITS`.
+        fn unbounded_shl(self, rhs: u32) -> Self;
+
+        /// Unbounded shift right. Returns 0 if `rhs >= Self::BITS`.
+        fn unbounded_shr(self, rhs: u32) -> Self;
+    }
+
     /// Base arithmetic traits for constant primitive integers.
     ///
     /// # Implementor requirements for default methods
@@ -1210,6 +1235,46 @@ const_carrying_mul_impl!(u32, u64, 32);
 const_carrying_mul_impl!(u64, u128, 64);
 // TODO: u128 carrying_mul requires u256 type (not available in Rust)
 
+macro_rules! const_midpoint_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstMidpoint for $t {
+                fn midpoint(self, rhs: Self) -> Self {
+                    // (a & b) + ((a ^ b) >> 1) avoids overflow
+                    (self & rhs) + ((self ^ rhs) >> 1)
+                }
+            }
+        }
+    };
+}
+
+const_midpoint_impl!(u8);
+const_midpoint_impl!(u16);
+const_midpoint_impl!(u32);
+const_midpoint_impl!(u64);
+const_midpoint_impl!(u128);
+
+macro_rules! const_unbounded_shift_impl {
+    ($t:ty, $bits:expr) => {
+        c0nst::c0nst! {
+            impl c0nst ConstUnboundedShift for $t {
+                fn unbounded_shl(self, rhs: u32) -> Self {
+                    if rhs >= $bits { 0 } else { self << rhs }
+                }
+                fn unbounded_shr(self, rhs: u32) -> Self {
+                    if rhs >= $bits { 0 } else { self >> rhs }
+                }
+            }
+        }
+    };
+}
+
+const_unbounded_shift_impl!(u8, 8);
+const_unbounded_shift_impl!(u16, 16);
+const_unbounded_shift_impl!(u32, 32);
+const_unbounded_shift_impl!(u64, 64);
+const_unbounded_shift_impl!(u128, 128);
+
 const_prim_int_impl!(u8);
 const_prim_int_impl!(u16);
 const_prim_int_impl!(u32);
@@ -1319,6 +1384,18 @@ mod tests {
 
         pub c0nst fn carrying_mul_word<T: [c0nst] ConstCarryingMul>(a: T, b: T, carry: T) -> (T, T) {
             a.carrying_mul(b, carry)
+        }
+
+        pub c0nst fn midpoint_word<T: [c0nst] ConstMidpoint>(a: T, b: T) -> T {
+            a.midpoint(b)
+        }
+
+        pub c0nst fn unbounded_shl_word<T: [c0nst] ConstUnboundedShift>(a: T, n: u32) -> T {
+            a.unbounded_shl(n)
+        }
+
+        pub c0nst fn unbounded_shr_word<T: [c0nst] ConstUnboundedShift>(a: T, n: u32) -> T {
+            a.unbounded_shr(n)
         }
     }
 
@@ -1737,6 +1814,93 @@ mod tests {
             assert_eq!(CM_SIMPLE, (50u8, 0u8));
             assert_eq!(CM_WITH_CARRY, (60u8, 0u8));
             assert_eq!(CM_MAX, (0x00u8, 0xFFu8));
+        }
+    }
+
+    #[test]
+    fn test_const_midpoint() {
+        // Simple midpoint
+        assert_eq!(midpoint_word(0u8, 10u8), 5u8);
+        assert_eq!(midpoint_word(10u8, 0u8), 5u8); // order doesn't matter
+
+        // Midpoint rounds down
+        assert_eq!(midpoint_word(0u8, 9u8), 4u8); // (0+9)/2 = 4.5 -> 4
+        assert_eq!(midpoint_word(1u8, 10u8), 5u8); // (1+10)/2 = 5.5 -> 5
+
+        // Same values
+        assert_eq!(midpoint_word(42u8, 42u8), 42u8);
+
+        // Edge cases with max values (no overflow!)
+        assert_eq!(midpoint_word(u8::MAX, u8::MAX), u8::MAX);
+        assert_eq!(midpoint_word(u8::MAX, u8::MAX - 1), u8::MAX - 1); // rounds down
+        assert_eq!(midpoint_word(0u8, u8::MAX), 127u8); // (0+255)/2 = 127.5 -> 127
+
+        // Test with larger types
+        assert_eq!(midpoint_word(0u64, 100u64), 50u64);
+        assert_eq!(midpoint_word(u64::MAX, u64::MAX), u64::MAX);
+        assert_eq!(midpoint_word(u64::MAX - 1, u64::MAX), u64::MAX - 1); // rounds down
+
+        // u128
+        assert_eq!(midpoint_word(0u128, u128::MAX), u128::MAX / 2);
+
+        #[cfg(feature = "nightly")]
+        {
+            const MID_SIMPLE: u8 = midpoint_word(0u8, 10u8);
+            const MID_ROUND: u8 = midpoint_word(0u8, 9u8);
+            const MID_MAX: u8 = midpoint_word(u8::MAX, u8::MAX);
+            const MID_EDGE: u8 = midpoint_word(0u8, u8::MAX);
+
+            assert_eq!(MID_SIMPLE, 5u8);
+            assert_eq!(MID_ROUND, 4u8);
+            assert_eq!(MID_MAX, u8::MAX);
+            assert_eq!(MID_EDGE, 127u8);
+        }
+    }
+
+    #[test]
+    fn test_const_unbounded_shift() {
+        // Normal shifts (within bounds)
+        assert_eq!(unbounded_shl_word(1u8, 0), 1u8);
+        assert_eq!(unbounded_shl_word(1u8, 1), 2u8);
+        assert_eq!(unbounded_shl_word(1u8, 7), 128u8);
+        assert_eq!(unbounded_shr_word(128u8, 7), 1u8);
+        assert_eq!(unbounded_shr_word(255u8, 4), 15u8);
+
+        // At boundary (shift by bit width)
+        assert_eq!(unbounded_shl_word(1u8, 8), 0u8);
+        assert_eq!(unbounded_shr_word(255u8, 8), 0u8);
+
+        // Beyond boundary
+        assert_eq!(unbounded_shl_word(255u8, 9), 0u8);
+        assert_eq!(unbounded_shl_word(255u8, 100), 0u8);
+        assert_eq!(unbounded_shr_word(255u8, 9), 0u8);
+        assert_eq!(unbounded_shr_word(255u8, 100), 0u8);
+
+        // Test with larger types
+        assert_eq!(unbounded_shl_word(1u64, 63), 1u64 << 63);
+        assert_eq!(unbounded_shl_word(1u64, 64), 0u64);
+        assert_eq!(unbounded_shr_word(u64::MAX, 64), 0u64);
+
+        // u128
+        assert_eq!(unbounded_shl_word(1u128, 127), 1u128 << 127);
+        assert_eq!(unbounded_shl_word(1u128, 128), 0u128);
+        assert_eq!(unbounded_shr_word(u128::MAX, 128), 0u128);
+
+        #[cfg(feature = "nightly")]
+        {
+            const SHL_NORMAL: u8 = unbounded_shl_word(1u8, 4);
+            const SHL_BOUNDARY: u8 = unbounded_shl_word(1u8, 8);
+            const SHL_BEYOND: u8 = unbounded_shl_word(1u8, 100);
+            const SHR_NORMAL: u8 = unbounded_shr_word(128u8, 4);
+            const SHR_BOUNDARY: u8 = unbounded_shr_word(255u8, 8);
+            const SHR_BEYOND: u8 = unbounded_shr_word(255u8, 100);
+
+            assert_eq!(SHL_NORMAL, 16u8);
+            assert_eq!(SHL_BOUNDARY, 0u8);
+            assert_eq!(SHL_BEYOND, 0u8);
+            assert_eq!(SHR_NORMAL, 8u8);
+            assert_eq!(SHR_BOUNDARY, 0u8);
+            assert_eq!(SHR_BEYOND, 0u8);
         }
     }
 }

--- a/src/const_numtrait.rs
+++ b/src/const_numtrait.rs
@@ -999,11 +999,7 @@ macro_rules! const_abs_diff_impl {
         c0nst::c0nst! {
             impl c0nst ConstAbsDiff for $t {
                 fn abs_diff(self, other: Self) -> Self {
-                    if self >= other {
-                        self - other
-                    } else {
-                        other - self
-                    }
+                    <$t>::abs_diff(self, other)
                 }
             }
         }
@@ -1067,6 +1063,8 @@ const_ilog_impl!(u32);
 const_ilog_impl!(u64);
 const_ilog_impl!(u128);
 
+// Native is_multiple_of() requires Rust 1.87+, gate behind 1_87 feature
+#[cfg(not(feature = "1_87"))]
 macro_rules! const_multiple_impl {
     ($t:ty) => {
         c0nst::c0nst! {
@@ -1077,6 +1075,25 @@ macro_rules! const_multiple_impl {
                     } else {
                         *self % *rhs == 0
                     }
+                }
+                fn next_multiple_of(self, rhs: Self) -> Self {
+                    self.next_multiple_of(rhs)
+                }
+                fn checked_next_multiple_of(self, rhs: Self) -> Option<Self> {
+                    self.checked_next_multiple_of(rhs)
+                }
+            }
+        }
+    };
+}
+
+#[cfg(feature = "1_87")]
+macro_rules! const_multiple_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstMultiple for $t {
+                fn is_multiple_of(&self, rhs: &Self) -> bool {
+                    <$t>::is_multiple_of(*self, *rhs)
                 }
                 fn next_multiple_of(self, rhs: Self) -> Self {
                     self.next_multiple_of(rhs)
@@ -1235,6 +1252,8 @@ const_carrying_mul_impl!(u32, u64, 32);
 const_carrying_mul_impl!(u64, u128, 64);
 // TODO: u128 carrying_mul requires u256 type (not available in Rust)
 
+// Native midpoint() requires Rust 1.85+, gate behind 1_87 feature
+#[cfg(not(feature = "1_87"))]
 macro_rules! const_midpoint_impl {
     ($t:ty) => {
         c0nst::c0nst! {
@@ -1248,12 +1267,27 @@ macro_rules! const_midpoint_impl {
     };
 }
 
+#[cfg(feature = "1_87")]
+macro_rules! const_midpoint_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstMidpoint for $t {
+                fn midpoint(self, rhs: Self) -> Self {
+                    <$t>::midpoint(self, rhs)
+                }
+            }
+        }
+    };
+}
+
 const_midpoint_impl!(u8);
 const_midpoint_impl!(u16);
 const_midpoint_impl!(u32);
 const_midpoint_impl!(u64);
 const_midpoint_impl!(u128);
 
+// Native unbounded_shl/shr() requires Rust 1.85+, gate behind 1_87 feature
+#[cfg(not(feature = "1_87"))]
 macro_rules! const_unbounded_shift_impl {
     ($t:ty, $bits:expr) => {
         c0nst::c0nst! {
@@ -1263,6 +1297,22 @@ macro_rules! const_unbounded_shift_impl {
                 }
                 fn unbounded_shr(self, rhs: u32) -> Self {
                     if rhs >= $bits { 0 } else { self >> rhs }
+                }
+            }
+        }
+    };
+}
+
+#[cfg(feature = "1_87")]
+macro_rules! const_unbounded_shift_impl {
+    ($t:ty, $bits:expr) => {
+        c0nst::c0nst! {
+            impl c0nst ConstUnboundedShift for $t {
+                fn unbounded_shl(self, rhs: u32) -> Self {
+                    <$t>::unbounded_shl(self, rhs)
+                }
+                fn unbounded_shr(self, rhs: u32) -> Self {
+                    <$t>::unbounded_shr(self, rhs)
                 }
             }
         }

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -37,6 +37,7 @@ mod extended_precision_impl;
 mod ilog_impl;
 mod isqrt_impl;
 mod iter_impl;
+mod midpoint_impl;
 mod mul_div_impl;
 mod multiple_impl;
 mod num_integer_impl;

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -359,20 +359,20 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstUnboundedShift for FixedUInt<T, N> {
         fn unbounded_shl(self, rhs: u32) -> Self {
-            let bit_size = Self::BIT_SIZE as u32;
-            if bit_size == 0 || rhs >= bit_size {
+            let rhs_usize = rhs as usize;
+            if rhs_usize >= Self::BIT_SIZE {
                 Self::zero()
             } else {
-                self << (rhs as usize)
+                self << rhs_usize
             }
         }
 
         fn unbounded_shr(self, rhs: u32) -> Self {
-            let bit_size = Self::BIT_SIZE as u32;
-            if bit_size == 0 || rhs >= bit_size {
+            let rhs_usize = rhs as usize;
+            if rhs_usize >= Self::BIT_SIZE {
                 Self::zero()
             } else {
-                self >> (rhs as usize)
+                self >> rhs_usize
             }
         }
     }

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -359,20 +359,20 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstUnboundedShift for FixedUInt<T, N> {
         fn unbounded_shl(self, rhs: u32) -> Self {
-            let rhs_usize = rhs as usize;
-            if rhs_usize >= Self::BIT_SIZE {
+            let (shift, overflow) = normalize_shift_amount(rhs, Self::BIT_SIZE);
+            if overflow {
                 Self::zero()
             } else {
-                self << rhs_usize
+                self << shift
             }
         }
 
         fn unbounded_shr(self, rhs: u32) -> Self {
-            let rhs_usize = rhs as usize;
-            if rhs_usize >= Self::BIT_SIZE {
+            let (shift, overflow) = normalize_shift_amount(rhs, Self::BIT_SIZE);
+            if overflow {
                 Self::zero()
             } else {
-                self >> rhs_usize
+                self >> shift
             }
         }
     }

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -1,8 +1,8 @@
 use super::{const_shl_impl, const_shr_impl, FixedUInt, MachineWord};
 
 use crate::const_numtrait::{
-    ConstCheckedShl, ConstCheckedShr, ConstOverflowingShl, ConstOverflowingShr, ConstWrappingShl,
-    ConstWrappingShr, ConstZero,
+    ConstCheckedShl, ConstCheckedShr, ConstOverflowingShl, ConstOverflowingShr,
+    ConstUnboundedShift, ConstWrappingShl, ConstWrappingShr, ConstZero,
 };
 use crate::machineword::ConstMachineWord;
 use crate::patch_num_traits::{OverflowingShl, OverflowingShr};
@@ -356,6 +356,26 @@ c0nst::c0nst! {
             if overflow { None } else { Some(res) }
         }
     }
+
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstUnboundedShift for FixedUInt<T, N> {
+        fn unbounded_shl(self, rhs: u32) -> Self {
+            let bit_size = Self::BIT_SIZE as u32;
+            if bit_size == 0 || rhs >= bit_size {
+                Self::zero()
+            } else {
+                self << (rhs as usize)
+            }
+        }
+
+        fn unbounded_shr(self, rhs: u32) -> Self {
+            let bit_size = Self::BIT_SIZE as u32;
+            if bit_size == 0 || rhs >= bit_size {
+                Self::zero()
+            } else {
+                self >> (rhs as usize)
+            }
+        }
+    }
 }
 
 // OverflowingShl/Shr from patch_num_traits - delegate to const impls
@@ -654,5 +674,101 @@ mod tests {
         // num_traits::CheckedShr
         assert_eq!(CheckedShr::checked_shr(&b, 4), Some(TestInt::from(1u8)));
         assert_eq!(CheckedShr::checked_shr(&b, 16), None);
+    }
+
+    #[test]
+    fn test_unbounded_shift() {
+        type U16 = FixedUInt<u8, 2>;
+
+        let one = U16::from(1u8);
+
+        // Normal shifts (within bounds)
+        assert_eq!(ConstUnboundedShift::unbounded_shl(one, 0), one);
+        assert_eq!(ConstUnboundedShift::unbounded_shl(one, 4), U16::from(16u8));
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shl(one, 15),
+            U16::from(0x8000u16)
+        );
+
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shr(U16::from(0x8000u16), 15),
+            one
+        );
+        assert_eq!(ConstUnboundedShift::unbounded_shr(U16::from(16u8), 4), one);
+
+        // At boundary (shift by bit width) - returns 0
+        assert_eq!(ConstUnboundedShift::unbounded_shl(one, 16), U16::from(0u8));
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shr(U16::from(0xFFFFu16), 16),
+            U16::from(0u8)
+        );
+
+        // Beyond boundary - returns 0
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shl(U16::from(0xFFFFu16), 17),
+            U16::from(0u8)
+        );
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shl(U16::from(0xFFFFu16), 100),
+            U16::from(0u8)
+        );
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shr(U16::from(0xFFFFu16), 17),
+            U16::from(0u8)
+        );
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shr(U16::from(0xFFFFu16), 100),
+            U16::from(0u8)
+        );
+
+        // Test with different word sizes
+        type U32 = FixedUInt<u8, 4>;
+        let one32 = U32::from(1u8);
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shl(one32, 31),
+            U32::from(0x80000000u32)
+        );
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shl(one32, 32),
+            U32::from(0u8)
+        );
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shr(U32::from(0x80000000u32), 31),
+            one32
+        );
+        assert_eq!(
+            ConstUnboundedShift::unbounded_shr(U32::from(0x80000000u32), 32),
+            U32::from(0u8)
+        );
+    }
+
+    #[test]
+    fn test_unbounded_shift_polymorphic() {
+        fn test_unbounded<T>(val: T, shift: u32, expected_shl: T, expected_shr: T)
+        where
+            T: ConstUnboundedShift + Eq + core::fmt::Debug + Copy,
+        {
+            assert_eq!(ConstUnboundedShift::unbounded_shl(val, shift), expected_shl);
+            assert_eq!(ConstUnboundedShift::unbounded_shr(val, shift), expected_shr);
+        }
+
+        // Test with FixedUInt layouts
+        type U8x2 = FixedUInt<u8, 2>;
+        type U8x4 = FixedUInt<u8, 4>;
+        type U16x2 = FixedUInt<u16, 2>;
+
+        // Same logical shift, different layouts
+        test_unbounded(U8x2::from(1u8), 4, U8x2::from(16u8), U8x2::from(0u8));
+        test_unbounded(U8x4::from(1u8), 4, U8x4::from(16u8), U8x4::from(0u8));
+        test_unbounded(U16x2::from(1u8), 4, U16x2::from(16u8), U16x2::from(0u8));
+
+        // Test with primitives
+        test_unbounded(1u8, 4, 16u8, 0u8);
+        test_unbounded(1u16, 4, 16u16, 0u16);
+        test_unbounded(1u32, 4, 16u32, 0u32);
+
+        // Boundary tests
+        test_unbounded(1u8, 8, 0u8, 0u8);
+        test_unbounded(U8x2::from(1u8), 16, U8x2::from(0u8), U8x2::from(0u8));
     }
 }

--- a/src/fixeduint/midpoint_impl.rs
+++ b/src/fixeduint/midpoint_impl.rs
@@ -1,0 +1,143 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Midpoint (average) implementation for FixedUInt.
+
+use super::{FixedUInt, MachineWord};
+use crate::const_numtrait::ConstMidpoint;
+use crate::machineword::ConstMachineWord;
+
+c0nst::c0nst! {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstMidpoint for FixedUInt<T, N> {
+        fn midpoint(self, rhs: Self) -> Self {
+            // (a & b) + ((a ^ b) >> 1) avoids overflow
+            (self & rhs) + ((self ^ rhs) >> 1usize)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_midpoint() {
+        type U16 = FixedUInt<u8, 2>;
+
+        // Simple midpoint
+        assert_eq!(
+            ConstMidpoint::midpoint(U16::from(0u8), U16::from(10u8)),
+            U16::from(5u8)
+        );
+
+        // Order doesn't matter
+        assert_eq!(
+            ConstMidpoint::midpoint(U16::from(10u8), U16::from(0u8)),
+            U16::from(5u8)
+        );
+
+        // Midpoint rounds down
+        assert_eq!(
+            ConstMidpoint::midpoint(U16::from(0u8), U16::from(9u8)),
+            U16::from(4u8)
+        );
+
+        // Same values
+        assert_eq!(
+            ConstMidpoint::midpoint(U16::from(42u8), U16::from(42u8)),
+            U16::from(42u8)
+        );
+
+        // Max values (no overflow)
+        let max = U16::from(0xFFFFu16);
+        assert_eq!(ConstMidpoint::midpoint(max, max), max);
+
+        // 0 and max
+        assert_eq!(
+            ConstMidpoint::midpoint(U16::from(0u8), max),
+            U16::from(0x7FFFu16)
+        );
+    }
+
+    c0nst::c0nst! {
+        pub c0nst fn const_midpoint<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
+            a: FixedUInt<T, N>,
+            b: FixedUInt<T, N>,
+        ) -> FixedUInt<T, N> {
+            ConstMidpoint::midpoint(a, b)
+        }
+    }
+
+    #[test]
+    fn test_const_midpoint() {
+        type U16 = FixedUInt<u8, 2>;
+
+        assert_eq!(
+            const_midpoint(U16::from(0u8), U16::from(10u8)),
+            U16::from(5u8)
+        );
+
+        #[cfg(feature = "nightly")]
+        {
+            const A: U16 = FixedUInt { array: [0, 0] };
+            const B: U16 = FixedUInt { array: [10, 0] };
+            const MID: U16 = const_midpoint(A, B);
+            assert_eq!(MID, FixedUInt { array: [5, 0] });
+
+            // Test with max values
+            const MAX: U16 = FixedUInt {
+                array: [0xFF, 0xFF],
+            };
+            const MID_MAX: U16 = const_midpoint(MAX, MAX);
+            assert_eq!(MID_MAX, MAX);
+        }
+    }
+
+    /// Polymorphic test: verify midpoint produces identical results across
+    /// different word layouts for the same values.
+    #[test]
+    fn test_midpoint_polymorphic() {
+        fn test_mid<T>(a: T, b: T, expected: T)
+        where
+            T: ConstMidpoint + Eq + core::fmt::Debug + Copy,
+        {
+            assert_eq!(ConstMidpoint::midpoint(a, b), expected);
+            assert_eq!(ConstMidpoint::midpoint(b, a), expected); // order doesn't matter
+        }
+
+        // Test with different layouts
+        type U8x2 = FixedUInt<u8, 2>;
+        type U8x4 = FixedUInt<u8, 4>;
+        type U16x2 = FixedUInt<u16, 2>;
+
+        // 0 and 100
+        test_mid(U8x2::from(0u8), U8x2::from(100u8), U8x2::from(50u8));
+        test_mid(U8x4::from(0u8), U8x4::from(100u8), U8x4::from(50u8));
+        test_mid(U16x2::from(0u8), U16x2::from(100u8), U16x2::from(50u8));
+
+        // Same with primitives
+        test_mid(0u8, 100u8, 50u8);
+        test_mid(0u16, 100u16, 50u16);
+        test_mid(0u32, 100u32, 50u32);
+
+        // Rounding down: (0 + 99) / 2 = 49.5 -> 49
+        test_mid(U8x2::from(0u8), U8x2::from(99u8), U8x2::from(49u8));
+        test_mid(0u8, 99u8, 49u8);
+
+        // Large values that would overflow with naive (a+b)/2
+        let max_u16 = U8x2::from(0xFFFFu16);
+        test_mid(max_u16, max_u16, max_u16);
+        test_mid(u16::MAX, u16::MAX, u16::MAX);
+    }
+}


### PR DESCRIPTION
midpoint: average of two values without overflow
unbounded_shl/shr: returns 0 when shift >= bit width

## Summary by Sourcery

Introduce const-evaluable midpoint and unbounded shift traits and implement them for primitive integers and FixedUInt types.

New Features:
- Add ConstMidpoint trait for overflow-safe, const-compatible midpoint computation.
- Add ConstUnboundedShift trait for const-compatible left and right shifts that return zero when shifting by or beyond the bit width.

Enhancements:
- Implement ConstMidpoint and ConstUnboundedShift for unsigned primitive integers and FixedUInt types, enabling generic use in const contexts.

Tests:
- Add unit tests and const-evaluable tests validating midpoint behavior, rounding, and overflow safety for primitives and FixedUInt.
- Add unit tests verifying unbounded shift semantics across boundaries and polymorphically across different FixedUInt layouts and primitive integer types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added const-compatible midpoint and unbounded bit-shift operations for unsigned integers, including composite fixed-size unsigned types. Midpoint is overflow-safe; unbounded shifts return zero when shift >= bit width. Compile-time evaluation supported.

* **Tests**
  * Added comprehensive compile-time and runtime tests covering boundaries, polymorphism, and const evaluation, plus public test helpers to exercise const behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->