### PR TITLE
Add Output type to WideningMul/CarryingMul, add ref impls

### DIFF
--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -181,7 +181,7 @@ impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, c
     }
 }
 
-/// Ref-based widening multiplication — avoids copying large FixedUInt on stack.
+/// Ref-based widening multiplication — allows calling with references.
 impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, const N: usize>
     WideningMul for &FixedUInt<T, N>
 {
@@ -205,7 +205,7 @@ impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, c
     }
 }
 
-/// Ref-based carrying multiplication — avoids copying large FixedUInt on stack.
+/// Ref-based carrying multiplication — allows calling with references.
 impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, const N: usize>
     CarryingMul for &FixedUInt<T, N>
 {

--- a/src/patch_num_traits.rs
+++ b/src/patch_num_traits.rs
@@ -67,7 +67,7 @@ macro_rules! widening_mul_impl {
         impl WideningMul for &$t {
             type Output = $t;
             fn widening_mul(self, rhs: Self) -> ($t, $t) {
-                WideningMul::widening_mul(*self, *rhs)
+                <$t as WideningMul>::widening_mul(*self, *rhs)
             }
         }
     };
@@ -118,10 +118,10 @@ macro_rules! carrying_mul_impl {
         impl CarryingMul for &$t {
             type Output = $t;
             fn carrying_mul(self, rhs: Self, carry: Self) -> ($t, $t) {
-                CarryingMul::carrying_mul(*self, *rhs, *carry)
+                <$t as CarryingMul>::carrying_mul(*self, *rhs, *carry)
             }
             fn carrying_mul_add(self, rhs: Self, addend: Self, carry: Self) -> ($t, $t) {
-                CarryingMul::carrying_mul_add(*self, *rhs, *addend, *carry)
+                <$t as CarryingMul>::carrying_mul_add(*self, *rhs, *addend, *carry)
             }
         }
     };


### PR DESCRIPTION
## Summary by Sourcery

Add associated Output types to the WideningMul and CarryingMul traits and their implementations, and provide reference-based implementations to avoid copying large integers.

New Features:
- Introduce associated Output type for WideningMul and CarryingMul traits to decouple input and result types.
- Add reference-based WideningMul and CarryingMul implementations for primitive integers and FixedUInt to support operations without value copying.

Tests:
- Add tests verifying that reference-based WideningMul and CarryingMul behavior matches value-based implementations for primitives and FixedUInt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiplication traits updated to support reference operands and an explicit associated output type, enabling more flexible and consistent multiply/carry operations across value and reference usage.

* **Tests**
  * Added tests ensuring reference-based and value-based multiplication (including carrying and add-with-carry variants) produce identical results for primitives and fixed-size numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->