### PR TITLE
Add MSRV (1.73) to CI matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, nightly]
+        rust: ["1.73", stable, nightly]
 
     steps:
     - uses: actions/checkout@v4

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -977,7 +977,7 @@ fn to_slice_hex<T: AsRef<[u8]>>(
     Ok(())
 }
 
-enum PanicReason {
+pub(super) enum PanicReason {
     Add,
     Sub,
     Mul,


### PR DESCRIPTION
Fixes #93

## Summary by Sourcery

CI:
- Expand GitHub Actions Rust workflow matrix to include Rust 1.73 as the minimum supported version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure to include an explicit Rust version in the build matrix alongside existing channels, enhancing test coverage across different Rust versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->