### PR TITLE
Fixup for mulacc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-bigint"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2018"

--- a/src/mul_acc_ops.rs
+++ b/src/mul_acc_ops.rs
@@ -11,12 +11,9 @@
 /// A higher-level crate (e.g. modmath) orchestrates the outer loop of
 /// a Montgomery multiplication variant using only these methods, without
 /// knowledge of the internal representation.
-pub trait MulAccOps: Sized + Copy + Default + crate::const_numtraits::ConstZero {
+pub trait MulAccOps: Sized + Copy + Default {
     /// The machine-word type used as a scalar in row operations.
-    type Word: Copy
-        + crate::const_numtraits::ConstZero
-        + crate::const_numtraits::ConstOne
-        + PartialOrd;
+    type Word: Copy + PartialOrd;
 
     /// Number of words in this type.
     fn word_count() -> usize;


### PR DESCRIPTION
## Summary by Sourcery

Relax trait bounds for multiplication/accumulation operations and bump the crate version.

Enhancements:
- Remove ConstZero and ConstOne constraints from MulAccOps and its associated Word type to loosen implementation requirements.

Build:
- Bump crate version from 0.2.4 to 0.2.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v0.2.5

* **Chores**
  * Updated package version to 0.2.5

* **Refactor**
  * Simplified type constraints on numeric operations to improve flexibility and reduce unnecessary coupling. Core interfaces now require fewer trait bounds while maintaining essential numeric semantics and ordering capabilities. This enables broader compatibility with custom numeric type implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->