### PR TITLE
Make is_even/odd simpler

### DIFF
--- a/src/fixeduint/num_integer_impl.rs
+++ b/src/fixeduint/num_integer_impl.rs
@@ -1,6 +1,6 @@
 use super::{FixedUInt, MachineWord};
 
-use num_traits::{One, PrimInt, Zero};
+use num_traits::{PrimInt, Zero};
 
 // Most code here from num_integer crate, unsigned implementation
 
@@ -52,10 +52,11 @@ impl<T: MachineWord, const N: usize> num_integer::Integer for FixedUInt<T, N> {
         (*self) % other == Self::zero()
     }
     fn is_even(&self) -> bool {
-        (*self) & Self::one() == Self::zero()
+        // O(1): only check LSB of first word, not full-width AND + compare
+        self.array[0] & T::one() == T::zero()
     }
     fn is_odd(&self) -> bool {
-        !self.is_even()
+        self.array[0] & T::one() != T::zero()
     }
     fn div_rem(&self, other: &Self) -> (Self, Self) {
         self.div_rem(other)

--- a/src/fixeduint/num_integer_impl.rs
+++ b/src/fixeduint/num_integer_impl.rs
@@ -53,7 +53,7 @@ impl<T: MachineWord, const N: usize> num_integer::Integer for FixedUInt<T, N> {
     }
     fn is_even(&self) -> bool {
         // O(1): only check LSB of first word, not full-width AND + compare
-        self.array[0] & T::one() == T::zero()
+        N == 0 || self.array[0] & T::one() == T::zero()
     }
     fn is_odd(&self) -> bool {
         !self.is_even()

--- a/src/fixeduint/num_integer_impl.rs
+++ b/src/fixeduint/num_integer_impl.rs
@@ -56,7 +56,7 @@ impl<T: MachineWord, const N: usize> num_integer::Integer for FixedUInt<T, N> {
         self.array[0] & T::one() == T::zero()
     }
     fn is_odd(&self) -> bool {
-        self.array[0] & T::one() != T::zero()
+        !self.is_even()
     }
     fn div_rem(&self, other: &Self) -> (Self, Self) {
         self.div_rem(other)

--- a/tests/integer.rs
+++ b/tests/integer.rs
@@ -30,6 +30,10 @@ fn test_evenodd() {
     even_odd::<FixedUInt<u8, 1>>();
     even_odd::<FixedUInt<u8, 2>>();
     even_odd::<FixedUInt<u16, 1>>();
+
+    let zero = FixedUInt::<u8, 0>::from(0u8);
+    assert!(zero.is_even());
+    assert!(!zero.is_odd());
 }
 
 #[test]


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Optimize FixedUInt::is_even and FixedUInt::is_odd to inspect only the least-significant word bit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Parity checks (even/odd) optimized to use a constant-time, bit-level operation on the underlying integer representation, improving performance and predictability while preserving public behavior.
* **Tests**
  * Added coverage to verify parity for a zero-width integer case to ensure correct even/odd reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->