### PR TITLE
Add widening and carrying mul

### DIFF
--- a/src/patch_num_traits.rs
+++ b/src/patch_num_traits.rs
@@ -40,3 +40,77 @@ overflowing_shift_impl!(OverflowingShr, overflowing_shr, u8);
 overflowing_shift_impl!(OverflowingShr, overflowing_shr, u16);
 overflowing_shift_impl!(OverflowingShr, overflowing_shr, u32);
 overflowing_shift_impl!(OverflowingShr, overflowing_shr, u64);
+
+/// Widening multiplication for extended precision arithmetic.
+///
+/// Multiplies two values and returns the full double-width result as (low, high).
+/// This is the non-const version that delegates to [`ConstWideningMul`] implementations.
+///
+/// [`ConstWideningMul`]: crate::const_numtraits::ConstWideningMul
+pub trait WideningMul: Sized {
+    /// Calculates the complete product `self * rhs` without overflow.
+    ///
+    /// Returns `(low, high)` where the full result is `high * 2^BITS + low`.
+    fn widening_mul(self, rhs: Self) -> (Self, Self);
+}
+
+macro_rules! widening_mul_impl {
+    ($t:ty, $double:ty, $bits:expr) => {
+        impl WideningMul for $t {
+            #[inline]
+            fn widening_mul(self, rhs: Self) -> (Self, Self) {
+                let product = (self as $double) * (rhs as $double);
+                (product as $t, (product >> $bits) as $t)
+            }
+        }
+    };
+}
+
+widening_mul_impl!(u8, u16, 8);
+widening_mul_impl!(u16, u32, 16);
+widening_mul_impl!(u32, u64, 32);
+widening_mul_impl!(u64, u128, 64);
+
+/// Carrying multiplication for extended precision arithmetic.
+///
+/// Provides multiply-accumulate operations returning double-width results.
+/// This is the non-const version that delegates to [`ConstCarryingMul`] implementations.
+///
+/// [`ConstCarryingMul`]: crate::const_numtraits::ConstCarryingMul
+pub trait CarryingMul: Sized {
+    /// Calculates `self * rhs + carry`, returning `(low, high)`.
+    ///
+    /// The result fits in double-width (2 * BITS) since
+    /// `MAX * MAX + MAX < (MAX+1)^2 = 2^(2*BITS)`.
+    fn carrying_mul(self, rhs: Self, carry: Self) -> (Self, Self);
+
+    /// Calculates `self * rhs + addend + carry`, returning `(low, high)`.
+    ///
+    /// The result fits in double-width (2 * BITS) since
+    /// `MAX * MAX + MAX + MAX < (MAX+1)^2 = 2^(2*BITS)`.
+    fn carrying_mul_add(self, rhs: Self, addend: Self, carry: Self) -> (Self, Self);
+}
+
+macro_rules! carrying_mul_impl {
+    ($t:ty, $double:ty, $bits:expr) => {
+        impl CarryingMul for $t {
+            #[inline]
+            fn carrying_mul(self, rhs: Self, carry: Self) -> (Self, Self) {
+                let product = (self as $double) * (rhs as $double) + (carry as $double);
+                (product as $t, (product >> $bits) as $t)
+            }
+
+            #[inline]
+            fn carrying_mul_add(self, rhs: Self, addend: Self, carry: Self) -> (Self, Self) {
+                let product =
+                    (self as $double) * (rhs as $double) + (addend as $double) + (carry as $double);
+                (product as $t, (product >> $bits) as $t)
+            }
+        }
+    };
+}
+
+carrying_mul_impl!(u8, u16, 8);
+carrying_mul_impl!(u16, u32, 16);
+carrying_mul_impl!(u32, u64, 32);
+carrying_mul_impl!(u64, u128, 64);


### PR DESCRIPTION
## Summary by Sourcery

Add non-const widening and carrying multiplication support for primitive integers and FixedUInt, delegating to existing const implementations and validating behavior with new tests.

New Features:
- Introduce a WideningMul trait with implementations for u8, u16, u32, and u64 that return full double-width products.
- Introduce a CarryingMul trait with implementations for u8, u16, u32, and u64 that support multiply-with-carry and multiply-add-with-carry operations.
- Implement WideningMul and CarryingMul for FixedUInt types by delegating to the corresponding const traits.

Tests:
- Add tests verifying WideningMul for primitive integers and FixedUInt, including consistency with ConstWideningMul results.
- Add tests verifying CarryingMul and carrying_mul_add for primitive integers and FixedUInt, including consistency with ConstCarryingMul results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extended precision multiplication traits enabling widening multiplication operations for full product computation and carrying multiply-accumulate functions with carry propagation support. These capabilities are now available for fixed-width unsigned integer types, supporting advanced arithmetic operations with proper overflow handling and carry management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->