### PR TITLE
Fix viral generic_const_exprs bounds, implement ConstFromBytes

### DIFF
--- a/src/const_numtraits.rs
+++ b/src/const_numtraits.rs
@@ -1537,6 +1537,14 @@ mod tests {
             v.to_be_bytes()
         }
 
+        pub c0nst fn from_le_bytes_word<T: [c0nst] ConstFromBytes>(bytes: &T::Bytes) -> T {
+            T::from_le_bytes(bytes)
+        }
+
+        pub c0nst fn from_be_bytes_word<T: [c0nst] ConstFromBytes>(bytes: &T::Bytes) -> T {
+            T::from_be_bytes(bytes)
+        }
+
         pub c0nst fn wrapping_add_word<T: [c0nst] ConstWrappingAdd>(a: &T, b: &T) -> T {
             a.wrapping_add(b)
         }
@@ -1747,6 +1755,39 @@ mod tests {
             const BE_BYTES: [u8; 4] = to_be_bytes_word(&0x12345678u32);
             assert_eq!(LE_BYTES, [0x78, 0x56, 0x34, 0x12]);
             assert_eq!(BE_BYTES, [0x12, 0x34, 0x56, 0x78]);
+        }
+    }
+
+    #[test]
+    fn test_const_from_bytes() {
+        // Test from_le_bytes with u32
+        let val: u32 = from_le_bytes_word(&[0x78, 0x56, 0x34, 0x12]);
+        assert_eq!(val, 0x12345678u32);
+
+        // Test from_be_bytes with u32
+        let val: u32 = from_be_bytes_word(&[0x12, 0x34, 0x56, 0x78]);
+        assert_eq!(val, 0x12345678u32);
+
+        // Test with u8
+        let val: u8 = from_le_bytes_word(&[0xAB]);
+        assert_eq!(val, 0xABu8);
+
+        // Test with u64
+        let val: u64 = from_le_bytes_word(&[0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01]);
+        assert_eq!(val, 0x0102030405060708u64);
+
+        // Test roundtrip
+        let original = 0xDEADBEEFu32;
+        let bytes = to_le_bytes_word(&original);
+        let roundtrip: u32 = from_le_bytes_word(&bytes);
+        assert_eq!(roundtrip, original);
+
+        #[cfg(feature = "nightly")]
+        {
+            const FROM_LE: u32 = from_le_bytes_word(&[0x78, 0x56, 0x34, 0x12]);
+            const FROM_BE: u32 = from_be_bytes_word(&[0x12, 0x34, 0x56, 0x78]);
+            assert_eq!(FROM_LE, 0x12345678u32);
+            assert_eq!(FROM_BE, 0x12345678u32);
         }
     }
 

--- a/src/const_numtraits.rs
+++ b/src/const_numtraits.rs
@@ -196,7 +196,7 @@ c0nst::c0nst! {
         fn checked_shr(&self, rhs: u32) -> Option<Self>;
     }
 
-    /// Const-compatible byte conversion.
+    /// Const-compatible byte serialization.
     pub c0nst trait ConstToBytes {
         /// The byte array type for this integer.
         type Bytes: Copy + [c0nst] AsRef<[u8]> + [c0nst] AsMut<[u8]>;
@@ -204,6 +204,16 @@ c0nst::c0nst! {
         fn to_le_bytes(&self) -> Self::Bytes;
         /// Returns the big-endian byte representation.
         fn to_be_bytes(&self) -> Self::Bytes;
+    }
+
+    /// Const-compatible byte deserialization.
+    pub c0nst trait ConstFromBytes: Sized {
+        /// The byte array type for this integer.
+        type Bytes: Copy + [c0nst] AsRef<[u8]> + [c0nst] AsMut<[u8]>;
+        /// Creates a value from its little-endian byte representation.
+        fn from_le_bytes(bytes: &Self::Bytes) -> Self;
+        /// Creates a value from its big-endian byte representation.
+        fn from_be_bytes(bytes: &Self::Bytes) -> Self;
     }
 
     /// Const-compatible power-of-two operations.
@@ -1020,6 +1030,24 @@ const_to_bytes_impl!(u16, 2);
 const_to_bytes_impl!(u32, 4);
 const_to_bytes_impl!(u64, 8);
 const_to_bytes_impl!(u128, 16);
+
+macro_rules! const_from_bytes_impl {
+    ($t:ty, $n:expr) => {
+        c0nst::c0nst! {
+            impl c0nst ConstFromBytes for $t {
+                type Bytes = [u8; $n];
+                fn from_le_bytes(bytes: &[u8; $n]) -> Self { <$t>::from_le_bytes(*bytes) }
+                fn from_be_bytes(bytes: &[u8; $n]) -> Self { <$t>::from_be_bytes(*bytes) }
+            }
+        }
+    };
+}
+
+const_from_bytes_impl!(u8, 1);
+const_from_bytes_impl!(u16, 2);
+const_from_bytes_impl!(u32, 4);
+const_from_bytes_impl!(u64, 8);
+const_from_bytes_impl!(u128, 16);
 
 macro_rules! const_power_of_two_impl {
     ($t:ty) => {

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -47,10 +47,11 @@ mod power_of_two_impl;
 mod prim_int_impl;
 mod roots_impl;
 mod string_conversion;
-// Prefer nightly (safe const impl) over use-unsafe when both are enabled
+// ConstToBytes trait (nightly only, uses generic_const_exprs)
 #[cfg(feature = "nightly")]
 mod const_to_from_bytes;
-#[cfg(all(feature = "use-unsafe", not(feature = "nightly")))]
+// num_traits::ToBytes/FromBytes (stable impl, no generic_const_exprs viral bounds)
+#[cfg(any(feature = "nightly", feature = "use-unsafe"))]
 mod to_from_bytes;
 
 #[cfg(feature = "zeroize")]
@@ -108,28 +109,40 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
         let (quotient, remainder) = const_div_rem(&self.array, &divisor.array);
         (Self { array: quotient }, Self { array: remainder })
     }
+}
 
-    /// Create a little-endian integer value from its representation as a byte array in little endian.
-    pub fn from_le_bytes(bytes: &[u8]) -> Self {
-        let mut ret = Self::new();
-        let total_bytes = core::cmp::min(bytes.len(), N * Self::WORD_SIZE);
+// Const-compatible from_bytes helper functions
+c0nst::c0nst! {
+    /// Const-compatible from_le_bytes implementation for slices
+    pub(crate) c0nst fn impl_from_le_bytes_slice<T: [c0nst] ConstMachineWord, const N: usize>(
+        bytes: &[u8],
+        word_size: usize,
+    ) -> [T; N] {
+        let mut ret: [T; N] = [T::zero(); N];
+        let capacity = N * word_size;
+        let total_bytes = if bytes.len() < capacity { bytes.len() } else { capacity };
 
-        for (byte_index, &byte) in bytes.iter().enumerate().take(total_bytes) {
-            let word_index = byte_index / Self::WORD_SIZE;
-            let byte_in_word = byte_index % Self::WORD_SIZE;
+        let mut byte_index = 0;
+        while byte_index < total_bytes {
+            let word_index = byte_index / word_size;
+            let byte_in_word = byte_index % word_size;
 
-            let byte_value: T = byte.into();
+            let byte_value: T = T::from(bytes[byte_index]);
             let shifted_value = byte_value.shl(byte_in_word * 8);
-            ret.array[word_index] |= shifted_value;
+            ret[word_index] = ret[word_index].bitor(shifted_value);
+            byte_index += 1;
         }
         ret
     }
 
-    /// Create a big-endian integer value from its representation as a byte array in big endian.
-    pub fn from_be_bytes(bytes: &[u8]) -> Self {
-        let mut ret = Self::new();
-        let capacity_bytes = N * Self::WORD_SIZE;
-        let total_bytes = core::cmp::min(bytes.len(), capacity_bytes);
+    /// Const-compatible from_be_bytes implementation for slices
+    pub(crate) c0nst fn impl_from_be_bytes_slice<T: [c0nst] ConstMachineWord, const N: usize>(
+        bytes: &[u8],
+        word_size: usize,
+    ) -> [T; N] {
+        let mut ret: [T; N] = [T::zero(); N];
+        let capacity_bytes = N * word_size;
+        let total_bytes = if bytes.len() < capacity_bytes { bytes.len() } else { capacity_bytes };
 
         // For consistent truncation semantics with from_le_bytes, always take the
         // least significant bytes (rightmost bytes in big-endian representation)
@@ -139,19 +152,40 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
             0
         };
 
-        for (byte_index, _) in (0..total_bytes).enumerate() {
+        let mut byte_index = 0;
+        while byte_index < total_bytes {
             // Take bytes from the end of the input (least significant in BE)
             let be_byte_index = start_offset + total_bytes - 1 - byte_index;
-            let word_index = byte_index / Self::WORD_SIZE;
-            let byte_in_word = byte_index % Self::WORD_SIZE;
+            let word_index = byte_index / word_size;
+            let byte_in_word = byte_index % word_size;
 
-            let byte_value: T = bytes[be_byte_index].into();
+            let byte_value: T = T::from(bytes[be_byte_index]);
             let shifted_value = byte_value.shl(byte_in_word * 8);
-            ret.array[word_index] |= shifted_value;
+            ret[word_index] = ret[word_index].bitor(shifted_value);
+            byte_index += 1;
         }
         ret
     }
+}
 
+// Inherent from_bytes methods (not const - use ConstFromBytes trait for const access)
+impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
+    /// Create a little-endian integer value from its representation as a byte array in little endian.
+    pub fn from_le_bytes(bytes: &[u8]) -> Self {
+        Self {
+            array: impl_from_le_bytes_slice::<T, N>(bytes, Self::WORD_SIZE),
+        }
+    }
+
+    /// Create a big-endian integer value from its representation as a byte array in big endian.
+    pub fn from_be_bytes(bytes: &[u8]) -> Self {
+        Self {
+            array: impl_from_be_bytes_slice::<T, N>(bytes, Self::WORD_SIZE),
+        }
+    }
+}
+
+impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
     /// Converts the FixedUInt into a little-endian byte array.
     pub fn to_le_bytes<'a>(&self, output_buffer: &'a mut [u8]) -> Result<&'a [u8], bool> {
         let total_bytes = N * Self::WORD_SIZE;

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -17,8 +17,8 @@
 //! This module requires the `nightly` feature and uses `generic_const_exprs`
 //! to compute byte array sizes at compile time without unsafe code.
 
-use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::ConstToBytes;
+use super::{impl_from_be_bytes_slice, impl_from_le_bytes_slice, FixedUInt, MachineWord};
+use crate::const_numtraits::{ConstFromBytes, ConstToBytes};
 use crate::machineword::ConstMachineWord;
 use core::mem::size_of;
 
@@ -119,41 +119,27 @@ c0nst::c0nst! {
             result
         }
     }
-}
 
-// num_traits::ToBytes implementation - delegates to ConstToBytes
-impl<T: MachineWord, const N: usize> num_traits::ToBytes for FixedUInt<T, N>
-where
-    [(); byte_len::<T, N>()]:,
-{
-    type Bytes = ConstBytesHolder<{ byte_len::<T, N>() }>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstFromBytes for FixedUInt<T, N>
+    where
+        [(); byte_len::<T, N>()]:,
+    {
+        type Bytes = ConstBytesHolder<{ byte_len::<T, N>() }>;
 
-    fn to_be_bytes(&self) -> Self::Bytes {
-        ConstToBytes::to_be_bytes(self)
-    }
+        fn from_le_bytes(bytes: &Self::Bytes) -> Self {
+            let word_size = size_of::<T>();
+            Self { array: impl_from_le_bytes_slice::<T, N>(bytes.as_ref(), word_size) }
+        }
 
-    fn to_le_bytes(&self) -> Self::Bytes {
-        ConstToBytes::to_le_bytes(self)
-    }
-}
-
-// num_traits::FromBytes implementation - delegates to inherent FixedUInt methods
-impl<T: MachineWord, const N: usize> num_traits::FromBytes for FixedUInt<T, N>
-where
-    [(); byte_len::<T, N>()]:,
-{
-    type Bytes = ConstBytesHolder<{ byte_len::<T, N>() }>;
-
-    fn from_be_bytes(bytes: &Self::Bytes) -> Self {
-        // Use UFCS to call the inherent method, not this trait method
-        FixedUInt::<T, N>::from_be_bytes(&bytes.bytes)
-    }
-
-    fn from_le_bytes(bytes: &Self::Bytes) -> Self {
-        // Use UFCS to call the inherent method, not this trait method
-        FixedUInt::<T, N>::from_le_bytes(&bytes.bytes)
+        fn from_be_bytes(bytes: &Self::Bytes) -> Self {
+            let word_size = size_of::<T>();
+            Self { array: impl_from_be_bytes_slice::<T, N>(bytes.as_ref(), word_size) }
+        }
     }
 }
+
+// Note: num_traits::ToBytes/FromBytes impls are in to_from_bytes.rs
+// to avoid viral generic_const_exprs bounds on downstream users.
 
 #[cfg(test)]
 mod tests {
@@ -203,5 +189,67 @@ mod tests {
     #[test]
     fn test_const_context() {
         assert_eq!(CONST_LE_BYTES, [0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn test_const_from_le_bytes() {
+        let bytes = ConstBytesHolder {
+            bytes: [0x01, 0x02, 0x03, 0x04],
+        };
+        let val: FixedUInt<u8, 4> = ConstFromBytes::from_le_bytes(&bytes);
+        assert_eq!(val.array, [0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn test_const_from_be_bytes() {
+        let bytes = ConstBytesHolder {
+            bytes: [0x04, 0x03, 0x02, 0x01],
+        };
+        let val: FixedUInt<u8, 4> = ConstFromBytes::from_be_bytes(&bytes);
+        assert_eq!(val.array, [0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn test_const_from_bytes_u32_words() {
+        let bytes = ConstBytesHolder {
+            bytes: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08],
+        };
+        let le_val: FixedUInt<u32, 2> = ConstFromBytes::from_le_bytes(&bytes);
+        assert_eq!(le_val.array, [0x04030201, 0x08070605]);
+
+        let be_bytes = ConstBytesHolder {
+            bytes: [0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01],
+        };
+        let be_val: FixedUInt<u32, 2> = ConstFromBytes::from_be_bytes(&be_bytes);
+        assert_eq!(be_val.array, [0x04030201, 0x08070605]);
+    }
+
+    // Test that ConstFromBytes works in const context
+    const CONST_FROM_LE: FixedUInt<u8, 4> = {
+        let bytes = ConstBytesHolder {
+            bytes: [0x01, 0x02, 0x03, 0x04],
+        };
+        ConstFromBytes::from_le_bytes(&bytes)
+    };
+
+    #[test]
+    fn test_const_from_bytes_context() {
+        assert_eq!(CONST_FROM_LE.array, [0x01, 0x02, 0x03, 0x04]);
+    }
+
+    // Test roundtrip: to_bytes -> from_bytes
+    #[test]
+    fn test_const_bytes_roundtrip() {
+        let original: FixedUInt<u32, 2> = FixedUInt {
+            array: [0x12345678, 0xDEADBEEF],
+        };
+
+        let le_bytes = ConstToBytes::to_le_bytes(&original);
+        let from_le: FixedUInt<u32, 2> = ConstFromBytes::from_le_bytes(&le_bytes);
+        assert_eq!(from_le.array, original.array);
+
+        let be_bytes = ConstToBytes::to_be_bytes(&original);
+        let from_be: FixedUInt<u32, 2> = ConstFromBytes::from_be_bytes(&be_bytes);
+        assert_eq!(from_be.array, original.array);
     }
 }

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -127,13 +127,11 @@ c0nst::c0nst! {
         type Bytes = ConstBytesHolder<{ byte_len::<T, N>() }>;
 
         fn from_le_bytes(bytes: &Self::Bytes) -> Self {
-            let word_size = size_of::<T>();
-            Self { array: impl_from_le_bytes_slice::<T, N>(bytes.as_ref(), word_size) }
+            Self { array: impl_from_le_bytes_slice::<T, N>(bytes.as_ref()) }
         }
 
         fn from_be_bytes(bytes: &Self::Bytes) -> Self {
-            let word_size = size_of::<T>();
-            Self { array: impl_from_be_bytes_slice::<T, N>(bytes.as_ref(), word_size) }
+            Self { array: impl_from_be_bytes_slice::<T, N>(bytes.as_ref()) }
         }
     }
 }


### PR DESCRIPTION
- Separate ConstToBytes/ConstFromBytes (nightly, generic_const_exprs) from num_traits::ToBytes/FromBytes (stable, no viral bounds)
- Add const-compatible from_le_bytes/from_be_bytes helper functions
- Implement ConstFromBytes for FixedUInt with roundtrip tests

## Summary by Sourcery

Add const-compatible byte deserialization support and reorganize byte-conversion traits to separate nightly-only const features from stable num_traits implementations.

New Features:
- Introduce a ConstFromBytes trait for const-compatible byte deserialization and implement it for primitive integers and FixedUInt.

Bug Fixes:
- Avoid propagating generic_const_exprs bounds to downstream users by moving num_traits::ToBytes/FromBytes implementations into a separate, stable module.

Enhancements:
- Refactor FixedUInt byte-conversion logic into shared const-compatible helper functions reused by both const and non-const from_bytes methods.

Tests:
- Add tests validating ConstFromBytes behavior for FixedUInt across endiannesses, word sizes, const contexts, and roundtrips with ConstToBytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added const-friendly deserialization for unsigned integers from little- and big-endian byte representations.
  * Added byte-array constructors to FixedUInt for LE/BE input, usable in const contexts.
  * Enabled const-compatible From conversions from primitive integers into FixedUInt.

* **Tests**
  * Added tests verifying LE/BE deserialization, round-trip behavior, and const-context usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->