### PR TITLE
Document const support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ The arithmetic operands ( +, -, .add() ) panic on overflow, just like native int
 
 In addition to basic arithmetic, two main traits are implemented: [num_traits::PrimInt](https://docs.rs/num-traits/latest/num_traits/int/trait.PrimInt.html) and [num_integer::Integer](https://docs.rs/num/latest/num/integer/trait.Integer.html).
 
+## Const Support
+
+Most arithmetic operations are const-compatible via the [c0nst](https://crates.io/crates/c0nst) crate. On nightly Rust with `--features nightly`, operations can be used in `const` contexts. On stable Rust, the same code compiles but without const evaluation.
+
 _TODO list_:
  * Implement experimental `unchecked_math` operands, unchecked_mul, unchecked_div etc.
  * Probably needs its own error structs instead of reusing core::fmt::Error and core::num::ParseIntError
  * Maybe implement signed version as well.
- * Adopt `const_trait` from nightly and constify everything
 
 _Note:_ This crate is mostly written as an exercise for learning the Rust type system and understanding how well it works on microcontrollers, its fitness for any particular purpose or quality has precisely zero guarantees.
 

--- a/src/const_numtraits.rs
+++ b/src/const_numtraits.rs
@@ -12,6 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! # Const-friendly num_traits
+//!
+//! This module is essentially a fork of [num_traits](https://crates.io/crates/num_traits) with
+//! nightly const traits support.
+//!
+//! # Features
+//!
+//! - `nightly`: Enables const traits support on nightly Rust.
+//!
+//! # Examples
+
 c0nst::c0nst! {
     // TODO: num_traits already has ConstZero and ConstOne,
     // Consider if we should use those as a base here

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -17,7 +17,7 @@ use num_traits::{ToPrimitive, Zero};
 use core::convert::TryFrom;
 use core::fmt::Write;
 
-pub use crate::const_numtrait::{
+pub use crate::const_numtraits::{
     ConstAbsDiff, ConstBorrowingSub, ConstBounded, ConstCarryingAdd, ConstCarryingMul,
     ConstCheckedPow, ConstDivCeil, ConstIlog, ConstIsqrt, ConstMultiple, ConstOne, ConstPowerOfTwo,
     ConstPrimInt, ConstWideningMul, ConstZero,

--- a/src/fixeduint/abs_diff_impl.rs
+++ b/src/fixeduint/abs_diff_impl.rs
@@ -15,7 +15,7 @@
 //! Absolute difference implementation for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::ConstAbsDiff;
+use crate::const_numtraits::ConstAbsDiff;
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/add_sub_impl.rs
+++ b/src/fixeduint/add_sub_impl.rs
@@ -1,12 +1,12 @@
 use super::{add_impl, maybe_panic, sub_impl, FixedUInt, MachineWord, PanicReason};
-use crate::const_numtrait::{
+use crate::const_numtraits::{
     ConstBounded, ConstCheckedAdd, ConstCheckedSub, ConstOverflowingAdd, ConstOverflowingSub,
     ConstSaturatingAdd, ConstSaturatingSub, ConstWrappingAdd, ConstWrappingSub, ConstZero,
 };
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst crate::const_numtrait::ConstOverflowingAdd for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst crate::const_numtraits::ConstOverflowingAdd for FixedUInt<T, N> {
         fn overflowing_add(&self, other: &Self) -> (Self, bool) {
             let mut ret = *self;
             let overflow = add_impl(&mut ret.array, &other.array);
@@ -14,7 +14,7 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst crate::const_numtrait::ConstOverflowingSub for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst crate::const_numtraits::ConstOverflowingSub for FixedUInt<T, N> {
         fn overflowing_sub(&self, other: &Self) -> (Self, bool) {
             let mut ret = *self;
             let overflow = sub_impl(&mut ret.array, &other.array);
@@ -65,7 +65,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Add for FixedUInt<T, N> {
         type Output = Self;
         fn add(self, other: Self) -> Self {
-            let (res, overflow) = <Self as crate::const_numtrait::ConstOverflowingAdd>::overflowing_add(&self, &other);
+            let (res, overflow) = <Self as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(&self, &other);
             if overflow {
                 maybe_panic(PanicReason::Add);
             }
@@ -76,7 +76,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Sub for FixedUInt<T, N> {
         type Output = Self;
         fn sub(self, other: Self) -> Self {
-            let (res, overflow) = <Self as crate::const_numtrait::ConstOverflowingSub>::overflowing_sub(&self, &other);
+            let (res, overflow) = <Self as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(&self, &other);
             if overflow {
                 maybe_panic(PanicReason::Sub);
             }
@@ -87,7 +87,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Add<&'_ Self> for FixedUInt<T, N> {
         type Output = Self;
         fn add(self, other: &Self) -> Self {
-            let (res, overflow) = <Self as crate::const_numtrait::ConstOverflowingAdd>::overflowing_add(&self, other);
+            let (res, overflow) = <Self as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(&self, other);
             if overflow {
                 maybe_panic(PanicReason::Add);
             }
@@ -98,7 +98,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Add<FixedUInt<T, N>> for &FixedUInt<T, N> {
         type Output = FixedUInt<T, N>;
         fn add(self, other: FixedUInt<T, N>) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtrait::ConstOverflowingAdd>::overflowing_add(self, &other);
+            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, &other);
             if overflow {
                 maybe_panic(PanicReason::Add);
             }
@@ -109,7 +109,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Add<Self> for &FixedUInt<T, N> {
         type Output = FixedUInt<T, N>;
         fn add(self, other: Self) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtrait::ConstOverflowingAdd>::overflowing_add(self, other);
+            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, other);
             if overflow {
                 maybe_panic(PanicReason::Add);
             }
@@ -120,7 +120,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Sub<&'_ Self> for FixedUInt<T, N> {
         type Output = Self;
         fn sub(self, other: &Self) -> Self {
-            let (res, overflow) = <Self as crate::const_numtrait::ConstOverflowingSub>::overflowing_sub(&self, other);
+            let (res, overflow) = <Self as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(&self, other);
             if overflow {
                 maybe_panic(PanicReason::Sub);
             }
@@ -131,7 +131,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Sub<FixedUInt<T, N>> for &FixedUInt<T, N> {
         type Output = FixedUInt<T, N>;
         fn sub(self, other: FixedUInt<T, N>) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtrait::ConstOverflowingSub>::overflowing_sub(self, &other);
+            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, &other);
             if overflow {
                 maybe_panic(PanicReason::Sub);
             }
@@ -142,7 +142,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Sub<Self> for &FixedUInt<T, N> {
         type Output = FixedUInt<T, N>;
         fn sub(self, other: Self) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtrait::ConstOverflowingSub>::overflowing_sub(self, other);
+            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, other);
             if overflow {
                 maybe_panic(PanicReason::Sub);
             }
@@ -187,7 +187,7 @@ impl<T: MachineWord, const N: usize> num_traits::ops::overflowing::OverflowingAd
     for FixedUInt<T, N>
 {
     fn overflowing_add(&self, other: &Self) -> (Self, bool) {
-        <Self as crate::const_numtrait::ConstOverflowingAdd>::overflowing_add(self, other)
+        <Self as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, other)
     }
 }
 
@@ -215,7 +215,7 @@ impl<T: MachineWord, const N: usize> num_traits::ops::overflowing::OverflowingSu
     for FixedUInt<T, N>
 {
     fn overflowing_sub(&self, other: &Self) -> (Self, bool) {
-        <Self as crate::const_numtrait::ConstOverflowingSub>::overflowing_sub(self, other)
+        <Self as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, other)
     }
 }
 
@@ -253,7 +253,7 @@ impl<T: MachineWord, const N: usize> num_traits::Saturating for FixedUInt<T, N> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::const_numtrait::{
+    use crate::const_numtraits::{
         ConstCheckedAdd, ConstCheckedSub, ConstOverflowingAdd, ConstOverflowingSub,
         ConstWrappingAdd, ConstWrappingSub,
     };

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -1,6 +1,6 @@
 use super::{const_shl_impl, const_shr_impl, FixedUInt, MachineWord};
 
-use crate::const_numtrait::{
+use crate::const_numtraits::{
     ConstCheckedShl, ConstCheckedShr, ConstOverflowingShl, ConstOverflowingShr,
     ConstUnboundedShift, ConstWrappingShl, ConstWrappingShr, ConstZero,
 };

--- a/src/fixeduint/checked_pow_impl.rs
+++ b/src/fixeduint/checked_pow_impl.rs
@@ -15,7 +15,7 @@
 //! Checked power implementation for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstCheckedMul, ConstCheckedPow, ConstOne};
+use crate::const_numtraits::{ConstCheckedMul, ConstCheckedPow, ConstOne};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -18,7 +18,7 @@
 //! to compute byte array sizes at compile time without unsafe code.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::ConstToBytes;
+use crate::const_numtraits::ConstToBytes;
 use crate::machineword::ConstMachineWord;
 use core::mem::size_of;
 

--- a/src/fixeduint/div_ceil_impl.rs
+++ b/src/fixeduint/div_ceil_impl.rs
@@ -15,7 +15,7 @@
 //! Ceiling division for FixedUInt.
 
 use super::{const_div, const_is_zero, FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstCheckedAdd, ConstDivCeil, ConstOne};
+use crate::const_numtraits::{ConstCheckedAdd, ConstDivCeil, ConstOne};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/euclid.rs
+++ b/src/fixeduint/euclid.rs
@@ -1,7 +1,7 @@
 use num_traits::{CheckedEuclid, Euclid};
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstCheckedEuclid, ConstEuclid, ConstZero};
+use crate::const_numtraits::{ConstCheckedEuclid, ConstEuclid, ConstZero};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -18,7 +18,7 @@
 //! multiplication, useful for implementing arbitrary-precision arithmetic.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::{
+use crate::const_numtraits::{
     ConstBorrowingSub, ConstCarryingAdd, ConstCarryingMul, ConstWideningMul,
 };
 use crate::machineword::ConstMachineWord;

--- a/src/fixeduint/ilog_impl.rs
+++ b/src/fixeduint/ilog_impl.rs
@@ -15,7 +15,7 @@
 //! Integer logarithm implementations for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstIlog, ConstPrimInt, ConstZero};
+use crate::const_numtraits::{ConstIlog, ConstPrimInt, ConstZero};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/isqrt_impl.rs
+++ b/src/fixeduint/isqrt_impl.rs
@@ -15,7 +15,7 @@
 //! Integer square root for FixedUInt.
 
 use super::{const_set_bit, FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstIsqrt, ConstPrimInt, ConstZero};
+use crate::const_numtraits::{ConstIsqrt, ConstPrimInt, ConstZero};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/midpoint_impl.rs
+++ b/src/fixeduint/midpoint_impl.rs
@@ -15,7 +15,7 @@
 //! Midpoint (average) implementation for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::ConstMidpoint;
+use crate::const_numtraits::ConstMidpoint;
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -1,5 +1,5 @@
 use super::{const_div_rem, const_mul, maybe_panic, FixedUInt, MachineWord, PanicReason};
-use crate::const_numtrait::{
+use crate::const_numtraits::{
     ConstBounded, ConstCheckedDiv, ConstCheckedMul, ConstCheckedRem, ConstOverflowingMul,
     ConstSaturatingMul, ConstWrappingMul, ConstZero,
 };

--- a/src/fixeduint/multiple_impl.rs
+++ b/src/fixeduint/multiple_impl.rs
@@ -15,7 +15,7 @@
 //! Multiple-of operations for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstCheckedAdd, ConstMultiple, ConstZero};
+use crate::const_numtraits::{ConstCheckedAdd, ConstMultiple, ConstZero};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/num_traits_identity.rs
+++ b/src/fixeduint/num_traits_identity.rs
@@ -1,5 +1,5 @@
 use super::{const_is_zero, FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstBounded, ConstOne, ConstZero};
+use crate::const_numtraits::{ConstBounded, ConstOne, ConstZero};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/power_of_two_impl.rs
+++ b/src/fixeduint/power_of_two_impl.rs
@@ -15,7 +15,7 @@
 //! Power-of-two operations for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtrait::{ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero};
+use crate::const_numtraits::{ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero};
 use crate::machineword::ConstMachineWord;
 
 c0nst::c0nst! {

--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -1,5 +1,5 @@
 use super::{const_leading_zeros, const_trailing_zeros, FixedUInt, MachineWord};
-use crate::const_numtrait::ConstPrimInt;
+use crate::const_numtraits::ConstPrimInt;
 use crate::machineword::ConstMachineWord;
 
 use num_traits::One;
@@ -31,7 +31,7 @@ c0nst::c0nst! {
             const_trailing_zeros(&self.array)
         }
         fn swap_bytes(self) -> Self {
-            let mut ret = <Self as crate::const_numtrait::ConstZero>::zero();
+            let mut ret = <Self as crate::const_numtraits::ConstZero>::zero();
             let mut i = 0;
             while i < N {
                 ret.array[i] = self.array[N - 1 - i].swap_bytes();
@@ -66,7 +66,7 @@ c0nst::c0nst! {
             core::ops::Shr::<u32>::shr(self, n)
         }
         fn reverse_bits(self) -> Self {
-            let mut ret = <Self as crate::const_numtrait::ConstZero>::zero();
+            let mut ret = <Self as crate::const_numtraits::ConstZero>::zero();
             let mut i = 0;
             while i < N {
                 ret.array[N - 1 - i] = self.array[i].reverse_bits();
@@ -89,10 +89,10 @@ c0nst::c0nst! {
         }
         fn pow(self, exp: u32) -> Self {
             if exp == 0 {
-                return <Self as crate::const_numtrait::ConstOne>::one();
+                return <Self as crate::const_numtraits::ConstOne>::one();
             }
             // Exponentiation by squaring: O(log exp) instead of O(exp)
-            let mut result = <Self as crate::const_numtrait::ConstOne>::one();
+            let mut result = <Self as crate::const_numtraits::ConstOne>::one();
             let mut base = self;
             let mut e = exp;
             while e > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod fixeduint;
 pub mod patch_num_traits;
 
 /// Constant versions of num_traits
-pub mod const_numtrait;
+pub mod const_numtraits;
 
 /// Machine word and doubleword
 mod machineword;

--- a/src/machineword.rs
+++ b/src/machineword.rs
@@ -15,8 +15,8 @@
 // Note: in the future, #![feature(const_trait_impl)] should allow
 // turning this into a const trait
 
-pub use crate::const_numtrait::ConstPrimInt;
-use crate::const_numtrait::{
+pub use crate::const_numtraits::ConstPrimInt;
+use crate::const_numtraits::{
     ConstOverflowingAdd, ConstOverflowingSub, ConstToBytes, ConstWideningMul,
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Document and consolidate const-evaluable numeric traits support and update the public API accordingly.

New Features:
- Expose a const-friendly numeric traits module as part of the public API for FixedUInt types.

Enhancements:
- Rename the internal const numeric traits module from `const_numtrait` to `const_numtraits` and update all usages to the new module path.
- Add Rustdoc to the `const_numtraits` module describing its relationship to `num_traits` and the nightly const traits support.

Documentation:
- Document const support in the README, including how nightly and stable Rust affect const evaluation of arithmetic operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Const Support" section to README describing const-compatibility of arithmetic operations, including details on nightly and stable Rust configurations.
  * Added module-level documentation for const traits functionality.

* **Chores**
  * Refactored internal module structure for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->