### PR TITLE
Implement constant-time subset

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,18 +3,6 @@
 We'd love to accept your patches and contributions to this project. There are
 just a few small guidelines you need to follow.
 
-## Contributor License Agreement
-
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
-
 ## Code Reviews
 
 All submissions, including submissions by project members, require review. We

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ default-features = false
 version = "2.6"
 default-features = false
 
+[dev-dependencies.static_assertions]
+version = "1.1"
+
 [profile.dev]
 opt-level = 0
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixed-bigint"
-version = "0.2.5"
+version = "0.3.0"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2018"
@@ -31,6 +31,10 @@ version = "0.2"
 [dependencies.zeroize]
 version = "1.8.1"
 optional = true
+default-features = false
+
+[dependencies.subtle]
+version = "2.6"
 default-features = false
 
 [profile.dev]

--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 [![minimum rustc 1.73](https://img.shields.io/badge/rustc-1.73+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/kaidokert/fixed-bigint-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/kaidokert/fixed-bigint-rs/actions)
 [![Coverage Status](https://coveralls.io/repos/github/kaidokert/fixed-bigint-rs/badge.svg?branch=main)](https://coveralls.io/github/kaidokert/fixed-bigint-rs?branch=main)
+![Crates.io MSRV](https://img.shields.io/crates/msrv/fixed-bigint)
 
 Unsigned BigInt implementation, backed by a fixed-size array.
-
-***Important***: Requires at least Rust 1.73 stable
 
 `FixedUInt<u8,4>`,`FixedUInt<u16,2>` or `FixedUInt<u32,1>` all create a 32-bit unsigned integer, that behaves mostly the same as builtin `u32`.
 `FixedUInt<u32, 64>` creates a 2048-bit value, that uses native 32-bit math. If running on 8-bit CPU, `FixedUInt<u8, 2048>` would work the same, just very much slower.
@@ -22,6 +21,10 @@ In addition to basic arithmetic, two main traits are implemented: [num_traits::P
 ## Const Support
 
 Most arithmetic operations are const-compatible via the [c0nst](https://crates.io/crates/c0nst) crate. On nightly Rust with `--features nightly`, operations can be used in `const` contexts. On stable Rust, the same code compiles but without const evaluation.
+
+## Constant time
+
+Constant-time execution is implemented for a subset of core operations. Ct mode is selected by a type parameter, allowing individual calling contexts to use either mode. This is purely experimental, not audited or throughly verified.
 
 _TODO list_:
  * Implement experimental `unchecked_math` operands, unchecked_mul, unchecked_div etc.
@@ -39,9 +42,3 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.
 ## License
 
 Apache 2.0; see [`LICENSE`](LICENSE) for details.
-
-## Disclaimer
-
-This project is not an official Google project. It is not supported by
-Google and Google specifically disclaims all warranties as to its quality,
-merchantability, or fitness for a particular purpose.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Most arithmetic operations are const-compatible via the [c0nst](https://crates.i
 
 ## Constant time
 
-Constant-time execution is implemented for a subset of core operations. Ct mode is selected by a type parameter, allowing individual calling contexts to use either mode. This is purely experimental, not audited or throughly verified.
+Constant-time execution is implemented for a subset of core operations. Ct mode is selected by a type parameter, allowing individual calling contexts to use either mode. This is purely experimental, not audited or thoroughly verified.
 
 _TODO list_:
  * Implement experimental `unchecked_math` operands, unchecked_mul, unchecked_div etc.

--- a/src/const_numtraits.rs
+++ b/src/const_numtraits.rs
@@ -1340,7 +1340,8 @@ macro_rules! const_widening_mul_impl {
         c0nst::c0nst! {
             impl c0nst ConstWideningMul for $t {
                 fn widening_mul(self, rhs: Self) -> (Self, Self) {
-                    <$t>::widening_mul(self, rhs)
+                    let product: $double = <$t>::widening_mul(self, rhs);
+                    (product as $t, (product >> $bits) as $t)
                 }
             }
         }

--- a/src/const_numtraits.rs
+++ b/src/const_numtraits.rs
@@ -1272,7 +1272,9 @@ macro_rules! const_carrying_add_impl {
                 fn carrying_add(self, rhs: Self, carry: bool) -> (Self, bool) {
                     let (sum1, c1) = self.overflowing_add(rhs);
                     let (sum2, c2) = sum1.overflowing_add(carry as $t);
-                    (sum2, c1 || c2)
+                    // Non-short-circuiting `|` to keep the body branch-free at
+                    // the source level (CT discipline).
+                    (sum2, c1 | c2)
                 }
             }
         }
@@ -1300,7 +1302,7 @@ macro_rules! const_borrowing_sub_impl {
                 fn borrowing_sub(self, rhs: Self, borrow: bool) -> (Self, bool) {
                     let (diff1, b1) = self.overflowing_sub(rhs);
                     let (diff2, b2) = diff1.overflowing_sub(borrow as $t);
-                    (diff2, b1 || b2)
+                    (diff2, b1 | b2)
                 }
             }
         }

--- a/src/const_numtraits.rs
+++ b/src/const_numtraits.rs
@@ -461,33 +461,20 @@ c0nst::c0nst! {
     /// representation. This is correct for all fixed-width unsigned integers
     /// (primitives and `FixedUInt`), but implementors of custom types should
     /// verify these assumptions hold or override the defaults.
-    pub c0nst trait ConstPrimInt:
-        [c0nst] core::ops::Add<Output = Self> +
-        [c0nst] core::ops::Sub<Output = Self> +
-        [c0nst] core::ops::Mul<Output = Self> +
-        [c0nst] core::ops::Div<Output = Self> +
+    pub c0nst trait ConstBitPrimInt:
         [c0nst] core::ops::BitAnd<Output = Self> +
         [c0nst] core::ops::BitOr<Output = Self> +
         [c0nst] core::ops::BitXor<Output = Self> +
         [c0nst] core::ops::Not<Output = Self> +
         [c0nst] core::ops::Shl<usize, Output = Self> +
         [c0nst] core::ops::Shr<usize, Output = Self> +
-        [c0nst] core::ops::AddAssign +
-        [c0nst] core::ops::SubAssign +
         [c0nst] core::ops::BitAndAssign +
         [c0nst] core::ops::BitOrAssign +
         [c0nst] core::ops::BitXorAssign +
         [c0nst] core::ops::ShlAssign<usize> +
         [c0nst] core::ops::ShrAssign<usize> +
-        [c0nst] core::cmp::PartialEq +
-        [c0nst] core::cmp::Eq +
-        [c0nst] core::cmp::PartialOrd +
-        [c0nst] core::cmp::Ord +
-        [c0nst] core::convert::From<u8> +
-        [c0nst] core::default::Default +
         [c0nst] ConstOne +
         [c0nst] ConstZero +
-        [c0nst] ConstBounded +
         Sized + Copy {
 
             fn swap_bytes(self) -> Self;
@@ -495,8 +482,6 @@ c0nst::c0nst! {
             fn trailing_zeros(self) -> u32;
             fn count_zeros(self) -> u32;
             fn count_ones(self) -> u32;
-
-            // PR 1: Shifts, rotations, and trivial derivations
             fn leading_ones(self) -> u32 {
                 (!self).leading_zeros()
             }
@@ -513,13 +498,36 @@ c0nst::c0nst! {
             fn signed_shr(self, n: u32) -> Self {
                 self.unsigned_shr(n)
             }
-
-            // PR 2: Endianness conversions, reverse_bits, pow
             fn reverse_bits(self) -> Self;
             fn from_be(x: Self) -> Self;
             fn from_le(x: Self) -> Self;
             fn to_be(self) -> Self;
             fn to_le(self) -> Self;
+    }
+
+    /// Base arithmetic traits for constant primitive integers.
+    ///
+    /// Extends [`ConstBitPrimInt`] with the arithmetic + ordering operations
+    /// that aren't generally available on CT-restricted types. Implementors
+    /// like `FixedUInt<_, _, Ct>` will get `ConstBitPrimInt` but not the
+    /// full `ConstPrimInt` because they don't expose `Div` (long division
+    /// is the leaky algorithmic core for unsigned big integers).
+    pub c0nst trait ConstPrimInt:
+        [c0nst] ConstBitPrimInt +
+        [c0nst] core::ops::Add<Output = Self> +
+        [c0nst] core::ops::Sub<Output = Self> +
+        [c0nst] core::ops::Mul<Output = Self> +
+        [c0nst] core::ops::Div<Output = Self> +
+        [c0nst] core::ops::AddAssign +
+        [c0nst] core::ops::SubAssign +
+        [c0nst] core::cmp::PartialEq +
+        [c0nst] core::cmp::Eq +
+        [c0nst] core::cmp::PartialOrd +
+        [c0nst] core::cmp::Ord +
+        [c0nst] core::convert::From<u8> +
+        [c0nst] core::default::Default +
+        [c0nst] ConstBounded {
+
             fn pow(self, exp: u32) -> Self;
     }
 }
@@ -559,10 +567,10 @@ macro_rules! const_bounded_impl {
     };
 }
 
-macro_rules! const_prim_int_impl {
+macro_rules! const_bit_prim_int_impl {
     ($t:ty) => {
         c0nst::c0nst! {
-            impl c0nst ConstPrimInt for $t {
+            impl c0nst ConstBitPrimInt for $t {
                 fn leading_zeros(self) -> u32 { self.leading_zeros() }
                 fn trailing_zeros(self) -> u32 { self.trailing_zeros() }
                 fn count_zeros(self) -> u32 { self.count_zeros() }
@@ -577,6 +585,15 @@ macro_rules! const_prim_int_impl {
                 fn from_le(x: Self) -> Self { <$t>::from_le(x) }
                 fn to_be(self) -> Self { self.to_be() }
                 fn to_le(self) -> Self { self.to_le() }
+            }
+        }
+    };
+}
+
+macro_rules! const_prim_int_impl {
+    ($t:ty) => {
+        c0nst::c0nst! {
+            impl c0nst ConstPrimInt for $t {
                 fn pow(self, exp: u32) -> Self { self.pow(exp) }
             }
         }
@@ -1465,6 +1482,12 @@ const_unbounded_shift_impl!(u16, 16);
 const_unbounded_shift_impl!(u32, 32);
 const_unbounded_shift_impl!(u64, 64);
 const_unbounded_shift_impl!(u128, 128);
+
+const_bit_prim_int_impl!(u8);
+const_bit_prim_int_impl!(u16);
+const_bit_prim_int_impl!(u32);
+const_bit_prim_int_impl!(u64);
+const_bit_prim_int_impl!(u128);
 
 const_prim_int_impl!(u8);
 const_prim_int_impl!(u16);

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -18,9 +18,9 @@ use core::convert::TryFrom;
 use core::fmt::Write;
 
 pub use crate::const_numtraits::{
-    ConstAbsDiff, ConstBorrowingSub, ConstBounded, ConstCarryingAdd, ConstCarryingMul,
-    ConstCheckedPow, ConstDivCeil, ConstIlog, ConstIsqrt, ConstMultiple, ConstOne, ConstPowerOfTwo,
-    ConstPrimInt, ConstWideningMul, ConstZero,
+    ConstAbsDiff, ConstBitPrimInt, ConstBorrowingSub, ConstBounded, ConstCarryingAdd,
+    ConstCarryingMul, ConstCheckedPow, ConstDivCeil, ConstIlog, ConstIsqrt, ConstMultiple,
+    ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstWideningMul, ConstZero,
 };
 use crate::machineword::{ConstMachineWord, MachineWord};
 
@@ -55,44 +55,274 @@ mod const_to_from_bytes;
 #[cfg(any(feature = "nightly", feature = "use-unsafe"))]
 mod to_from_bytes;
 
+use crate::personality::{Ct, Nct, Personality, PersonalityMarker, PersonalityTag};
 #[cfg(feature = "zeroize")]
 use zeroize::DefaultIsZeroes;
 
-/// Fixed-size unsigned integer, represented by array of N words of builtin unsigned type T
-#[derive(Debug, Copy)]
-pub struct FixedUInt<T, const N: usize>
+/// Fixed-size unsigned integer, represented by array of N words of builtin unsigned type T.
+///
+/// The optional `P: Personality` parameter selects which implementations of
+/// operation primitives are used at each call site. Defaults to [`Nct`]
+/// (non-constant-time). Use `FixedUInt<T, N, Ct>` for
+/// values that must be handled in constant time. See [`crate::personality`].
+///
+/// [`Nct`]: crate::personality::Nct
+/// [`Ct`]: crate::personality::Ct
+#[derive(Copy)]
+pub struct FixedUInt<T, const N: usize, P: Personality = Nct>
 where
     T: MachineWord,
 {
     /// Little-endian word array
     pub(super) array: [T; N],
+    /// Personality marker (zero-size).
+    pub(super) _p: PersonalityMarker<P>,
+}
+
+// Debug is implemented manually so the Ct variant can redact its value.
+// Nct keeps the conventional "FixedUInt { array, _p }" format; Ct prints
+// `FixedUInt<…>` (placeholder) to keep limb contents out of panic
+// messages, dbg! output, and logs.
+impl<T: MachineWord + core::fmt::Debug, const N: usize> core::fmt::Debug for FixedUInt<T, N, Nct> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FixedUInt")
+            .field("array", &self.array)
+            .finish()
+    }
+}
+
+impl<T: MachineWord, const N: usize> core::fmt::Debug for FixedUInt<T, N, Ct> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("FixedUInt<…>")
+    }
 }
 
 #[cfg(feature = "zeroize")]
-impl<T: MachineWord, const N: usize> DefaultIsZeroes for FixedUInt<T, N> {}
+impl<T: MachineWord, const N: usize, P: Personality> DefaultIsZeroes for FixedUInt<T, N, P> {}
 
-impl<T, const N: usize> From<[T; N]> for FixedUInt<T, N>
+impl<T, const N: usize, P: Personality> From<[T; N]> for FixedUInt<T, N, P>
 where
     T: MachineWord,
 {
     fn from(array: [T; N]) -> Self {
-        Self { array }
+        Self {
+            array,
+            _p: core::marker::PhantomData,
+        }
     }
+}
+
+// Internal constructor for sites that need to build a FixedUInt from a raw
+// limb array.
+impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
+    pub(crate) const fn from_array(array: [T; N]) -> Self {
+        Self {
+            array,
+            _p: core::marker::PhantomData,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Personality conversions.
+// ---------------------------------------------------------------------------
+
+/// Lossless conversion from `Nct` to `Ct`. Tightens the invariant
+/// (declares that the value will be handled under the CT threat model going
+/// forward). Bit representation is identical; this is a free reinterpretation.
+impl<T: MachineWord, const N: usize> From<FixedUInt<T, N, Nct>> for FixedUInt<T, N, Ct> {
+    fn from(v: FixedUInt<T, N, Nct>) -> Self {
+        FixedUInt::from_array(v.array)
+    }
+}
+
+impl<T: MachineWord, const N: usize> FixedUInt<T, N, Ct> {
+    /// Drop the CT guarantee and convert to the `Nct` variant.
+    ///
+    /// **This is an explicit downgrade.** The caller is asserting that the
+    /// value is no longer secret — typically because the CT-handling phase
+    /// has ended (e.g. a finalized signature, a published key, a post-
+    /// reduction modular value about to be serialized).
+    pub const fn forget_ct(self) -> FixedUInt<T, N, Nct> {
+        FixedUInt::from_array(self.array)
+    }
+}
+
+impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize> FixedUInt<T, N, Ct> {
+    /// CT-friendly counterpart to `num_traits::CheckedAdd::checked_add`.
+    /// Returns `CtOption::new(res, Choice::from(!overflow))` — the result is
+    /// always computed (always-iterate via overflowing_add), and the
+    /// validity Choice carries the overflow flag without exposing it as
+    /// a control-flow signal.
+    pub fn ct_checked_add(&self, other: &Self) -> subtle::CtOption<Self> {
+        let (res, overflow) =
+            <Self as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, other);
+        let valid = subtle::Choice::from((!overflow) as u8);
+        subtle::CtOption::new(res, valid)
+    }
+
+    /// CT-friendly counterpart to `num_traits::CheckedSub::checked_sub`.
+    pub fn ct_checked_sub(&self, other: &Self) -> subtle::CtOption<Self> {
+        let (res, overflow) =
+            <Self as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, other);
+        let valid = subtle::Choice::from((!overflow) as u8);
+        subtle::CtOption::new(res, valid)
+    }
+
+    /// CT-friendly counterpart to `num_traits::CheckedMul::checked_mul`.
+    pub fn ct_checked_mul(&self, other: &Self) -> subtle::CtOption<Self> {
+        let (res, overflow) =
+            <Self as crate::const_numtraits::ConstOverflowingMul>::overflowing_mul(self, other);
+        let valid = subtle::Choice::from((!overflow) as u8);
+        subtle::CtOption::new(res, valid)
+    }
+
+    /// CT-friendly counterpart to `ConstCheckedShl::checked_shl`.
+    pub fn ct_checked_shl(&self, bits: u32) -> subtle::CtOption<Self> {
+        let (res, overflow) =
+            <Self as crate::const_numtraits::ConstOverflowingShl>::overflowing_shl(self, bits);
+        let valid = subtle::Choice::from((!overflow) as u8);
+        subtle::CtOption::new(res, valid)
+    }
+
+    /// CT-friendly counterpart to `ConstCheckedShr::checked_shr`.
+    pub fn ct_checked_shr(&self, bits: u32) -> subtle::CtOption<Self> {
+        let (res, overflow) =
+            <Self as crate::const_numtraits::ConstOverflowingShr>::overflowing_shr(self, bits);
+        let valid = subtle::Choice::from((!overflow) as u8);
+        subtle::CtOption::new(res, valid)
+    }
+
+    /// CT-friendly counterpart to `ConstPowerOfTwo::checked_next_power_of_two`.
+    pub fn ct_checked_next_power_of_two(self) -> subtle::CtOption<Self>
+    where
+        T: subtle::ConstantTimeEq,
+    {
+        let one = <Self as num_traits::One>::one();
+        let m_one = <Self as crate::const_numtraits::ConstWrappingSub>::wrapping_sub(&self, &one);
+        let leading = <Self as crate::const_numtraits::ConstBitPrimInt>::leading_zeros(m_one);
+        let bits = Self::BIT_SIZE as u32 - leading;
+        let shifted = one << (bits as usize);
+        let is_zero_choice =
+            <Self as subtle::ConstantTimeEq>::ct_eq(&self, &<Self as num_traits::Zero>::zero());
+        // result = is_zero ? 1 : shifted
+        let result = <Self as subtle::ConditionallySelectable>::conditional_select(
+            &shifted,
+            &one,
+            is_zero_choice,
+        );
+        // overflow iff bits >= BIT_SIZE; when input == 0 we treat as valid
+        // (the answer is 1).
+        let overflow = (bits >= Self::BIT_SIZE as u32) as u8;
+        let valid_otherwise = subtle::Choice::from(1u8 ^ overflow);
+        let valid = <subtle::Choice as subtle::ConditionallySelectable>::conditional_select(
+            &valid_otherwise,
+            &subtle::Choice::from(1u8),
+            is_zero_choice,
+        );
+        subtle::CtOption::new(result, valid)
+    }
+
+    pub fn ct_checked_pow(self, exp: u32) -> subtle::CtOption<Self>
+    where
+        T: subtle::ConstantTimeEq + subtle::ConstantTimeGreater,
+        for<'a> &'a Self: core::ops::Mul<&'a Self, Output = Self>,
+    {
+        use num_traits::ops::overflowing::OverflowingMul;
+        let mut result = <Self as num_traits::One>::one();
+        let mut base = self;
+        let mut e = exp;
+        let mut any_overflow: u8 = 0;
+        for _ in 0..u32::BITS {
+            let bit = (e & 1) as u8;
+            let (candidate, mul_ov) = OverflowingMul::overflowing_mul(&result, &base);
+            // Multiply overflow matters iff bit_k is set.
+            any_overflow |= (mul_ov as u8) & bit;
+            // Per-limb CT-select of result vs candidate.
+            let bit_t = <T as core::convert::From<u8>>::from(bit);
+            let mask = bit_t * <T as crate::const_numtraits::ConstBounded>::max_value();
+            for i in 0..N {
+                let diff = result.array[i] ^ candidate.array[i];
+                result.array[i] ^= mask & diff;
+            }
+            e >>= 1;
+            let (new_base, base_ov) = OverflowingMul::overflowing_mul(&base, &base);
+            // Square overflow matters iff there are remaining set bits in e.
+            let any_remaining: u8 = (e != 0) as u8;
+            any_overflow |= (base_ov as u8) & any_remaining;
+            base = new_base;
+        }
+        let valid = subtle::Choice::from(1u8 ^ any_overflow);
+        subtle::CtOption::new(result, valid)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// subtle integration — Ct variant only.
+// ---------------------------------------------------------------------------
+
+impl<T: MachineWord + subtle::ConstantTimeEq, const N: usize> subtle::ConstantTimeEq
+    for FixedUInt<T, N, Ct>
+{
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        <[T] as subtle::ConstantTimeEq>::ct_eq(self.array.as_slice(), other.array.as_slice())
+    }
+}
+
+impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize>
+    subtle::ConditionallySelectable for FixedUInt<T, N, Ct>
+{
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        let mut array = a.array;
+        let mut i = 0;
+        while i < N {
+            array[i] = T::conditional_select(&a.array[i], &b.array[i], choice);
+            i += 1;
+        }
+        FixedUInt::from_array(array)
+    }
+}
+
+// `Ord::cmp` / `PartialOrd::partial_cmp` dispatch on `P::TAG`: the `Ct` arm
+// runs `const_cmp_ct`, a full-width scan with no short-circuit. The returned
+// `Ordering` is still a CT leak if a caller branches on it, so secret-data
+// callers should prefer `ConstantTimeGreater`/`ConstantTimeLess` below, which
+// produce a `Choice` that pairs with `ConditionallySelectable` for branch-free
+// Montgomery conditional-subtract.
+impl<T: MachineWord + subtle::ConstantTimeEq + subtle::ConstantTimeGreater, const N: usize>
+    subtle::ConstantTimeGreater for FixedUInt<T, N, Ct>
+{
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        let mut gt = subtle::Choice::from(0u8);
+        let mut undecided = subtle::Choice::from(1u8);
+        let mut i = N;
+        while i > 0 {
+            i -= 1;
+            let gt_here = self.array[i].ct_gt(&other.array[i]);
+            let eq_here = self.array[i].ct_eq(&other.array[i]);
+            gt |= undecided & gt_here;
+            undecided &= eq_here;
+        }
+        gt
+    }
+}
+
+impl<T: MachineWord + subtle::ConstantTimeEq + subtle::ConstantTimeGreater, const N: usize>
+    subtle::ConstantTimeLess for FixedUInt<T, N, Ct>
+{
 }
 
 const LONGEST_WORD_IN_BITS: usize = 128;
 
-impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
     const WORD_SIZE: usize = core::mem::size_of::<T>();
     const WORD_BITS: usize = Self::WORD_SIZE * 8;
     const BYTE_SIZE: usize = Self::WORD_SIZE * N;
     const BIT_SIZE: usize = Self::BYTE_SIZE * 8;
 
     /// Creates and zero-initializes a FixedUInt.
-    pub fn new() -> FixedUInt<T, N> {
-        FixedUInt {
-            array: [T::zero(); N],
-        }
+    pub fn new() -> FixedUInt<T, N, P> {
+        FixedUInt::from_array([T::zero(); N])
     }
 
     /// Returns the underlying array.
@@ -102,13 +332,13 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
 
     /// Returns number of used bits.
     pub fn bit_length(&self) -> u32 {
-        Self::BIT_SIZE as u32 - ConstPrimInt::leading_zeros(*self)
+        Self::BIT_SIZE as u32 - ConstBitPrimInt::leading_zeros(*self)
     }
 
     /// Performs a division, returning both the quotient and remainder in a tuple.
     pub fn div_rem(&self, divisor: &Self) -> (Self, Self) {
         let (quotient, remainder) = const_div_rem(&self.array, &divisor.array);
-        (Self { array: quotient }, Self { array: remainder })
+        (Self::from_array(quotient), Self::from_array(remainder))
     }
 }
 
@@ -172,23 +402,19 @@ c0nst::c0nst! {
 }
 
 // Inherent from_bytes methods (not const - use ConstFromBytes trait for const access)
-impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
     /// Create a little-endian integer value from its representation as a byte array in little endian.
     pub fn from_le_bytes(bytes: &[u8]) -> Self {
-        Self {
-            array: impl_from_le_bytes_slice::<T, N>(bytes),
-        }
+        Self::from_array(impl_from_le_bytes_slice::<T, N>(bytes))
     }
 
     /// Create a big-endian integer value from its representation as a byte array in big endian.
     pub fn from_be_bytes(bytes: &[u8]) -> Self {
-        Self {
-            array: impl_from_be_bytes_slice::<T, N>(bytes),
-        }
+        Self::from_array(impl_from_be_bytes_slice::<T, N>(bytes))
     }
 }
 
-impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
     /// Converts the FixedUInt into a little-endian byte array.
     pub fn to_le_bytes<'a>(&self, output_buffer: &'a mut [u8]) -> Result<&'a [u8], bool> {
         let total_bytes = N * Self::WORD_SIZE;
@@ -332,7 +558,7 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N> {
         let mut array = [T::zero(); N2];
         let min_size = N.min(N2);
         array[..min_size].copy_from_slice(&self.array[..min_size]);
-        FixedUInt { array }
+        FixedUInt::from_array(array)
     }
 
     fn hex_fmt(
@@ -428,8 +654,8 @@ c0nst::c0nst! {
 
 c0nst::c0nst! {
     /// Const-compatible left shift implementation
-    pub(crate) c0nst fn const_shl_impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-        target: &mut FixedUInt<T, N>,
+    pub(crate) c0nst fn const_shl_impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+        target: &mut FixedUInt<T, N, P>,
         bits: usize,
     ) {
         if N == 0 {
@@ -476,8 +702,8 @@ c0nst::c0nst! {
     }
 
     /// Const-compatible right shift implementation
-    pub(crate) c0nst fn const_shr_impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-        target: &mut FixedUInt<T, N>,
+    pub(crate) c0nst fn const_shr_impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+        target: &mut FixedUInt<T, N, P>,
         bits: usize,
     ) {
         if N == 0 {
@@ -524,6 +750,83 @@ c0nst::c0nst! {
                 i += 1;
             }
             target.array[last_index] >>= nbits;
+        }
+    }
+
+    /// CT variant of `const_shl_impl`: barrel shifter. Iterates every
+    /// bit position of `bits` from 0 to `usize::BITS - 1`. At each
+    /// layer k, computes `target << 2^k` (via `const_shl_impl` with a
+    /// publicly-known power-of-two amount — non-CT internally but the
+    /// amount is *not* secret) and CT-selects per-limb between the
+    /// shifted and unshifted forms based on bit k of `bits`. Runtime
+    /// is O(N * usize::BITS), independent of the secret shift amount.
+    /// Used by the `Ct`-personality arm of `Shl<usize>` / `Shl<u32>`.
+    pub(crate) c0nst fn const_shl_ct<
+        T: [c0nst] ConstMachineWord + MachineWord,
+        const N: usize,
+        P: Personality,
+    >(
+        target: &mut FixedUInt<T, N, P>,
+        bits: usize,
+    ) {
+        if N == 0 {
+            return;
+        }
+        let layers = core::mem::size_of::<usize>() * 8;
+        let mut k = 0;
+        while k < layers {
+            let amount = 1usize << k;
+            // Build the "shifted by 2^k" candidate without mutating target.
+            let mut shifted = *target;
+            const_shl_impl(&mut shifted, amount);
+            // Spread bit k of `bits` to a full-T mask: 0 if cleared, T::MAX if set.
+            let bit_k = ((bits >> k) & 1) as u8;
+            let bit_k_t = <T as core::convert::From<u8>>::from(bit_k);
+            let mask = <T as core::ops::Mul>::mul(bit_k_t, <T as ConstBounded>::max_value());
+            // CT-select per limb: target[i] ^= mask & (target[i] ^ shifted[i])
+            let mut i = 0;
+            while i < N {
+                let diff =
+                    <T as core::ops::BitXor>::bitxor(target.array[i], shifted.array[i]);
+                let masked = <T as core::ops::BitAnd>::bitand(mask, diff);
+                target.array[i] = <T as core::ops::BitXor>::bitxor(target.array[i], masked);
+                i += 1;
+            }
+            k += 1;
+        }
+    }
+
+    /// CT variant of `const_shr_impl`: barrel shifter, mirror of
+    /// `const_shl_ct`. See that helper for the design rationale.
+    pub(crate) c0nst fn const_shr_ct<
+        T: [c0nst] ConstMachineWord + MachineWord,
+        const N: usize,
+        P: Personality,
+    >(
+        target: &mut FixedUInt<T, N, P>,
+        bits: usize,
+    ) {
+        if N == 0 {
+            return;
+        }
+        let layers = core::mem::size_of::<usize>() * 8;
+        let mut k = 0;
+        while k < layers {
+            let amount = 1usize << k;
+            let mut shifted = *target;
+            const_shr_impl(&mut shifted, amount);
+            let bit_k = ((bits >> k) & 1) as u8;
+            let bit_k_t = <T as core::convert::From<u8>>::from(bit_k);
+            let mask = <T as core::ops::Mul>::mul(bit_k_t, <T as ConstBounded>::max_value());
+            let mut i = 0;
+            while i < N {
+                let diff =
+                    <T as core::ops::BitXor>::bitxor(target.array[i], shifted.array[i]);
+                let masked = <T as core::ops::BitAnd>::bitand(mask, diff);
+                target.array[i] = <T as core::ops::BitXor>::bitxor(target.array[i], masked);
+                i += 1;
+            }
+            k += 1;
         }
     }
 
@@ -602,12 +905,39 @@ c0nst::c0nst! {
         while index > 0 {
             index -= 1;
             let v = array[index];
-            ret += <T as ConstPrimInt>::leading_zeros(v);
+            ret += <T as ConstBitPrimInt>::leading_zeros(v);
             if !<T as ConstZero>::is_zero(&v) {
                 break;
             }
         }
         ret
+    }
+
+    /// CT variant of `const_leading_zeros`: scans every limb without
+    /// short-circuiting. A bitmask tracks whether we're still in the
+    /// leading-zero region; once a non-zero limb is seen, subsequent
+    /// limbs contribute 0 to the total. Used by the `Ct`-personality
+    /// arm of `ConstBitPrimInt::leading_zeros`. Branchless apart from a
+    /// `bool -> u32` cast that rustc compiles to a setne.
+    pub(crate) c0nst fn const_leading_zeros_ct<T: [c0nst] ConstMachineWord, const N: usize>(
+        array: &[T; N],
+    ) -> u32 {
+        let mut total: u32 = 0;
+        // 0 while still in leading-zero region; u32::MAX once a non-zero limb is seen.
+        let mut decided: u32 = 0;
+        let mut index = N;
+        while index > 0 {
+            index -= 1;
+            let v = array[index];
+            let v_lz = <T as ConstBitPrimInt>::leading_zeros(v);
+            // Add this limb's lz contribution iff we haven't decided yet.
+            total += (!decided) & v_lz;
+            // Lock the decision the moment we see a non-zero limb.
+            let v_nz_bit = (!<T as ConstZero>::is_zero(&v)) as u32;
+            let v_nz_mask = v_nz_bit.wrapping_neg();
+            decided |= v_nz_mask;
+        }
+        total
     }
 
     /// Count trailing zeros in a const-compatible way
@@ -618,13 +948,36 @@ c0nst::c0nst! {
         let mut index = 0;
         while index < N {
             let v = array[index];
-            ret += <T as ConstPrimInt>::trailing_zeros(v);
+            ret += <T as ConstBitPrimInt>::trailing_zeros(v);
             if !<T as ConstZero>::is_zero(&v) {
                 break;
             }
             index += 1;
         }
         ret
+    }
+
+    /// CT variant of `const_trailing_zeros`: scans LSB-to-MSB without
+    /// short-circuiting. Mirror of `const_leading_zeros_ct` — see that
+    /// helper for the rationale. Used by the `Ct`-personality arm of
+    /// `ConstBitPrimInt::trailing_zeros`.
+    pub(crate) c0nst fn const_trailing_zeros_ct<T: [c0nst] ConstMachineWord, const N: usize>(
+        array: &[T; N],
+    ) -> u32 {
+        let mut total: u32 = 0;
+        // 0 while still in trailing-zero region; u32::MAX once a non-zero limb is seen.
+        let mut decided: u32 = 0;
+        let mut index = 0;
+        while index < N {
+            let v = array[index];
+            let v_tz = <T as ConstBitPrimInt>::trailing_zeros(v);
+            total += (!decided) & v_tz;
+            let v_nz_bit = (!<T as ConstZero>::is_zero(&v)) as u32;
+            let v_nz_mask = v_nz_bit.wrapping_neg();
+            decided |= v_nz_mask;
+            index += 1;
+        }
+        total
     }
 
     /// Get bit length of array (total bits - leading zeros)
@@ -648,6 +1001,61 @@ c0nst::c0nst! {
             index += 1;
         }
         true
+    }
+
+    /// CT variant of `const_is_zero`: OR-folds all N limbs into one accumulator
+    /// before checking, so timing is uniform regardless of where (or whether)
+    /// a non-zero limb appears. Used by the `Ct`-personality arm of
+    /// `ConstZero::is_zero`.
+    pub(crate) c0nst fn const_is_zero_ct<T: [c0nst] ConstMachineWord, const N: usize>(
+        array: &[T; N],
+    ) -> bool {
+        let mut acc = <T as ConstZero>::zero();
+        let mut index = 0;
+        while index < N {
+            acc = <T as core::ops::BitOr>::bitor(acc, array[index]);
+            index += 1;
+        }
+        <T as ConstZero>::is_zero(&acc)
+    }
+
+    /// Check if array is one. Short-circuits as soon as a non-matching limb
+    /// is found, so timing leaks where the array first deviates from the
+    /// canonical "one" representation. Used by the `Nct`-personality arm of
+    /// `ConstOne::is_one`.
+    pub(crate) c0nst fn const_is_one<T: [c0nst] ConstMachineWord, const N: usize>(
+        array: &[T; N],
+    ) -> bool {
+        if N == 0 || !array[0].is_one() {
+            return false;
+        }
+        let mut i = 1;
+        while i < N {
+            if !<T as ConstZero>::is_zero(&array[i]) {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// CT variant of `const_is_one`: folds `(array[0] ^ 1) | array[1] | ...`
+    /// into one accumulator before checking, so timing does not depend on
+    /// *where* the array first differs from the canonical "one"
+    /// representation. Used by the `Ct`-personality arm of `ConstOne::is_one`.
+    pub(crate) c0nst fn const_is_one_ct<T: [c0nst] ConstMachineWord, const N: usize>(
+        array: &[T; N],
+    ) -> bool {
+        if N == 0 {
+            return false;
+        }
+        let mut acc = <T as core::ops::BitXor>::bitxor(array[0], <T as ConstOne>::one());
+        let mut index = 1;
+        while index < N {
+            acc = <T as core::ops::BitOr>::bitor(acc, array[index]);
+            index += 1;
+        }
+        <T as ConstZero>::is_zero(&acc)
     }
 
     /// Set a specific bit in the array.
@@ -684,6 +1092,38 @@ c0nst::c0nst! {
             }
         }
         core::cmp::Ordering::Equal
+    }
+
+    /// CT variant of `const_cmp`: scans every limb from high to low without
+    /// short-circuiting; once the first differing limb is seen, subsequent
+    /// limbs cannot overturn the locked decision. Used by the `Ct`-personality
+    /// arm of `Ord::cmp` (and therefore `PartialOrd::partial_cmp`).
+    pub(crate) c0nst fn const_cmp_ct<T: [c0nst] ConstMachineWord, const N: usize>(
+        a: &[T; N],
+        b: &[T; N],
+    ) -> core::cmp::Ordering {
+        // result encoding: 2 = Greater, 1 = Less, 0 = Equal.
+        let mut result: u8 = 0;
+        // 0 while still undecided; u8::MAX once a differing limb has been seen.
+        let mut decided: u8 = 0;
+        let mut index = N;
+        while index > 0 {
+            index -= 1;
+            let gt = (a[index] > b[index]) as u8;
+            let lt = (a[index] < b[index]) as u8;
+            // here ∈ {0, 1, 2}: 2 for Greater, 1 for Less, 0 for Equal.
+            let here = (gt << 1) | lt;
+            let undecided_mask = !decided;
+            result |= undecided_mask & here;
+            // Lock the decision the moment a non-zero `here` is observed.
+            let here_nz_mask = ((here != 0) as u8).wrapping_neg();
+            decided |= here_nz_mask;
+        }
+        match result {
+            2 => core::cmp::Ordering::Greater,
+            1 => core::cmp::Ordering::Less,
+            _ => core::cmp::Ordering::Equal,
+        }
     }
 
     /// Get the value of array's word at position `word_idx` when logically shifted left.
@@ -903,39 +1343,56 @@ c0nst::c0nst! {
 }
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst Default for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst Default for FixedUInt<T, N, P> {
         fn default() -> Self {
-            <Self as ConstZero>::zero()
+            FixedUInt::from_array([<T as ConstZero>::zero(); N])
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst Clone for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst Clone for FixedUInt<T, N, P> {
         fn clone(&self) -> Self {
             *self
         }
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::Unsigned for FixedUInt<T, N> {}
+// num_traits::Unsigned requires Num as a supertrait; Num is Nct-only,
+// so Unsigned is Nct-only too.
+impl<T: MachineWord, const N: usize> num_traits::Unsigned for FixedUInt<T, N, Nct> {}
 
 // #region Equality and Ordering
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::cmp::PartialEq for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::cmp::PartialEq for FixedUInt<T, N, P> {
         fn eq(&self, other: &Self) -> bool {
-            self.array == other.array
+            match P::TAG {
+                PersonalityTag::Nct => self.array == other.array,
+                PersonalityTag::Ct => {
+                    let mut diff = <T as crate::const_numtraits::ConstZero>::zero();
+                    let mut i = 0;
+                    while i < N {
+                        let x = <T as core::ops::BitXor>::bitxor(self.array[i], other.array[i]);
+                        diff = <T as core::ops::BitOr>::bitor(diff, x);
+                        i += 1;
+                    }
+                    <T as crate::const_numtraits::ConstZero>::is_zero(&diff)
+                }
+            }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::cmp::Eq for FixedUInt<T, N> {}
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::cmp::Eq for FixedUInt<T, N, P> {}
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::cmp::Ord for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::cmp::Ord for FixedUInt<T, N, P> {
         fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-            const_cmp(&self.array, &other.array)
+            match P::TAG {
+                PersonalityTag::Nct => const_cmp(&self.array, &other.array),
+                PersonalityTag::Ct => const_cmp_ct(&self.array, &other.array),
+            }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::cmp::PartialOrd for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::cmp::PartialOrd for FixedUInt<T, N, P> {
         fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
             Some(self.cmp(other))
         }
@@ -955,27 +1412,27 @@ c0nst::c0nst! {
         impl_from_le_bytes_slice::<T, N>(&bytes)
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::convert::From<u8> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::convert::From<u8> for FixedUInt<T, N, P> {
         fn from(x: u8) -> Self {
-            Self { array: const_from_le_bytes(x.to_le_bytes()) }
+            Self::from_array(const_from_le_bytes(x.to_le_bytes()))
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::convert::From<u16> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::convert::From<u16> for FixedUInt<T, N, P> {
         fn from(x: u16) -> Self {
-            Self { array: const_from_le_bytes(x.to_le_bytes()) }
+            Self::from_array(const_from_le_bytes(x.to_le_bytes()))
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::convert::From<u32> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::convert::From<u32> for FixedUInt<T, N, P> {
         fn from(x: u32) -> Self {
-            Self { array: const_from_le_bytes(x.to_le_bytes()) }
+            Self::from_array(const_from_le_bytes(x.to_le_bytes()))
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::convert::From<u64> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::convert::From<u64> for FixedUInt<T, N, P> {
         fn from(x: u64) -> Self {
-            Self { array: const_from_le_bytes(x.to_le_bytes()) }
+            Self::from_array(const_from_le_bytes(x.to_le_bytes()))
         }
     }
 }
@@ -1030,6 +1487,47 @@ c0nst::c0nst! {
             PanicReason::Sub => panic!("attempt to subtract with overflow"),
             PanicReason::Mul => panic!("attempt to multiply with overflow"),
             PanicReason::DivByZero => panic!("attempt to divide by zero"),
+        }
+    }
+
+    /// Branchless per-limb select: returns `if_zero` when `choice == 0`,
+    /// `if_one` when `choice == 1`.
+    pub(crate) c0nst fn const_ct_select<
+        T: [c0nst] ConstMachineWord + MachineWord,
+        const N: usize,
+        P: Personality,
+    >(
+        if_zero: FixedUInt<T, N, P>,
+        if_one: FixedUInt<T, N, P>,
+        choice: u8,
+    ) -> FixedUInt<T, N, P> {
+        let bit_t = <T as core::convert::From<u8>>::from(choice);
+        let mask = <T as core::ops::Mul>::mul(bit_t, <T as ConstBounded>::max_value());
+        let mut result = if_zero;
+        let mut i = 0;
+        while i < N {
+            let diff = <T as core::ops::BitXor>::bitxor(if_zero.array[i], if_one.array[i]);
+            let masked = <T as core::ops::BitAnd>::bitand(mask, diff);
+            result.array[i] = <T as core::ops::BitXor>::bitxor(if_zero.array[i], masked);
+            i += 1;
+        }
+        result
+    }
+
+    pub(super) c0nst fn maybe_panic_if<P: Personality>(
+        overflow: bool,
+        reason: PanicReason,
+    ) {
+        match P::TAG {
+            PersonalityTag::Nct => {
+                if overflow {
+                    maybe_panic(reason);
+                }
+            }
+            PersonalityTag::Ct => {
+                let _ = overflow;
+                let _ = reason;
+            }
         }
     }
 }
@@ -1784,9 +2282,9 @@ mod tests {
         {
             use core::cmp::Ordering;
 
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [10, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [20, 0] };
-            const C: FixedUInt<u8, 2> = FixedUInt { array: [10, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([10, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([20, 0]);
+            const C: FixedUInt<u8, 2> = FixedUInt::from_array([10, 0]);
 
             const CMP_LT: Ordering = A.cmp(&B);
             const CMP_GT: Ordering = B.cmp(&A);
@@ -1822,7 +2320,7 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [42, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([42, 0]);
             const B: FixedUInt<u8, 2> = A.clone();
             assert_eq!(A.array, B.array);
         }

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -804,6 +804,8 @@ c0nst::c0nst! {
         if N == 0 {
             return;
         }
+        // `layers == usize::BITS`, so `k < layers` guarantees `1usize << k`
+        // stays in range. Do not raise this bound without revisiting the shift.
         let layers = core::mem::size_of::<usize>() * 8;
         let mut k = 0;
         while k < layers {
@@ -841,6 +843,8 @@ c0nst::c0nst! {
         if N == 0 {
             return;
         }
+        // See `const_shl_ct`: `layers == usize::BITS` keeps `1usize << k`
+        // in range.
         let layers = core::mem::size_of::<usize>() * 8;
         let mut k = 0;
         while k < layers {

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -609,48 +609,78 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
 }
 
 c0nst::c0nst! {
-    /// Const-compatible add implementation operating on raw arrays
+    /// Single canonical limb-wise add-with-carry over a fixed-width array.
+    /// CT under `Ct`-personality callers: iteration count is `N`, the inner
+    /// `ConstCarryingAdd::carrying_add` lowers to a hardware ADC, and no
+    /// step branches on the data.
+    pub(crate) c0nst fn add_with_carry<T: [c0nst] ConstMachineWord, const N: usize>(
+        a: &[T; N],
+        b: &[T; N],
+        carry_in: bool,
+    ) -> ([T; N], bool) {
+        let mut result = [T::zero(); N];
+        let mut carry = carry_in;
+        let mut i = 0usize;
+        while i < N {
+            let (sum, c) = ConstCarryingAdd::carrying_add(a[i], b[i], carry);
+            result[i] = sum;
+            carry = c;
+            i += 1;
+        }
+        (result, carry)
+    }
+
+    /// Mirror of `add_with_carry` for subtraction.
+    pub(crate) c0nst fn sub_with_borrow<T: [c0nst] ConstMachineWord, const N: usize>(
+        a: &[T; N],
+        b: &[T; N],
+        borrow_in: bool,
+    ) -> ([T; N], bool) {
+        let mut result = [T::zero(); N];
+        let mut borrow = borrow_in;
+        let mut i = 0usize;
+        while i < N {
+            let (diff, br) = ConstBorrowingSub::borrowing_sub(a[i], b[i], borrow);
+            result[i] = diff;
+            borrow = br;
+            i += 1;
+        }
+        (result, borrow)
+    }
+
+    /// In-place limb-wise add, no carry-in. Same per-limb primitive
+    /// (`ConstCarryingAdd::carrying_add`) as `add_with_carry`, just writing
+    /// directly to `target` to avoid a stack-allocated temp array that
+    /// LLVM might not always elide on embedded builds.
     pub(crate) c0nst fn add_impl<T: [c0nst] ConstMachineWord, const N: usize>(
         target: &mut [T; N],
         other: &[T; N]
     ) -> bool {
-        let mut carry = T::zero();
+        let mut carry = false;
         let mut i = 0usize;
         while i < N {
-            let (res, carry1) = target[i].overflowing_add(&other[i]);
-            let (res, carry2) = res.overflowing_add(&carry);
-            carry = if carry1 || carry2 {
-                T::one()
-            } else {
-                T::zero()
-            };
-            target[i] = res;
+            let (sum, c) = ConstCarryingAdd::carrying_add(target[i], other[i], carry);
+            target[i] = sum;
+            carry = c;
             i += 1;
         }
-        !carry.is_zero()
+        carry
     }
-}
 
-c0nst::c0nst! {
-    /// Const-compatible sub implementation operating on raw arrays
+    /// In-place limb-wise sub, no borrow-in. Mirror of `add_impl`.
     pub(crate) c0nst fn sub_impl<T: [c0nst] ConstMachineWord, const N: usize>(
         target: &mut [T; N],
         other: &[T; N]
     ) -> bool {
-        let mut borrow = T::zero();
+        let mut borrow = false;
         let mut i = 0usize;
         while i < N {
-            let (res, borrow1) = target[i].overflowing_sub(&other[i]);
-            let (res, borrow2) = res.overflowing_sub(&borrow);
-            borrow = if borrow1 || borrow2 {
-                T::one()
-            } else {
-                T::zero()
-            };
-            target[i] = res;
+            let (diff, br) = ConstBorrowingSub::borrowing_sub(target[i], other[i], borrow);
+            target[i] = diff;
+            borrow = br;
             i += 1;
         }
-        !borrow.is_zero()
+        borrow
     }
 }
 
@@ -832,9 +862,16 @@ c0nst::c0nst! {
         }
     }
 
-    /// Standalone const-compatible array multiplication (no FixedUInt dependency)
-    /// Returns (result_array, overflowed)
-    pub(crate) c0nst fn const_mul<T: [c0nst] ConstMachineWord, const N: usize, const CHECK_OVERFLOW: bool>(
+    /// Standalone const-compatible array multiplication (no FixedUInt dependency).
+    /// Returns (result_array, overflowed).
+    ///
+    /// The carry split (`accumulator > t_max ? ... : 0`) dispatches on
+    /// personality. Nct keeps the original predictable branch (the fast
+    /// path skips the shift+mask when the sum already fits in one word);
+    /// Ct does the shift+mask unconditionally so the body has no
+    /// value-dependent branch. Overflow accumulation is branchless (`|` on
+    /// bools) under both personalities since the per-step cost is tiny.
+    pub(crate) c0nst fn const_mul<T: [c0nst] ConstMachineWord, const N: usize, const CHECK_OVERFLOW: bool, P: Personality>(
         op1: &[T; N],
         op2: &[T; N],
         word_bits: usize,
@@ -842,7 +879,6 @@ c0nst::c0nst! {
         let mut result: [T; N] = [<T as ConstZero>::zero(); N];
         let mut overflowed = false;
         let t_max = <T as ConstMachineWord>::to_double(<T as ConstBounded>::max_value());
-        // Zero for double word type
         let dw_zero = <<T as ConstMachineWord>::ConstDoubleWord as ConstZero>::zero();
 
         let mut i = 0;
@@ -859,23 +895,31 @@ c0nst::c0nst! {
                 } else {
                     dw_zero
                 };
-                accumulator = accumulator + mul_res + carry;
+                accumulator += mul_res + carry;
 
-                if accumulator > t_max {
-                    carry = accumulator >> word_bits;
-                    accumulator &= t_max;
-                } else {
-                    carry = dw_zero;
+                match P::TAG {
+                    PersonalityTag::Nct => {
+                        if accumulator > t_max {
+                            carry = accumulator >> word_bits;
+                            accumulator &= t_max;
+                        } else {
+                            carry = dw_zero;
+                        }
+                    }
+                    PersonalityTag::Ct => {
+                        carry = accumulator >> word_bits;
+                        accumulator &= t_max;
+                    }
                 }
                 if round < N {
                     result[round] = <T as ConstMachineWord>::from_double(accumulator);
                 } else if CHECK_OVERFLOW {
-                    overflowed = overflowed || accumulator != dw_zero;
+                    overflowed |= accumulator != dw_zero;
                 }
                 j += 1;
             }
-            if carry != dw_zero && CHECK_OVERFLOW {
-                overflowed = true;
+            if CHECK_OVERFLOW {
+                overflowed |= carry != dw_zero;
             }
             i += 1;
         }
@@ -1566,7 +1610,7 @@ mod tests {
             b: &[T; N],
             word_bits: usize,
         ) -> ([T; N], bool) {
-            const_mul::<T, N, true>(a, b, word_bits)
+            const_mul::<T, N, true, crate::personality::Nct>(a, b, word_bits)
         }
 
         pub c0nst fn arr_leading_zeros<T: [c0nst] ConstMachineWord, const N: usize>(

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -334,11 +334,64 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
     pub fn bit_length(&self) -> u32 {
         Self::BIT_SIZE as u32 - ConstBitPrimInt::leading_zeros(*self)
     }
+}
 
+impl<T: MachineWord, const N: usize> FixedUInt<T, N, Nct> {
     /// Performs a division, returning both the quotient and remainder in a tuple.
     pub fn div_rem(&self, divisor: &Self) -> (Self, Self) {
         let (quotient, remainder) = const_div_rem(&self.array, &divisor.array);
         (Self::from_array(quotient), Self::from_array(remainder))
+    }
+
+    /// Converts to decimal string, given a buffer. CAVEAT: This method removes any leading zeroes
+    pub fn to_radix_str<'a>(
+        &self,
+        result: &'a mut [u8],
+        radix: u8,
+    ) -> Result<&'a str, core::fmt::Error> {
+        type Error = core::fmt::Error;
+
+        if !(2..=16).contains(&radix) {
+            return Err(Error {}); // Radix out of supported range
+        }
+        for byte in result.iter_mut() {
+            *byte = b'0';
+        }
+        if Zero::is_zero(self) {
+            if !result.is_empty() {
+                result[0] = b'0';
+                return core::str::from_utf8(&result[0..1]).map_err(|_| Error {});
+            } else {
+                return Err(Error {});
+            }
+        }
+
+        let mut number = *self;
+        let mut idx = result.len();
+
+        let radix_t = Self::from(radix);
+
+        while !Zero::is_zero(&number) {
+            if idx == 0 {
+                return Err(Error {}); // not enough space in result...
+            }
+
+            idx -= 1;
+            let (quotient, remainder) = number.div_rem(&radix_t);
+
+            let digit = remainder.to_u8().unwrap();
+            result[idx] = match digit {
+                0..=9 => b'0' + digit,          // digits
+                10..=16 => b'a' + (digit - 10), // alphabetic digits for bases > 10
+                _ => return Err(Error {}),
+            };
+
+            number = quotient;
+        }
+
+        let start = result[idx..].iter().position(|&c| c != b'0').unwrap_or(0);
+        let radix_str = core::str::from_utf8(&result[idx + start..]).map_err(|_| Error {})?;
+        Ok(radix_str)
     }
 }
 
@@ -498,67 +551,16 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
         }
     }
 
-    /// Converts to decimal string, given a buffer. CAVEAT: This method removes any leading zeroes
-    pub fn to_radix_str<'a>(
-        &self,
-        result: &'a mut [u8],
-        radix: u8,
-    ) -> Result<&'a str, core::fmt::Error> {
-        type Error = core::fmt::Error;
-
-        if !(2..=16).contains(&radix) {
-            return Err(Error {}); // Radix out of supported range
-        }
-        for byte in result.iter_mut() {
-            *byte = b'0';
-        }
-        if Zero::is_zero(self) {
-            if !result.is_empty() {
-                result[0] = b'0';
-                return core::str::from_utf8(&result[0..1]).map_err(|_| Error {});
-            } else {
-                return Err(Error {});
-            }
-        }
-
-        let mut number = *self;
-        let mut idx = result.len();
-
-        let radix_t = Self::from(radix);
-
-        while !Zero::is_zero(&number) {
-            if idx == 0 {
-                return Err(Error {}); // not enough space in result...
-            }
-
-            idx -= 1;
-            let (quotient, remainder) = number.div_rem(&radix_t);
-
-            let digit = remainder.to_u8().unwrap();
-            result[idx] = match digit {
-                0..=9 => b'0' + digit,          // digits
-                10..=16 => b'a' + (digit - 10), // alphabetic digits for bases > 10
-                _ => return Err(Error {}),
-            };
-
-            number = quotient;
-        }
-
-        let start = result[idx..].iter().position(|&c| c != b'0').unwrap_or(0);
-        let radix_str = core::str::from_utf8(&result[idx + start..]).map_err(|_| Error {})?;
-        Ok(radix_str)
-    }
-
     /// Construct a new value with a different size.
     ///
     /// - If `N2 < N`, the most-significant (upper) words are truncated.
     /// - If `N2 > N`, the additional most-significant words are filled with zeros.
     #[must_use]
-    pub fn resize<const N2: usize>(&self) -> FixedUInt<T, N2> {
+    pub fn resize<const N2: usize>(&self) -> FixedUInt<T, N2, P> {
         let mut array = [T::zero(); N2];
         let min_size = N.min(N2);
         array[..min_size].copy_from_slice(&self.array[..min_size]);
-        FixedUInt::from_array(array)
+        FixedUInt::<T, N2, P>::from_array(array)
     }
 
     fn hex_fmt(

--- a/src/fixeduint/abs_diff_impl.rs
+++ b/src/fixeduint/abs_diff_impl.rs
@@ -14,17 +14,29 @@
 
 //! Absolute difference implementation for FixedUInt.
 
-use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::ConstAbsDiff;
+use super::{const_ct_select, FixedUInt, MachineWord};
+use crate::const_numtraits::{ConstAbsDiff, ConstOverflowingSub, ConstWrappingSub, ConstZero};
 use crate::machineword::ConstMachineWord;
+use crate::personality::{Personality, PersonalityTag};
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstAbsDiff for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstAbsDiff for FixedUInt<T, N, P> {
         fn abs_diff(self, other: Self) -> Self {
-            if self >= other {
-                self - other
-            } else {
-                other - self
+            match P::TAG {
+                PersonalityTag::Nct => {
+                    if self >= other {
+                        self - other
+                    } else {
+                        other - self
+                    }
+                }
+                PersonalityTag::Ct => {
+                    let (diff, borrow) =
+                        <Self as ConstOverflowingSub>::overflowing_sub(&self, &other);
+                    let neg_diff =
+                        <Self as ConstWrappingSub>::wrapping_sub(&<Self as ConstZero>::zero(), &diff);
+                    const_ct_select(diff, neg_diff, borrow as u8)
+                }
             }
         }
     }
@@ -61,10 +73,10 @@ mod tests {
     }
 
     c0nst::c0nst! {
-        pub c0nst fn const_abs_diff<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
-        ) -> FixedUInt<T, N> {
+        pub c0nst fn const_abs_diff<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>,
+        ) -> FixedUInt<T, N, P> {
             ConstAbsDiff::abs_diff(a, b)
         }
     }
@@ -80,10 +92,10 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: U16 = FixedUInt { array: [10, 0] };
-            const B: U16 = FixedUInt { array: [3, 0] };
+            const A: U16 = FixedUInt::from_array([10, 0]);
+            const B: U16 = FixedUInt::from_array([3, 0]);
             const DIFF: U16 = const_abs_diff(A, B);
-            assert_eq!(DIFF, FixedUInt { array: [7, 0] });
+            assert_eq!(DIFF, FixedUInt::from_array([7, 0]));
         }
     }
 }

--- a/src/fixeduint/add_sub_impl.rs
+++ b/src/fixeduint/add_sub_impl.rs
@@ -1,12 +1,15 @@
-use super::{add_impl, maybe_panic, sub_impl, FixedUInt, MachineWord, PanicReason};
+use super::{
+    add_impl, const_ct_select, maybe_panic_if, sub_impl, FixedUInt, MachineWord, PanicReason,
+};
 use crate::const_numtraits::{
     ConstBounded, ConstCheckedAdd, ConstCheckedSub, ConstOverflowingAdd, ConstOverflowingSub,
     ConstSaturatingAdd, ConstSaturatingSub, ConstWrappingAdd, ConstWrappingSub, ConstZero,
 };
 use crate::machineword::ConstMachineWord;
+use crate::personality::{Personality, PersonalityTag};
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst crate::const_numtraits::ConstOverflowingAdd for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst crate::const_numtraits::ConstOverflowingAdd for FixedUInt<T, N, P> {
         fn overflowing_add(&self, other: &Self) -> (Self, bool) {
             let mut ret = *self;
             let overflow = add_impl(&mut ret.array, &other.array);
@@ -14,7 +17,7 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst crate::const_numtraits::ConstOverflowingSub for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst crate::const_numtraits::ConstOverflowingSub for FixedUInt<T, N, P> {
         fn overflowing_sub(&self, other: &Self) -> (Self, bool) {
             let mut ret = *self;
             let overflow = sub_impl(&mut ret.array, &other.array);
@@ -22,217 +25,207 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstWrappingAdd for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstWrappingAdd for FixedUInt<T, N, P> {
         fn wrapping_add(&self, other: &Self) -> Self {
             <Self as ConstOverflowingAdd>::overflowing_add(self, other).0
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstWrappingSub for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstWrappingSub for FixedUInt<T, N, P> {
         fn wrapping_sub(&self, other: &Self) -> Self {
             <Self as ConstOverflowingSub>::overflowing_sub(self, other).0
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedAdd for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstCheckedAdd for FixedUInt<T, N, P> {
         fn checked_add(&self, other: &Self) -> Option<Self> {
             let (res, overflow) = <Self as ConstOverflowingAdd>::overflowing_add(self, other);
             if overflow { None } else { Some(res) }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedSub for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstCheckedSub for FixedUInt<T, N, P> {
         fn checked_sub(&self, other: &Self) -> Option<Self> {
             let (res, overflow) = <Self as ConstOverflowingSub>::overflowing_sub(self, other);
             if overflow { None } else { Some(res) }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstSaturatingAdd for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstSaturatingAdd for FixedUInt<T, N, P> {
         fn saturating_add(&self, other: &Self) -> Self {
             let (res, overflow) = <Self as ConstOverflowingAdd>::overflowing_add(self, other);
-            if overflow { <Self as ConstBounded>::max_value() } else { res }
+            match P::TAG {
+                PersonalityTag::Nct => if overflow { <Self as ConstBounded>::max_value() } else { res },
+                PersonalityTag::Ct => const_ct_select(res, <Self as ConstBounded>::max_value(), overflow as u8),
+            }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstSaturatingSub for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstSaturatingSub for FixedUInt<T, N, P> {
         fn saturating_sub(&self, other: &Self) -> Self {
             let (res, overflow) = <Self as ConstOverflowingSub>::overflowing_sub(self, other);
-            if overflow { <Self as ConstZero>::zero() } else { res }
+            match P::TAG {
+                PersonalityTag::Nct => if overflow { <Self as ConstZero>::zero() } else { res },
+                PersonalityTag::Ct => const_ct_select(res, <Self as ConstZero>::zero(), overflow as u8),
+            }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Add for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Add for FixedUInt<T, N, P> {
         type Output = Self;
         fn add(self, other: Self) -> Self {
             let (res, overflow) = <Self as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(&self, &other);
-            if overflow {
-                maybe_panic(PanicReason::Add);
-            }
+            maybe_panic_if::<P>(overflow, PanicReason::Add);
             res
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Sub for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Sub for FixedUInt<T, N, P> {
         type Output = Self;
         fn sub(self, other: Self) -> Self {
             let (res, overflow) = <Self as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(&self, &other);
-            if overflow {
-                maybe_panic(PanicReason::Sub);
-            }
+            maybe_panic_if::<P>(overflow, PanicReason::Sub);
             res
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Add<&'_ Self> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Add<&'_ Self> for FixedUInt<T, N, P> {
         type Output = Self;
         fn add(self, other: &Self) -> Self {
             let (res, overflow) = <Self as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(&self, other);
-            if overflow {
-                maybe_panic(PanicReason::Add);
-            }
+            maybe_panic_if::<P>(overflow, PanicReason::Add);
             res
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Add<FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn add(self, other: FixedUInt<T, N>) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, &other);
-            if overflow {
-                maybe_panic(PanicReason::Add);
-            }
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Add<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn add(self, other: FixedUInt<T, N, P>) -> Self::Output {
+            let (res, overflow) = <FixedUInt<T, N, P> as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, &other);
+            maybe_panic_if::<P>(overflow, PanicReason::Add);
             res
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Add<Self> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Add<Self> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn add(self, other: Self) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, other);
-            if overflow {
-                maybe_panic(PanicReason::Add);
-            }
+            let (res, overflow) = <FixedUInt<T, N, P> as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, other);
+            maybe_panic_if::<P>(overflow, PanicReason::Add);
             res
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Sub<&'_ Self> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Sub<&'_ Self> for FixedUInt<T, N, P> {
         type Output = Self;
         fn sub(self, other: &Self) -> Self {
             let (res, overflow) = <Self as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(&self, other);
-            if overflow {
-                maybe_panic(PanicReason::Sub);
-            }
+            maybe_panic_if::<P>(overflow, PanicReason::Sub);
             res
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Sub<FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn sub(self, other: FixedUInt<T, N>) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, &other);
-            if overflow {
-                maybe_panic(PanicReason::Sub);
-            }
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Sub<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn sub(self, other: FixedUInt<T, N, P>) -> Self::Output {
+            let (res, overflow) = <FixedUInt<T, N, P> as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, &other);
+            maybe_panic_if::<P>(overflow, PanicReason::Sub);
             res
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Sub<Self> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Sub<Self> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn sub(self, other: Self) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N> as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, other);
-            if overflow {
-                maybe_panic(PanicReason::Sub);
-            }
+            let (res, overflow) = <FixedUInt<T, N, P> as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, other);
+            maybe_panic_if::<P>(overflow, PanicReason::Sub);
             res
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::AddAssign<Self> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::AddAssign<Self> for FixedUInt<T, N, P> {
         fn add_assign(&mut self, other: Self) {
-            if add_impl(&mut self.array, &other.array) {
-                maybe_panic(PanicReason::Add);
-            }
+            let overflow = add_impl(&mut self.array, &other.array);
+            maybe_panic_if::<P>(overflow, PanicReason::Add);
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::AddAssign<&'_ Self> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::AddAssign<&'_ Self> for FixedUInt<T, N, P> {
         fn add_assign(&mut self, other: &Self) {
-            if add_impl(&mut self.array, &other.array) {
-                maybe_panic(PanicReason::Add);
-            }
+            let overflow = add_impl(&mut self.array, &other.array);
+            maybe_panic_if::<P>(overflow, PanicReason::Add);
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::SubAssign<Self> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::SubAssign<Self> for FixedUInt<T, N, P> {
         fn sub_assign(&mut self, other: Self) {
-            if sub_impl(&mut self.array, &other.array) {
-                maybe_panic(PanicReason::Sub);
-            }
+            let overflow = sub_impl(&mut self.array, &other.array);
+            maybe_panic_if::<P>(overflow, PanicReason::Sub);
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::SubAssign<&'_ Self> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::SubAssign<&'_ Self> for FixedUInt<T, N, P> {
         fn sub_assign(&mut self, other: &Self) {
-            if sub_impl(&mut self.array, &other.array) {
-                maybe_panic(PanicReason::Sub);
-            }
+            let overflow = sub_impl(&mut self.array, &other.array);
+            maybe_panic_if::<P>(overflow, PanicReason::Sub);
         }
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::ops::overflowing::OverflowingAdd
-    for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::overflowing::OverflowingAdd
+    for FixedUInt<T, N, P>
 {
     fn overflowing_add(&self, other: &Self) -> (Self, bool) {
         <Self as crate::const_numtraits::ConstOverflowingAdd>::overflowing_add(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::WrappingAdd for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingAdd
+    for FixedUInt<T, N, P>
+{
     fn wrapping_add(&self, other: &Self) -> Self {
         <Self as ConstWrappingAdd>::wrapping_add(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::CheckedAdd for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedAdd for FixedUInt<T, N, P> {
     fn checked_add(&self, other: &Self) -> Option<Self> {
         <Self as ConstCheckedAdd>::checked_add(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::ops::saturating::SaturatingAdd
-    for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::saturating::SaturatingAdd
+    for FixedUInt<T, N, P>
 {
     fn saturating_add(&self, other: &Self) -> Self {
         <Self as ConstSaturatingAdd>::saturating_add(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::ops::overflowing::OverflowingSub
-    for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::overflowing::OverflowingSub
+    for FixedUInt<T, N, P>
 {
     fn overflowing_sub(&self, other: &Self) -> (Self, bool) {
         <Self as crate::const_numtraits::ConstOverflowingSub>::overflowing_sub(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::WrappingSub for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingSub
+    for FixedUInt<T, N, P>
+{
     fn wrapping_sub(&self, other: &Self) -> Self {
         <Self as ConstWrappingSub>::wrapping_sub(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::CheckedSub for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedSub for FixedUInt<T, N, P> {
     fn checked_sub(&self, other: &Self) -> Option<Self> {
         <Self as ConstCheckedSub>::checked_sub(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::ops::saturating::SaturatingSub
-    for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::saturating::SaturatingSub
+    for FixedUInt<T, N, P>
 {
     fn saturating_sub(&self, other: &Self) -> Self {
         <Self as ConstSaturatingSub>::saturating_sub(self, other)
@@ -240,7 +233,7 @@ impl<T: MachineWord, const N: usize> num_traits::ops::saturating::SaturatingSub
 }
 
 /// Note: This is marked deprecated, but still used by PrimInt
-impl<T: MachineWord, const N: usize> num_traits::Saturating for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::Saturating for FixedUInt<T, N, P> {
     fn saturating_add(self, other: Self) -> Self {
         <Self as ConstSaturatingAdd>::saturating_add(&self, &other)
     }
@@ -262,67 +255,67 @@ mod tests {
 
     c0nst::c0nst! {
         /// Test wrapper for ConstOverflowingAdd
-        pub c0nst fn const_overflowing_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>
-        ) -> (FixedUInt<T, N>, bool) {
-            <FixedUInt<T, N> as ConstOverflowingAdd>::overflowing_add(a, b)
+        pub c0nst fn const_overflowing_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: &FixedUInt<T, N, P>,
+            b: &FixedUInt<T, N, P>
+        ) -> (FixedUInt<T, N, P>, bool) {
+            <FixedUInt<T, N, P> as ConstOverflowingAdd>::overflowing_add(a, b)
         }
 
         /// Test wrapper for ConstOverflowingSub
-        pub c0nst fn const_overflowing_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>
-        ) -> (FixedUInt<T, N>, bool) {
-            <FixedUInt<T, N> as ConstOverflowingSub>::overflowing_sub(a, b)
+        pub c0nst fn const_overflowing_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: &FixedUInt<T, N, P>,
+            b: &FixedUInt<T, N, P>
+        ) -> (FixedUInt<T, N, P>, bool) {
+            <FixedUInt<T, N, P> as ConstOverflowingSub>::overflowing_sub(a, b)
         }
 
         /// Test wrapper for const Add
-        pub c0nst fn const_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>
-        ) -> FixedUInt<T, N> {
+        pub c0nst fn const_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>
+        ) -> FixedUInt<T, N, P> {
             a + b
         }
 
         /// Test wrapper for const Sub
-        pub c0nst fn const_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>
-        ) -> FixedUInt<T, N> {
+        pub c0nst fn const_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>
+        ) -> FixedUInt<T, N, P> {
             a - b
         }
 
         /// Test wrapper for ConstWrappingAdd
-        pub c0nst fn const_wrapping_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>
-        ) -> FixedUInt<T, N> {
-            <FixedUInt<T, N> as ConstWrappingAdd>::wrapping_add(a, b)
+        pub c0nst fn const_wrapping_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: &FixedUInt<T, N, P>,
+            b: &FixedUInt<T, N, P>
+        ) -> FixedUInt<T, N, P> {
+            <FixedUInt<T, N, P> as ConstWrappingAdd>::wrapping_add(a, b)
         }
 
         /// Test wrapper for ConstWrappingSub
-        pub c0nst fn const_wrapping_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>
-        ) -> FixedUInt<T, N> {
-            <FixedUInt<T, N> as ConstWrappingSub>::wrapping_sub(a, b)
+        pub c0nst fn const_wrapping_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: &FixedUInt<T, N, P>,
+            b: &FixedUInt<T, N, P>
+        ) -> FixedUInt<T, N, P> {
+            <FixedUInt<T, N, P> as ConstWrappingSub>::wrapping_sub(a, b)
         }
 
         /// Test wrapper for ConstCheckedAdd
-        pub c0nst fn const_checked_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>
-        ) -> Option<FixedUInt<T, N>> {
-            <FixedUInt<T, N> as ConstCheckedAdd>::checked_add(a, b)
+        pub c0nst fn const_checked_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: &FixedUInt<T, N, P>,
+            b: &FixedUInt<T, N, P>
+        ) -> Option<FixedUInt<T, N, P>> {
+            <FixedUInt<T, N, P> as ConstCheckedAdd>::checked_add(a, b)
         }
 
         /// Test wrapper for ConstCheckedSub
-        pub c0nst fn const_checked_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>
-        ) -> Option<FixedUInt<T, N>> {
-            <FixedUInt<T, N> as ConstCheckedSub>::checked_sub(a, b)
+        pub c0nst fn const_checked_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: &FixedUInt<T, N, P>,
+            b: &FixedUInt<T, N, P>
+        ) -> Option<FixedUInt<T, N, P>> {
+            <FixedUInt<T, N, P> as ConstCheckedSub>::checked_sub(a, b)
         }
     }
 
@@ -383,8 +376,8 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [12, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [3, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([12, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([3, 0]);
             const RESULT: (FixedUInt<u8, 2>, bool) = const_overflowing_add(&A, &B);
             assert_eq!(RESULT.0.array, [15, 0]);
             assert!(!RESULT.1);
@@ -408,8 +401,8 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [15, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [3, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([15, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([3, 0]);
             const RESULT: (FixedUInt<u8, 2>, bool) = const_overflowing_sub(&A, &B);
             assert_eq!(RESULT.0.array, [12, 0]);
             assert!(!RESULT.1);
@@ -431,8 +424,8 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [12, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [3, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([12, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([3, 0]);
             const RESULT: FixedUInt<u8, 2> = const_add(A, B);
             assert_eq!(RESULT.array, [15, 0]);
         }
@@ -453,8 +446,8 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [15, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [3, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([15, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([3, 0]);
             const RESULT: FixedUInt<u8, 2> = const_sub(A, B);
             assert_eq!(RESULT.array, [12, 0]);
         }
@@ -512,8 +505,8 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [100, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [50, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([100, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([50, 0]);
 
             const WRAP_ADD: FixedUInt<u8, 2> = const_wrapping_add(&A, &B);
             const WRAP_SUB: FixedUInt<u8, 2> = const_wrapping_sub(&A, &B);
@@ -525,8 +518,8 @@ mod tests {
             assert!(CHECK_ADD.is_some());
             assert!(CHECK_SUB.is_some());
 
-            const MAX: FixedUInt<u8, 2> = FixedUInt { array: [255, 255] };
-            const ONE: FixedUInt<u8, 2> = FixedUInt { array: [1, 0] };
+            const MAX: FixedUInt<u8, 2> = FixedUInt::from_array([255, 255]);
+            const ONE: FixedUInt<u8, 2> = FixedUInt::from_array([1, 0]);
             const CHECK_ADD_OVERFLOW: Option<FixedUInt<u8, 2>> = const_checked_add(&MAX, &ONE);
             assert!(CHECK_ADD_OVERFLOW.is_none());
         }

--- a/src/fixeduint/add_sub_impl.rs
+++ b/src/fixeduint/add_sub_impl.rs
@@ -145,29 +145,37 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::AddAssign<Self> for FixedUInt<T, N, P> {
         fn add_assign(&mut self, other: Self) {
-            let overflow = add_impl(&mut self.array, &other.array);
+            let mut array = self.array;
+            let overflow = add_impl(&mut array, &other.array);
             maybe_panic_if::<P>(overflow, PanicReason::Add);
+            self.array = array;
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::AddAssign<&'_ Self> for FixedUInt<T, N, P> {
         fn add_assign(&mut self, other: &Self) {
-            let overflow = add_impl(&mut self.array, &other.array);
+            let mut array = self.array;
+            let overflow = add_impl(&mut array, &other.array);
             maybe_panic_if::<P>(overflow, PanicReason::Add);
+            self.array = array;
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::SubAssign<Self> for FixedUInt<T, N, P> {
         fn sub_assign(&mut self, other: Self) {
-            let overflow = sub_impl(&mut self.array, &other.array);
+            let mut array = self.array;
+            let overflow = sub_impl(&mut array, &other.array);
             maybe_panic_if::<P>(overflow, PanicReason::Sub);
+            self.array = array;
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::SubAssign<&'_ Self> for FixedUInt<T, N, P> {
         fn sub_assign(&mut self, other: &Self) {
-            let overflow = sub_impl(&mut self.array, &other.array);
+            let mut array = self.array;
+            let overflow = sub_impl(&mut array, &other.array);
             maybe_panic_if::<P>(overflow, PanicReason::Sub);
+            self.array = array;
         }
     }
 }

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -1,4 +1,7 @@
-use super::{const_shl_impl, const_shr_impl, FixedUInt, MachineWord};
+use super::{
+    const_ct_select, const_shl_ct, const_shl_impl, const_shr_ct, const_shr_impl, FixedUInt,
+    MachineWord,
+};
 
 use crate::const_numtraits::{
     ConstCheckedShl, ConstCheckedShr, ConstOverflowingShl, ConstOverflowingShr,
@@ -6,9 +9,10 @@ use crate::const_numtraits::{
 };
 use crate::machineword::ConstMachineWord;
 use crate::patch_num_traits::{OverflowingShl, OverflowingShr};
+use crate::personality::{Personality, PersonalityTag};
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Not for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Not for FixedUInt<T, N, P> {
         type Output = Self;
         fn not(self) -> Self::Output {
             let mut ret = <Self as ConstZero>::zero();
@@ -21,10 +25,10 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitAnd<&FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn bitand(self, other: &FixedUInt<T, N>) -> Self::Output {
-            let mut ret = <FixedUInt<T, N> as ConstZero>::zero();
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitAnd<&FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn bitand(self, other: &FixedUInt<T, N, P>) -> Self::Output {
+            let mut ret = <FixedUInt<T, N, P> as ConstZero>::zero();
             let mut i = 0;
             while i < N {
                 ret.array[i] = self.array[i] & other.array[i];
@@ -34,28 +38,28 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitAnd for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitAnd for FixedUInt<T, N, P> {
         type Output = Self;
         fn bitand(self, other: Self) -> Self::Output {
             (&self).bitand(&other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitAnd<&FixedUInt<T, N>> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitAnd<&FixedUInt<T, N, P>> for FixedUInt<T, N, P> {
         type Output = Self;
-        fn bitand(self, other: &FixedUInt<T, N>) -> Self::Output {
+        fn bitand(self, other: &FixedUInt<T, N, P>) -> Self::Output {
             (&self).bitand(other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitAnd<FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn bitand(self, other: FixedUInt<T, N>) -> Self::Output {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitAnd<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn bitand(self, other: FixedUInt<T, N, P>) -> Self::Output {
             self.bitand(&other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitAndAssign for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitAndAssign for FixedUInt<T, N, P> {
         fn bitand_assign(&mut self, other: Self) {
             let mut i = 0;
             while i < N {
@@ -65,10 +69,10 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitOr<&FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn bitor(self, other: &FixedUInt<T, N>) -> Self::Output {
-            let mut ret = <FixedUInt<T, N> as ConstZero>::zero();
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitOr<&FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn bitor(self, other: &FixedUInt<T, N, P>) -> Self::Output {
+            let mut ret = <FixedUInt<T, N, P> as ConstZero>::zero();
             let mut i = 0;
             while i < N {
                 ret.array[i] = self.array[i] | other.array[i];
@@ -78,28 +82,28 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitOr for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitOr for FixedUInt<T, N, P> {
         type Output = Self;
         fn bitor(self, other: Self) -> Self::Output {
             (&self).bitor(&other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitOr<&FixedUInt<T, N>> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitOr<&FixedUInt<T, N, P>> for FixedUInt<T, N, P> {
         type Output = Self;
-        fn bitor(self, other: &FixedUInt<T, N>) -> Self::Output {
+        fn bitor(self, other: &FixedUInt<T, N, P>) -> Self::Output {
             (&self).bitor(other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitOr<FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn bitor(self, other: FixedUInt<T, N>) -> Self::Output {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitOr<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn bitor(self, other: FixedUInt<T, N, P>) -> Self::Output {
             self.bitor(&other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitOrAssign for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitOrAssign for FixedUInt<T, N, P> {
         fn bitor_assign(&mut self, other: Self) {
             let mut i = 0;
             while i < N {
@@ -109,10 +113,10 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitXor<&FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn bitxor(self, other: &FixedUInt<T, N>) -> Self::Output {
-            let mut ret = <FixedUInt<T, N> as ConstZero>::zero();
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitXor<&FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn bitxor(self, other: &FixedUInt<T, N, P>) -> Self::Output {
+            let mut ret = <FixedUInt<T, N, P> as ConstZero>::zero();
             let mut i = 0;
             while i < N {
                 ret.array[i] = self.array[i] ^ other.array[i];
@@ -122,28 +126,28 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitXor for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitXor for FixedUInt<T, N, P> {
         type Output = Self;
         fn bitxor(self, other: Self) -> Self::Output {
             (&self).bitxor(&other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitXor<&FixedUInt<T, N>> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitXor<&FixedUInt<T, N, P>> for FixedUInt<T, N, P> {
         type Output = Self;
-        fn bitxor(self, other: &FixedUInt<T, N>) -> Self::Output {
+        fn bitxor(self, other: &FixedUInt<T, N, P>) -> Self::Output {
             (&self).bitxor(other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitXor<FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn bitxor(self, other: FixedUInt<T, N>) -> Self::Output {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitXor<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn bitxor(self, other: FixedUInt<T, N, P>) -> Self::Output {
             self.bitxor(&other)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::BitXorAssign for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::BitXorAssign for FixedUInt<T, N, P> {
         fn bitxor_assign(&mut self, other: Self) {
             let mut i = 0;
             while i < N {
@@ -154,60 +158,66 @@ c0nst::c0nst! {
     }
 
     // Primary Shl/Shr implementations
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shl<usize> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<usize> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shl(self, bits: usize) -> Self::Output {
             let mut result = self;
-            const_shl_impl(&mut result, bits);
+            match P::TAG {
+                PersonalityTag::Nct => const_shl_impl(&mut result, bits),
+                PersonalityTag::Ct => const_shl_ct(&mut result, bits),
+            }
             result
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shr<usize> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<usize> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shr(self, bits: usize) -> Self::Output {
             let mut result = self;
-            const_shr_impl(&mut result, bits);
+            match P::TAG {
+                PersonalityTag::Nct => const_shr_impl(&mut result, bits),
+                PersonalityTag::Ct => const_shr_ct(&mut result, bits),
+            }
             result
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shl<u32> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shl(self, bits: u32) -> Self::Output {
             self.shl(bits as usize)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shr<u32> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shr(self, bits: u32) -> Self::Output {
             self.shr(bits as usize)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shl<&usize> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<&usize> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shl(self, bits: &usize) -> Self::Output {
             self.shl(*bits)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shr<&usize> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<&usize> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shr(self, bits: &usize) -> Self::Output {
             self.shr(*bits)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shl<&u32> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<&u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shl(self, bits: &u32) -> Self::Output {
             self.shl(*bits as usize)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shr<&u32> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<&u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shr(self, bits: &u32) -> Self::Output {
             self.shr(*bits as usize)
@@ -215,84 +225,96 @@ c0nst::c0nst! {
     }
 
     // Shl/Shr for &FixedUInt
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shl<usize> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<usize> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: usize) -> Self::Output {
             (*self).shl(bits)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shr<usize> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<usize> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: usize) -> Self::Output {
             (*self).shr(bits)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shl<u32> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<u32> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: u32) -> Self::Output {
             (*self).shl(bits as usize)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shr<u32> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<u32> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: u32) -> Self::Output {
             (*self).shr(bits as usize)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shl<&usize> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<&usize> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: &usize) -> Self::Output {
             (*self).shl(*bits)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shr<&usize> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<&usize> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: &usize) -> Self::Output {
             (*self).shr(*bits)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shl<&u32> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<&u32> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: &u32) -> Self::Output {
             (*self).shl(*bits as usize)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Shr<&u32> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<&u32> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: &u32) -> Self::Output {
             (*self).shr(*bits as usize)
         }
     }
 
     // ShlAssign/ShrAssign
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::ShlAssign<usize> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::ShlAssign<usize> for FixedUInt<T, N, P> {
         fn shl_assign(&mut self, bits: usize) {
-            const_shl_impl(self, bits);
+            match P::TAG {
+                PersonalityTag::Nct => const_shl_impl(self, bits),
+                PersonalityTag::Ct => const_shl_ct(self, bits),
+            }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::ShrAssign<usize> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::ShrAssign<usize> for FixedUInt<T, N, P> {
         fn shr_assign(&mut self, bits: usize) {
-            const_shr_impl(self, bits);
+            match P::TAG {
+                PersonalityTag::Nct => const_shr_impl(self, bits),
+                PersonalityTag::Ct => const_shr_ct(self, bits),
+            }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::ShlAssign<&usize> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::ShlAssign<&usize> for FixedUInt<T, N, P> {
         fn shl_assign(&mut self, bits: &usize) {
-            const_shl_impl(self, *bits);
+            match P::TAG {
+                PersonalityTag::Nct => const_shl_impl(self, *bits),
+                PersonalityTag::Ct => const_shl_ct(self, *bits),
+            }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::ShrAssign<&usize> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::ShrAssign<&usize> for FixedUInt<T, N, P> {
         fn shr_assign(&mut self, bits: &usize) {
-            const_shr_impl(self, *bits);
+            match P::TAG {
+                PersonalityTag::Nct => const_shr_impl(self, *bits),
+                PersonalityTag::Ct => const_shr_ct(self, *bits),
+            }
         }
     }
 
@@ -315,7 +337,7 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstOverflowingShl for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstOverflowingShl for FixedUInt<T, N, P> {
         fn overflowing_shl(&self, bits: u32) -> (Self, bool) {
             let (shift, overflow) = normalize_shift_amount(bits, Self::BIT_SIZE);
             let res = core::ops::Shl::<usize>::shl(*self, shift);
@@ -323,7 +345,7 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstOverflowingShr for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstOverflowingShr for FixedUInt<T, N, P> {
         fn overflowing_shr(&self, bits: u32) -> (Self, bool) {
             let (shift, overflow) = normalize_shift_amount(bits, Self::BIT_SIZE);
             let res = core::ops::Shr::<usize>::shr(*self, shift);
@@ -331,86 +353,106 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstWrappingShl for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstWrappingShl for FixedUInt<T, N, P> {
         fn wrapping_shl(&self, bits: u32) -> Self {
             ConstOverflowingShl::overflowing_shl(self, bits).0
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstWrappingShr for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstWrappingShr for FixedUInt<T, N, P> {
         fn wrapping_shr(&self, bits: u32) -> Self {
             ConstOverflowingShr::overflowing_shr(self, bits).0
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedShl for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstCheckedShl for FixedUInt<T, N, P> {
         fn checked_shl(&self, bits: u32) -> Option<Self> {
             let (res, overflow) = ConstOverflowingShl::overflowing_shl(self, bits);
             if overflow { None } else { Some(res) }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedShr for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstCheckedShr for FixedUInt<T, N, P> {
         fn checked_shr(&self, bits: u32) -> Option<Self> {
             let (res, overflow) = ConstOverflowingShr::overflowing_shr(self, bits);
             if overflow { None } else { Some(res) }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstUnboundedShift for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstUnboundedShift for FixedUInt<T, N, P> {
         fn unbounded_shl(self, rhs: u32) -> Self {
             let (shift, overflow) = normalize_shift_amount(rhs, Self::BIT_SIZE);
-            if overflow {
-                Self::zero()
-            } else {
-                self << shift
+            match P::TAG {
+                PersonalityTag::Nct => {
+                    if overflow {
+                        Self::zero()
+                    } else {
+                        self << shift
+                    }
+                }
+                PersonalityTag::Ct => {
+                    let shifted = self << shift;
+                    const_ct_select(shifted, Self::zero(), overflow as u8)
+                }
             }
         }
 
         fn unbounded_shr(self, rhs: u32) -> Self {
             let (shift, overflow) = normalize_shift_amount(rhs, Self::BIT_SIZE);
-            if overflow {
-                Self::zero()
-            } else {
-                self >> shift
+            match P::TAG {
+                PersonalityTag::Nct => {
+                    if overflow {
+                        Self::zero()
+                    } else {
+                        self >> shift
+                    }
+                }
+                PersonalityTag::Ct => {
+                    let shifted = self >> shift;
+                    const_ct_select(shifted, Self::zero(), overflow as u8)
+                }
             }
         }
     }
 }
 
 // OverflowingShl/Shr from patch_num_traits - delegate to const impls
-impl<T: MachineWord, const N: usize> OverflowingShl for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> OverflowingShl for FixedUInt<T, N, P> {
     fn overflowing_shl(self, bits: u32) -> (Self, bool) {
         ConstOverflowingShl::overflowing_shl(&self, bits)
     }
 }
 
-impl<T: MachineWord, const N: usize> OverflowingShr for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> OverflowingShr for FixedUInt<T, N, P> {
     fn overflowing_shr(self, bits: u32) -> (Self, bool) {
         ConstOverflowingShr::overflowing_shr(&self, bits)
     }
 }
 
 // num_traits wrappers - delegate to const impls
-impl<T: MachineWord, const N: usize> num_traits::WrappingShl for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingShl
+    for FixedUInt<T, N, P>
+{
     fn wrapping_shl(&self, bits: u32) -> Self {
         ConstWrappingShl::wrapping_shl(self, bits)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::WrappingShr for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingShr
+    for FixedUInt<T, N, P>
+{
     fn wrapping_shr(&self, bits: u32) -> Self {
         ConstWrappingShr::wrapping_shr(self, bits)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::CheckedShl for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedShl for FixedUInt<T, N, P> {
     fn checked_shl(&self, bits: u32) -> Option<Self> {
         ConstCheckedShl::checked_shl(self, bits)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::CheckedShr for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedShr for FixedUInt<T, N, P> {
     fn checked_shr(&self, bits: u32) -> Option<Self> {
         ConstCheckedShr::checked_shr(self, bits)
     }
@@ -543,19 +585,15 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: TestInt = FixedUInt {
-                array: [0b11001100, 0],
-            };
-            const B: TestInt = FixedUInt {
-                array: [0b10101010, 0],
-            };
+            const A: TestInt = FixedUInt::from_array([0b11001100, 0]);
+            const B: TestInt = FixedUInt::from_array([0b10101010, 0]);
 
             const NOT_A: TestInt = !A;
             const AND_AB: TestInt = A & B;
             const OR_AB: TestInt = A | B;
             const XOR_AB: TestInt = A ^ B;
-            const SHL_1: TestInt = FixedUInt { array: [1u8, 0] } << 4usize;
-            const SHR_16: TestInt = FixedUInt { array: [16u8, 0] } >> 2usize;
+            const SHL_1: TestInt = FixedUInt::from_array([1u8, 0]) << 4usize;
+            const SHR_16: TestInt = FixedUInt::from_array([16u8, 0]) >> 2usize;
 
             assert_eq!(NOT_A.array[0], 0b00110011);
             assert_eq!(AND_AB.array[0], 0b10001000);
@@ -640,7 +678,7 @@ mod tests {
     fn test_const_shift_traits_n0() {
         // Test with N=0 (zero-sized type)
         type ZeroInt = FixedUInt<u8, 0>;
-        let z = ZeroInt { array: [] };
+        let z = ZeroInt::from_array([]);
 
         // All shifts on zero-sized type should overflow
         assert_eq!(ConstOverflowingShl::overflowing_shl(&z, 0), (z, true));

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -185,14 +185,19 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shl(self, bits: u32) -> Self::Output {
-            self.shl(bits as usize)
+            // `bits as usize` would truncate on 16-bit-usize targets; route
+            // through the u32-aware normalizer that the Overflowing*/Unbounded
+            // paths already use.
+            let (shift, overflow) = normalize_shift_amount(bits, Self::BIT_SIZE);
+            if overflow { <Self as ConstZero>::zero() } else { self.shl(shift) }
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shr(self, bits: u32) -> Self::Output {
-            self.shr(bits as usize)
+            let (shift, overflow) = normalize_shift_amount(bits, Self::BIT_SIZE);
+            if overflow { <Self as ConstZero>::zero() } else { self.shr(shift) }
         }
     }
 
@@ -213,14 +218,14 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<&u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shl(self, bits: &u32) -> Self::Output {
-            self.shl(*bits as usize)
+            self.shl(*bits)
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<&u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shr(self, bits: &u32) -> Self::Output {
-            self.shr(*bits as usize)
+            self.shr(*bits)
         }
     }
 
@@ -242,14 +247,14 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<u32> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: u32) -> Self::Output {
-            (*self).shl(bits as usize)
+            (*self).shl(bits)
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<u32> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: u32) -> Self::Output {
-            (*self).shr(bits as usize)
+            (*self).shr(bits)
         }
     }
 
@@ -270,14 +275,14 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<&u32> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: &u32) -> Self::Output {
-            (*self).shl(*bits as usize)
+            (*self).shl(*bits)
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<&u32> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: &u32) -> Self::Output {
-            (*self).shr(*bits as usize)
+            (*self).shr(*bits)
         }
     }
 

--- a/src/fixeduint/checked_pow_impl.rs
+++ b/src/fixeduint/checked_pow_impl.rs
@@ -17,9 +17,10 @@
 use super::{FixedUInt, MachineWord};
 use crate::const_numtraits::{ConstCheckedMul, ConstCheckedPow, ConstOne};
 use crate::machineword::ConstMachineWord;
+use crate::personality::Nct;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedPow for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedPow for FixedUInt<T, N, Nct> {
         fn checked_pow(self, exp: u32) -> Option<Self> {
             if exp == 0 {
                 return Some(Self::one());
@@ -105,9 +106,9 @@ mod tests {
 
     c0nst::c0nst! {
         pub c0nst fn const_checked_pow<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            base: FixedUInt<T, N>,
+            base: FixedUInt<T, N, Nct>,
             exp: u32,
-        ) -> Option<FixedUInt<T, N>> {
+        ) -> Option<FixedUInt<T, N, Nct>> {
             ConstCheckedPow::checked_pow(base, exp)
         }
     }
@@ -123,9 +124,9 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const BASE: U16 = FixedUInt { array: [2, 0] };
+            const BASE: U16 = FixedUInt::from_array([2, 0]);
             const POW_RESULT: Option<U16> = const_checked_pow(BASE, 8);
-            assert_eq!(POW_RESULT, Some(FixedUInt { array: [0, 1] })); // 256 = [0, 1] in little-endian
+            assert_eq!(POW_RESULT, Some(FixedUInt::from_array([0, 1]))); // 256 = [0, 1] in little-endian
         }
     }
 }

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -20,6 +20,7 @@
 use super::{impl_from_be_bytes_slice, impl_from_le_bytes_slice, FixedUInt, MachineWord};
 use crate::const_numtraits::{ConstFromBytes, ConstToBytes};
 use crate::machineword::ConstMachineWord;
+use crate::personality::Personality;
 use core::mem::size_of;
 
 /// Compute byte length for FixedUInt<T, N>.
@@ -77,7 +78,7 @@ impl<const SIZE: usize> core::borrow::BorrowMut<[u8]> for ConstBytesHolder<SIZE>
 }
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstToBytes for FixedUInt<T, N>
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstToBytes for FixedUInt<T, N, P>
     where
         [(); byte_len::<T, N>()]:,
     {
@@ -120,18 +121,18 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstFromBytes for FixedUInt<T, N>
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstFromBytes for FixedUInt<T, N, P>
     where
         [(); byte_len::<T, N>()]:,
     {
         type Bytes = ConstBytesHolder<{ byte_len::<T, N>() }>;
 
         fn from_le_bytes(bytes: &Self::Bytes) -> Self {
-            Self { array: impl_from_le_bytes_slice::<T, N>(bytes.as_ref()) }
+            Self::from_array(impl_from_le_bytes_slice::<T, N>(bytes.as_ref()))
         }
 
         fn from_be_bytes(bytes: &Self::Bytes) -> Self {
-            Self { array: impl_from_be_bytes_slice::<T, N>(bytes.as_ref()) }
+            Self::from_array(impl_from_be_bytes_slice::<T, N>(bytes.as_ref()))
         }
     }
 }
@@ -159,9 +160,7 @@ mod tests {
 
     #[test]
     fn test_const_to_bytes_u32_words() {
-        let val: FixedUInt<u32, 2> = FixedUInt {
-            array: [0x04030201, 0x08070605],
-        };
+        let val: FixedUInt<u32, 2> = FixedUInt::from_array([0x04030201, 0x08070605]);
         let le_bytes = ConstToBytes::to_le_bytes(&val);
         assert_eq!(
             le_bytes.as_ref(),
@@ -177,9 +176,7 @@ mod tests {
 
     // Test that it works in const context
     const CONST_LE_BYTES: [u8; 4] = {
-        let val: FixedUInt<u8, 4> = FixedUInt {
-            array: [0x01, 0x02, 0x03, 0x04],
-        };
+        let val: FixedUInt<u8, 4> = FixedUInt::from_array([0x01, 0x02, 0x03, 0x04]);
         let holder = ConstToBytes::to_le_bytes(&val);
         holder.bytes
     };
@@ -238,9 +235,7 @@ mod tests {
     // Test roundtrip: to_bytes -> from_bytes
     #[test]
     fn test_const_bytes_roundtrip() {
-        let original: FixedUInt<u32, 2> = FixedUInt {
-            array: [0x12345678, 0xDEADBEEF],
-        };
+        let original: FixedUInt<u32, 2> = FixedUInt::from_array([0x12345678, 0xDEADBEEF]);
 
         let le_bytes = ConstToBytes::to_le_bytes(&original);
         let from_le: FixedUInt<u32, 2> = ConstFromBytes::from_le_bytes(&le_bytes);

--- a/src/fixeduint/div_ceil_impl.rs
+++ b/src/fixeduint/div_ceil_impl.rs
@@ -17,9 +17,10 @@
 use super::{const_div, const_is_zero, FixedUInt, MachineWord};
 use crate::const_numtraits::{ConstCheckedAdd, ConstDivCeil, ConstOne};
 use crate::machineword::ConstMachineWord;
+use crate::personality::Nct;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstDivCeil for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstDivCeil for FixedUInt<T, N, Nct> {
         fn div_ceil(self, rhs: Self) -> Self {
             match self.checked_div_ceil(rhs) {
                 Some(v) => v,
@@ -35,10 +36,10 @@ c0nst::c0nst! {
             let mut quotient = self.array;
             let remainder = const_div(&mut quotient, &rhs.array);
             if const_is_zero(&remainder) {
-                Some(Self { array: quotient })
+                Some(Self::from_array(quotient))
             } else {
                 // Use checked_add to return None on overflow
-                ConstCheckedAdd::checked_add(&Self { array: quotient }, &Self::one())
+                ConstCheckedAdd::checked_add(&Self::from_array(quotient), &Self::one())
             }
         }
     }
@@ -121,9 +122,9 @@ mod tests {
 
     c0nst::c0nst! {
         pub c0nst fn const_div_ceil<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
-        ) -> FixedUInt<T, N> {
+            a: FixedUInt<T, N, Nct>,
+            b: FixedUInt<T, N, Nct>,
+        ) -> FixedUInt<T, N, Nct> {
             ConstDivCeil::div_ceil(a, b)
         }
     }
@@ -139,10 +140,10 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const TEN: U16 = FixedUInt { array: [10, 0] };
-            const THREE: U16 = FixedUInt { array: [3, 0] };
+            const TEN: U16 = FixedUInt::from_array([10, 0]);
+            const THREE: U16 = FixedUInt::from_array([3, 0]);
             const RESULT: U16 = const_div_ceil(TEN, THREE);
-            assert_eq!(RESULT, FixedUInt { array: [4, 0] });
+            assert_eq!(RESULT, FixedUInt::from_array([4, 0]));
         }
     }
 }

--- a/src/fixeduint/euclid.rs
+++ b/src/fixeduint/euclid.rs
@@ -3,9 +3,10 @@ use num_traits::{CheckedEuclid, Euclid};
 use super::{FixedUInt, MachineWord};
 use crate::const_numtraits::{ConstCheckedEuclid, ConstEuclid, ConstZero};
 use crate::machineword::ConstMachineWord;
+use crate::personality::Nct;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstEuclid for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstEuclid for FixedUInt<T, N, Nct> {
         fn div_euclid(&self, v: &Self) -> Self {
             // For unsigned integers, Euclidean division is the same as regular division
             *self / *v
@@ -17,7 +18,7 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedEuclid for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedEuclid for FixedUInt<T, N, Nct> {
         fn checked_div_euclid(&self, v: &Self) -> Option<Self> {
             if v.is_zero() {
                 None
@@ -36,8 +37,8 @@ c0nst::c0nst! {
     }
 }
 
-// num_traits::Euclid - uses direct operators (no const bounds needed)
-impl<T: MachineWord, const N: usize> Euclid for FixedUInt<T, N> {
+// num_traits::Euclid — Nct only.
+impl<T: MachineWord, const N: usize> Euclid for FixedUInt<T, N, Nct> {
     fn div_euclid(&self, v: &Self) -> Self {
         self / v
     }
@@ -47,8 +48,8 @@ impl<T: MachineWord, const N: usize> Euclid for FixedUInt<T, N> {
     }
 }
 
-// num_traits::CheckedEuclid - uses direct checked calls (no const bounds needed)
-impl<T: MachineWord, const N: usize> CheckedEuclid for FixedUInt<T, N> {
+// num_traits::CheckedEuclid — Nct only.
+impl<T: MachineWord, const N: usize> CheckedEuclid for FixedUInt<T, N, Nct> {
     fn checked_div_euclid(&self, v: &Self) -> Option<Self> {
         num_traits::CheckedDiv::checked_div(self, v)
     }
@@ -88,30 +89,30 @@ mod tests {
 
     c0nst::c0nst! {
         pub c0nst fn const_div_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>,
-        ) -> FixedUInt<T, N> {
+            a: &FixedUInt<T, N, Nct>,
+            b: &FixedUInt<T, N, Nct>,
+        ) -> FixedUInt<T, N, Nct> {
             ConstEuclid::div_euclid(a, b)
         }
 
         pub c0nst fn const_rem_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>,
-        ) -> FixedUInt<T, N> {
+            a: &FixedUInt<T, N, Nct>,
+            b: &FixedUInt<T, N, Nct>,
+        ) -> FixedUInt<T, N, Nct> {
             ConstEuclid::rem_euclid(a, b)
         }
 
         pub c0nst fn const_checked_div_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>,
-        ) -> Option<FixedUInt<T, N>> {
+            a: &FixedUInt<T, N, Nct>,
+            b: &FixedUInt<T, N, Nct>,
+        ) -> Option<FixedUInt<T, N, Nct>> {
             ConstCheckedEuclid::checked_div_euclid(a, b)
         }
 
         pub c0nst fn const_checked_rem_euclid<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>,
-        ) -> Option<FixedUInt<T, N>> {
+            a: &FixedUInt<T, N, Nct>,
+            b: &FixedUInt<T, N, Nct>,
+        ) -> Option<FixedUInt<T, N, Nct>> {
             ConstCheckedEuclid::checked_rem_euclid(a, b)
         }
     }
@@ -127,16 +128,16 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [100, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [30, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([100, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([30, 0]);
             const DIV_RESULT: FixedUInt<u8, 2> = const_div_euclid(&A, &B);
             const REM_RESULT: FixedUInt<u8, 2> = const_rem_euclid(&A, &B);
             const CHECKED_DIV: Option<FixedUInt<u8, 2>> = const_checked_div_euclid(&A, &B);
             const CHECKED_REM: Option<FixedUInt<u8, 2>> = const_checked_rem_euclid(&A, &B);
-            assert_eq!(DIV_RESULT, FixedUInt { array: [3, 0] });
-            assert_eq!(REM_RESULT, FixedUInt { array: [10, 0] });
-            assert_eq!(CHECKED_DIV, Some(FixedUInt { array: [3, 0] }));
-            assert_eq!(CHECKED_REM, Some(FixedUInt { array: [10, 0] }));
+            assert_eq!(DIV_RESULT, FixedUInt::from_array([3, 0]));
+            assert_eq!(REM_RESULT, FixedUInt::from_array([10, 0]));
+            assert_eq!(CHECKED_DIV, Some(FixedUInt::from_array([3, 0])));
+            assert_eq!(CHECKED_REM, Some(FixedUInt::from_array([10, 0])));
         }
     }
 }

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -23,6 +23,7 @@ use crate::const_numtraits::{
 };
 use crate::machineword::ConstMachineWord;
 use crate::patch_num_traits::{CarryingMul, WideningMul};
+use crate::personality::Personality;
 
 c0nst::c0nst! {
     /// Add with carry input, returns sum and carry output.
@@ -63,17 +64,17 @@ c0nst::c0nst! {
         (result, borrow)
     }
 
-    impl<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + MachineWord, const N: usize> c0nst ConstCarryingAdd for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + MachineWord, const N: usize, P: Personality> c0nst ConstCarryingAdd for FixedUInt<T, N, P> {
         fn carrying_add(self, rhs: Self, carry: bool) -> (Self, bool) {
             let (array, carry_out) = add_with_carry(&self.array, &rhs.array, carry);
-            (Self { array }, carry_out)
+            (Self::from_array(array), carry_out)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + [c0nst] ConstBorrowingSub + MachineWord, const N: usize> c0nst ConstBorrowingSub for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + [c0nst] ConstBorrowingSub + MachineWord, const N: usize, P: Personality> c0nst ConstBorrowingSub for FixedUInt<T, N, P> {
         fn borrowing_sub(self, rhs: Self, borrow: bool) -> (Self, bool) {
             let (array, borrow_out) = sub_with_borrow(&self.array, &rhs.array, borrow);
-            (Self { array }, borrow_out)
+            (Self::from_array(array), borrow_out)
         }
     }
 
@@ -91,7 +92,7 @@ c0nst::c0nst! {
         if pos < N { lo[pos] = val; } else if pos < 2 * N { hi[pos - N] = val; }
     }
 
-    impl<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize> c0nst ConstWideningMul for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize, P: Personality> c0nst ConstWideningMul for FixedUInt<T, N, P> {
         fn widening_mul(self, rhs: Self) -> (Self, Self) {
             // Schoolbook multiplication: for each (i,j), add the 2-word product a[i]*b[j]
             // to result[i+j : i+j+2], propagating any carry upward.
@@ -132,11 +133,11 @@ c0nst::c0nst! {
                 i += 1;
             }
 
-            (Self { array: result_low }, Self { array: result_high })
+            (Self::from_array(result_low), Self::from_array(result_high))
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize> c0nst ConstCarryingMul for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize, P: Personality> c0nst ConstCarryingMul for FixedUInt<T, N, P> {
         fn carrying_mul(self, rhs: Self, carry: Self) -> (Self, Self) {
             // widening_mul + add carry to result
             let (lo, hi) = ConstWideningMul::widening_mul(self, rhs);
@@ -148,7 +149,7 @@ c0nst::c0nst! {
             let zeros = [T::zero(); N];
             let (hi2, _) = add_with_carry(&hi.array, &zeros, c);
 
-            (Self { array: lo2 }, Self { array: hi2 })
+            (Self::from_array(lo2), Self::from_array(hi2))
         }
 
         fn carrying_mul_add(self, rhs: Self, addend: Self, carry: Self) -> (Self, Self) {
@@ -166,14 +167,17 @@ c0nst::c0nst! {
             let (hi2, _) = add_with_carry(&hi.array, &zeros, c1);
             let (hi3, _) = add_with_carry(&hi2, &zeros, c2);
 
-            (Self { array: lo3 }, Self { array: hi3 })
+            (Self::from_array(lo3), Self::from_array(hi3))
         }
     }
 }
 
 /// Non-const widening multiplication that delegates to ConstWideningMul.
-impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, const N: usize>
-    WideningMul for FixedUInt<T, N>
+impl<
+        T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord,
+        const N: usize,
+        P: Personality,
+    > WideningMul for FixedUInt<T, N, P>
 {
     type Output = Self;
     fn widening_mul(self, rhs: Self) -> (Self, Self) {
@@ -182,18 +186,24 @@ impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, c
 }
 
 /// Ref-based widening multiplication — allows calling with references.
-impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, const N: usize>
-    WideningMul for &FixedUInt<T, N>
+impl<
+        T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord,
+        const N: usize,
+        P: Personality,
+    > WideningMul for &FixedUInt<T, N, P>
 {
-    type Output = FixedUInt<T, N>;
-    fn widening_mul(self, rhs: Self) -> (FixedUInt<T, N>, FixedUInt<T, N>) {
-        <FixedUInt<T, N> as ConstWideningMul>::widening_mul(*self, *rhs)
+    type Output = FixedUInt<T, N, P>;
+    fn widening_mul(self, rhs: Self) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
+        <FixedUInt<T, N, P> as ConstWideningMul>::widening_mul(*self, *rhs)
     }
 }
 
 /// Non-const carrying multiplication that delegates to ConstCarryingMul.
-impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, const N: usize>
-    CarryingMul for FixedUInt<T, N>
+impl<
+        T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord,
+        const N: usize,
+        P: Personality,
+    > CarryingMul for FixedUInt<T, N, P>
 {
     type Output = Self;
     fn carrying_mul(self, rhs: Self, carry: Self) -> (Self, Self) {
@@ -206,12 +216,15 @@ impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, c
 }
 
 /// Ref-based carrying multiplication — allows calling with references.
-impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, const N: usize>
-    CarryingMul for &FixedUInt<T, N>
+impl<
+        T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord,
+        const N: usize,
+        P: Personality,
+    > CarryingMul for &FixedUInt<T, N, P>
 {
-    type Output = FixedUInt<T, N>;
-    fn carrying_mul(self, rhs: Self, carry: Self) -> (FixedUInt<T, N>, FixedUInt<T, N>) {
-        <FixedUInt<T, N> as ConstCarryingMul>::carrying_mul(*self, *rhs, *carry)
+    type Output = FixedUInt<T, N, P>;
+    fn carrying_mul(self, rhs: Self, carry: Self) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
+        <FixedUInt<T, N, P> as ConstCarryingMul>::carrying_mul(*self, *rhs, *carry)
     }
 
     fn carrying_mul_add(
@@ -219,8 +232,8 @@ impl<T: ConstMachineWord + ConstCarryingAdd + ConstBorrowingSub + MachineWord, c
         rhs: Self,
         addend: Self,
         carry: Self,
-    ) -> (FixedUInt<T, N>, FixedUInt<T, N>) {
-        <FixedUInt<T, N> as ConstCarryingMul>::carrying_mul_add(*self, *rhs, *addend, *carry)
+    ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
+        <FixedUInt<T, N, P> as ConstCarryingMul>::carrying_mul_add(*self, *rhs, *addend, *carry)
     }
 }
 
@@ -232,43 +245,43 @@ mod tests {
     type U32 = FixedUInt<u8, 4>;
 
     c0nst::c0nst! {
-        pub c0nst fn const_carrying_add<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
+        pub c0nst fn const_carrying_add<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>,
             carry: bool,
-        ) -> (FixedUInt<T, N>, bool) {
+        ) -> (FixedUInt<T, N, P>, bool) {
             ConstCarryingAdd::carrying_add(a, b, carry)
         }
 
-        pub c0nst fn const_borrowing_sub<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
+        pub c0nst fn const_borrowing_sub<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>,
             borrow: bool,
-        ) -> (FixedUInt<T, N>, bool) {
+        ) -> (FixedUInt<T, N, P>, bool) {
             ConstBorrowingSub::borrowing_sub(a, b, borrow)
         }
 
-        pub c0nst fn const_widening_mul<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
-        ) -> (FixedUInt<T, N>, FixedUInt<T, N>) {
+        pub c0nst fn const_widening_mul<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>,
+        ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
             ConstWideningMul::widening_mul(a, b)
         }
 
-        pub c0nst fn const_carrying_mul<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
-            carry: FixedUInt<T, N>,
-        ) -> (FixedUInt<T, N>, FixedUInt<T, N>) {
+        pub c0nst fn const_carrying_mul<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>,
+            carry: FixedUInt<T, N, P>,
+        ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
             ConstCarryingMul::carrying_mul(a, b, carry)
         }
 
-        pub c0nst fn const_carrying_mul_add<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
-            addend: FixedUInt<T, N>,
-            carry: FixedUInt<T, N>,
-        ) -> (FixedUInt<T, N>, FixedUInt<T, N>) {
+        pub c0nst fn const_carrying_mul_add<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + [c0nst] ConstBorrowingSub + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>,
+            addend: FixedUInt<T, N, P>,
+            carry: FixedUInt<T, N, P>,
+        ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
             ConstCarryingMul::carrying_mul_add(a, b, addend, carry)
         }
     }
@@ -429,8 +442,8 @@ mod tests {
     fn test_const_context() {
         #[cfg(feature = "nightly")]
         {
-            const A: U16 = FixedUInt { array: [100, 0] };
-            const B: U16 = FixedUInt { array: [50, 0] };
+            const A: U16 = FixedUInt::from_array([100, 0]);
+            const B: U16 = FixedUInt::from_array([50, 0]);
 
             // Test carrying_add in const context
             const ADD_RESULT: (U16, bool) = const_carrying_add(A, B, false);
@@ -446,7 +459,7 @@ mod tests {
             assert!(!SUB_RESULT.1);
 
             // Test widening_mul in const context
-            const C: U16 = FixedUInt { array: [0, 1] }; // 256
+            const C: U16 = FixedUInt::from_array([0, 1]); // 256
             const MUL_RESULT: (U16, U16) = const_widening_mul(C, C);
             assert_eq!(MUL_RESULT.0, U16::from(0u8)); // 256*256 = 65536, low = 0
             assert_eq!(MUL_RESULT.1, U16::from(1u8)); // high = 1

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -17,53 +17,15 @@
 //! These operations expose carry/borrow inputs and outputs, and widening
 //! multiplication, useful for implementing arbitrary-precision arithmetic.
 
-use super::{FixedUInt, MachineWord};
+use super::{add_with_carry, sub_with_borrow, FixedUInt, MachineWord};
 use crate::const_numtraits::{
     ConstBorrowingSub, ConstCarryingAdd, ConstCarryingMul, ConstWideningMul,
 };
 use crate::machineword::ConstMachineWord;
 use crate::patch_num_traits::{CarryingMul, WideningMul};
-use crate::personality::Personality;
+use crate::personality::{Personality, PersonalityTag};
 
 c0nst::c0nst! {
-    /// Add with carry input, returns sum and carry output.
-    /// Uses ConstCarryingAdd on limb types for consistency.
-    c0nst fn add_with_carry<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd, const N: usize>(
-        a: &[T; N],
-        b: &[T; N],
-        carry_in: bool,
-    ) -> ([T; N], bool) {
-        let mut result = [T::zero(); N];
-        let mut carry = carry_in;
-        let mut i = 0usize;
-        while i < N {
-            let (sum, c) = ConstCarryingAdd::carrying_add(a[i], b[i], carry);
-            result[i] = sum;
-            carry = c;
-            i += 1;
-        }
-        (result, carry)
-    }
-
-    /// Subtract with borrow input, returns difference and borrow output.
-    /// Uses ConstBorrowingSub on limb types for consistency.
-    c0nst fn sub_with_borrow<T: [c0nst] ConstMachineWord + [c0nst] ConstBorrowingSub, const N: usize>(
-        a: &[T; N],
-        b: &[T; N],
-        borrow_in: bool,
-    ) -> ([T; N], bool) {
-        let mut result = [T::zero(); N];
-        let mut borrow = borrow_in;
-        let mut i = 0usize;
-        while i < N {
-            let (diff, b) = ConstBorrowingSub::borrowing_sub(a[i], b[i], borrow);
-            result[i] = diff;
-            borrow = b;
-            i += 1;
-        }
-        (result, borrow)
-    }
-
     impl<T: [c0nst] ConstMachineWord + [c0nst] ConstCarryingAdd + MachineWord, const N: usize, P: Personality> c0nst ConstCarryingAdd for FixedUInt<T, N, P> {
         fn carrying_add(self, rhs: Self, carry: bool) -> (Self, bool) {
             let (array, carry_out) = add_with_carry(&self.array, &rhs.array, carry);
@@ -117,15 +79,34 @@ c0nst::c0nst! {
                     let (sum1, c1) = ConstCarryingAdd::carrying_add(cur1, mul_hi, c0);
                     set_at(&mut result_low, &mut result_high, pos + 1, sum1);
 
-                    // Step 3: propagate any remaining carry
+                    // Step 3: propagate any remaining carry. Dispatched on
+                    // personality so Nct keeps the original fast early-exit
+                    // (the tail is the inner-inner loop of Montgomery
+                    // multiplication and matters a lot for verify-side
+                    // throughput). Ct iterates the full tail unconditionally
+                    // so the loop length depends only on the public outer
+                    // counters i, j.
                     let mut carry = c1;
                     let mut p = pos + 2;
-                    while carry && p < 2 * N {
-                        let cur = get_at(&result_low, &result_high, p);
-                        let (sum, c) = ConstCarryingAdd::carrying_add(cur, T::zero(), true);
-                        set_at(&mut result_low, &mut result_high, p, sum);
-                        carry = c;
-                        p += 1;
+                    match P::TAG {
+                        PersonalityTag::Nct => {
+                            while carry && p < 2 * N {
+                                let cur = get_at(&result_low, &result_high, p);
+                                let (sum, c) = ConstCarryingAdd::carrying_add(cur, T::zero(), true);
+                                set_at(&mut result_low, &mut result_high, p, sum);
+                                carry = c;
+                                p += 1;
+                            }
+                        }
+                        PersonalityTag::Ct => {
+                            while p < 2 * N {
+                                let cur = get_at(&result_low, &result_high, p);
+                                let (sum, c) = ConstCarryingAdd::carrying_add(cur, T::zero(), carry);
+                                set_at(&mut result_low, &mut result_high, p, sum);
+                                carry = c;
+                                p += 1;
+                            }
+                        }
                     }
 
                     j += 1;

--- a/src/fixeduint/ilog_impl.rs
+++ b/src/fixeduint/ilog_impl.rs
@@ -15,11 +15,12 @@
 //! Integer logarithm implementations for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::{ConstIlog, ConstPrimInt, ConstZero};
+use crate::const_numtraits::{ConstBitPrimInt, ConstIlog, ConstZero};
 use crate::machineword::ConstMachineWord;
+use crate::personality::Nct;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstIlog for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstIlog for FixedUInt<T, N, Nct> {
         fn ilog2(self) -> u32 {
             match self.checked_ilog2() {
                 Some(v) => v,
@@ -46,7 +47,7 @@ c0nst::c0nst! {
                 return None;
             }
             // ilog2 = position of highest set bit = BIT_SIZE - 1 - leading_zeros
-            let leading = ConstPrimInt::leading_zeros(self);
+            let leading = ConstBitPrimInt::leading_zeros(self);
             Some(Self::BIT_SIZE as u32 - 1 - leading)
         }
 
@@ -184,13 +185,13 @@ mod tests {
 
     c0nst::c0nst! {
         pub c0nst fn const_ilog2<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            v: FixedUInt<T, N>,
+            v: FixedUInt<T, N, Nct>,
         ) -> u32 {
             ConstIlog::ilog2(v)
         }
 
         pub c0nst fn const_ilog10<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            v: FixedUInt<T, N>,
+            v: FixedUInt<T, N, Nct>,
         ) -> u32 {
             ConstIlog::ilog10(v)
         }
@@ -205,8 +206,8 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const EIGHT: U16 = FixedUInt { array: [8, 0] };
-            const HUNDRED: U16 = FixedUInt { array: [100, 0] };
+            const EIGHT: U16 = FixedUInt::from_array([8, 0]);
+            const HUNDRED: U16 = FixedUInt::from_array([100, 0]);
             const LOG2_RESULT: u32 = const_ilog2(EIGHT);
             const LOG10_RESULT: u32 = const_ilog10(HUNDRED);
             assert_eq!(LOG2_RESULT, 3);

--- a/src/fixeduint/isqrt_impl.rs
+++ b/src/fixeduint/isqrt_impl.rs
@@ -15,11 +15,12 @@
 //! Integer square root for FixedUInt.
 
 use super::{const_set_bit, FixedUInt, MachineWord};
-use crate::const_numtraits::{ConstIsqrt, ConstPrimInt, ConstZero};
+use crate::const_numtraits::{ConstBitPrimInt, ConstIsqrt, ConstZero};
 use crate::machineword::ConstMachineWord;
+use crate::personality::Nct;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstIsqrt for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstIsqrt for FixedUInt<T, N, Nct> {
         fn isqrt(self) -> Self {
             // For unsigned types, isqrt always succeeds
             match ConstIsqrt::checked_isqrt(self) {
@@ -40,7 +41,7 @@ c0nst::c0nst! {
             let mut result = Self::zero();
 
             // Find starting bit position: half of the bit length of self
-            let bit_len = Self::BIT_SIZE - ConstPrimInt::leading_zeros(self) as usize;
+            let bit_len = Self::BIT_SIZE - ConstBitPrimInt::leading_zeros(self) as usize;
             let start_bit = bit_len.div_ceil(2);
 
             let mut bit_pos = start_bit;
@@ -193,8 +194,8 @@ mod tests {
 
     c0nst::c0nst! {
         pub c0nst fn const_isqrt<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            v: FixedUInt<T, N>,
-        ) -> FixedUInt<T, N> {
+            v: FixedUInt<T, N, Nct>,
+        ) -> FixedUInt<T, N, Nct> {
             ConstIsqrt::isqrt(v)
         }
     }
@@ -208,9 +209,9 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const SIXTEEN: U16 = FixedUInt { array: [16, 0] };
+            const SIXTEEN: U16 = FixedUInt::from_array([16, 0]);
             const RESULT: U16 = const_isqrt(SIXTEEN);
-            assert_eq!(RESULT, FixedUInt { array: [4, 0] });
+            assert_eq!(RESULT, FixedUInt::from_array([4, 0]));
         }
     }
 }

--- a/src/fixeduint/iter_impl.rs
+++ b/src/fixeduint/iter_impl.rs
@@ -1,25 +1,30 @@
 use super::{FixedUInt, MachineWord};
+use crate::personality::Personality;
 use num_traits::{One, Zero};
 
-impl<T: MachineWord, const N: usize> core::iter::Sum for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> core::iter::Sum for FixedUInt<T, N, P> {
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |acc, x| acc + x)
     }
 }
 
-impl<'a, T: MachineWord, const N: usize> core::iter::Sum<&'a Self> for FixedUInt<T, N> {
+impl<'a, T: MachineWord, const N: usize, P: Personality> core::iter::Sum<&'a Self>
+    for FixedUInt<T, N, P>
+{
     fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), |acc, x| acc + *x)
     }
 }
 
-impl<T: MachineWord, const N: usize> core::iter::Product for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> core::iter::Product for FixedUInt<T, N, P> {
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::one(), |acc, x| acc * x)
     }
 }
 
-impl<'a, T: MachineWord, const N: usize> core::iter::Product<&'a Self> for FixedUInt<T, N> {
+impl<'a, T: MachineWord, const N: usize, P: Personality> core::iter::Product<&'a Self>
+    for FixedUInt<T, N, P>
+{
     fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::one(), |acc, x| acc * *x)
     }

--- a/src/fixeduint/midpoint_impl.rs
+++ b/src/fixeduint/midpoint_impl.rs
@@ -17,9 +17,10 @@
 use super::{FixedUInt, MachineWord};
 use crate::const_numtraits::ConstMidpoint;
 use crate::machineword::ConstMachineWord;
+use crate::personality::Personality;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstMidpoint for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstMidpoint for FixedUInt<T, N, P> {
         fn midpoint(self, rhs: Self) -> Self {
             // (a & b) + ((a ^ b) >> 1) avoids overflow
             (self & rhs) + ((self ^ rhs) >> 1usize)
@@ -71,10 +72,10 @@ mod tests {
     }
 
     c0nst::c0nst! {
-        pub c0nst fn const_midpoint<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
-        ) -> FixedUInt<T, N> {
+        pub c0nst fn const_midpoint<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            a: FixedUInt<T, N, P>,
+            b: FixedUInt<T, N, P>,
+        ) -> FixedUInt<T, N, P> {
             ConstMidpoint::midpoint(a, b)
         }
     }
@@ -90,15 +91,13 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: U16 = FixedUInt { array: [0, 0] };
-            const B: U16 = FixedUInt { array: [10, 0] };
+            const A: U16 = FixedUInt::from_array([0, 0]);
+            const B: U16 = FixedUInt::from_array([10, 0]);
             const MID: U16 = const_midpoint(A, B);
-            assert_eq!(MID, FixedUInt { array: [5, 0] });
+            assert_eq!(MID, FixedUInt::from_array([5, 0]));
 
             // Test with max values
-            const MAX: U16 = FixedUInt {
-                array: [0xFF, 0xFF],
-            };
+            const MAX: U16 = FixedUInt::from_array([0xFF, 0xFF]);
             const MID_MAX: U16 = const_midpoint(MAX, MAX);
             assert_eq!(MID_MAX, MAX);
         }

--- a/src/fixeduint/mul_acc_ops_impl.rs
+++ b/src/fixeduint/mul_acc_ops_impl.rs
@@ -8,66 +8,108 @@ use super::{FixedUInt, MachineWord};
 use crate::const_numtraits::{ConstCarryingAdd, ConstZero};
 use crate::mul_acc_ops::MulAccOps;
 use crate::patch_num_traits::CarryingMul;
+use crate::personality::{Ct, Nct};
 
-impl<T, const N: usize> MulAccOps for FixedUInt<T, N>
+macro_rules! mul_acc_ops_common {
+    () => {
+        type Word = T;
+
+        fn word_count() -> usize {
+            N
+        }
+
+        fn mul_acc_row(scalar: T, multiplicand: &Self, acc: &mut Self, carry_in: T) -> T {
+            let mut carry = carry_in;
+            let mut j = 0;
+            while j < N {
+                let (lo, hi) = CarryingMul::carrying_mul_add(
+                    scalar,
+                    multiplicand.array[j],
+                    acc.array[j],
+                    carry,
+                );
+                acc.array[j] = lo;
+                carry = hi;
+                j += 1;
+            }
+            carry
+        }
+
+        fn mul_acc_shift_row(scalar: T, multiplicand: &Self, acc: &mut Self, acc_hi: T) -> T {
+            debug_assert!(N > 0, "MulAccOps requires at least one word");
+            // First word: discarded (zero by construction)
+            let (_, mut carry) = CarryingMul::carrying_mul_add(
+                scalar,
+                multiplicand.array[0],
+                acc.array[0],
+                <T as ConstZero>::zero(),
+            );
+
+            // Remaining words: shift down by one position
+            let mut j = 1;
+            while j < N {
+                let (lo, hi) = CarryingMul::carrying_mul_add(
+                    scalar,
+                    multiplicand.array[j],
+                    acc.array[j],
+                    carry,
+                );
+                acc.array[j - 1] = lo;
+                carry = hi;
+                j += 1;
+            }
+
+            // Fold acc_hi + carry into acc[N-1]
+            let (sum, overflow) = <T as ConstCarryingAdd>::carrying_add(acc_hi, carry, false);
+            acc.array[N - 1] = sum;
+
+            // Branchless: convert overflow bool to word via carrying_add(0, 0, overflow)
+            let (overflow_word, _) = <T as ConstCarryingAdd>::carrying_add(
+                <T as ConstZero>::zero(),
+                <T as ConstZero>::zero(),
+                overflow,
+            );
+            overflow_word
+        }
+    };
+}
+
+impl<T, const N: usize> MulAccOps for FixedUInt<T, N, Nct>
 where
     T: MachineWord + CarryingMul<Output = T> + ConstCarryingAdd,
 {
-    type Word = T;
-
-    fn word_count() -> usize {
-        N
-    }
+    type GetWordOutput = Option<T>;
 
     fn get_word(&self, i: usize) -> Option<T> {
         self.array.get(i).copied()
     }
 
-    fn mul_acc_row(scalar: T, multiplicand: &Self, acc: &mut Self, carry_in: T) -> T {
-        let mut carry = carry_in;
+    mul_acc_ops_common!();
+}
+
+impl<T, const N: usize> MulAccOps for FixedUInt<T, N, Ct>
+where
+    T: MachineWord + CarryingMul<Output = T> + ConstCarryingAdd + subtle::ConditionallySelectable,
+{
+    type GetWordOutput = subtle::CtOption<T>;
+
+    fn get_word(&self, i: usize) -> subtle::CtOption<T> {
+        use subtle::{Choice, CtOption};
+        let mut selected = <T as ConstZero>::zero();
         let mut j = 0;
         while j < N {
-            let (lo, hi) =
-                CarryingMul::carrying_mul_add(scalar, multiplicand.array[j], acc.array[j], carry);
-            acc.array[j] = lo;
-            carry = hi;
+            let is_target = Choice::from((j == i) as u8);
+            selected = <T as subtle::ConditionallySelectable>::conditional_select(
+                &selected,
+                &self.array[j],
+                is_target,
+            );
             j += 1;
         }
-        carry
+        CtOption::new(selected, Choice::from((i < N) as u8))
     }
 
-    fn mul_acc_shift_row(scalar: T, multiplicand: &Self, acc: &mut Self, acc_hi: T) -> T {
-        debug_assert!(N > 0, "MulAccOps requires at least one word");
-        // First word: discarded (zero by construction)
-        let (_, mut carry) = CarryingMul::carrying_mul_add(
-            scalar,
-            multiplicand.array[0],
-            acc.array[0],
-            <T as ConstZero>::zero(),
-        );
-
-        // Remaining words: shift down by one position
-        let mut j = 1;
-        while j < N {
-            let (lo, hi) =
-                CarryingMul::carrying_mul_add(scalar, multiplicand.array[j], acc.array[j], carry);
-            acc.array[j - 1] = lo;
-            carry = hi;
-            j += 1;
-        }
-
-        // Fold acc_hi + carry into acc[N-1]
-        let (sum, overflow) = <T as ConstCarryingAdd>::carrying_add(acc_hi, carry, false);
-        acc.array[N - 1] = sum;
-
-        // Branchless: convert overflow bool to word via carrying_add(0, 0, overflow)
-        let (overflow_word, _) = <T as ConstCarryingAdd>::carrying_add(
-            <T as ConstZero>::zero(),
-            <T as ConstZero>::zero(),
-            overflow,
-        );
-        overflow_word
-    }
+    mul_acc_ops_common!();
 }
 
 #[cfg(test)]

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -1,12 +1,15 @@
-use super::{const_div_rem, const_mul, maybe_panic, FixedUInt, MachineWord, PanicReason};
+use super::{
+    const_ct_select, const_div_rem, const_mul, maybe_panic_if, FixedUInt, MachineWord, PanicReason,
+};
 use crate::const_numtraits::{
     ConstBounded, ConstCheckedDiv, ConstCheckedMul, ConstCheckedRem, ConstOverflowingMul,
     ConstSaturatingMul, ConstWrappingMul, ConstZero,
 };
 use crate::machineword::ConstMachineWord;
+use crate::personality::{Nct, Personality, PersonalityTag};
 
-impl<T: MachineWord, const N: usize> num_traits::ops::overflowing::OverflowingMul
-    for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::overflowing::OverflowingMul
+    for FixedUInt<T, N, P>
 {
     fn overflowing_mul(&self, other: &Self) -> (Self, bool) {
         <Self as ConstOverflowingMul>::overflowing_mul(self, other)
@@ -14,127 +17,118 @@ impl<T: MachineWord, const N: usize> num_traits::ops::overflowing::OverflowingMu
 }
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstOverflowingMul for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstOverflowingMul for FixedUInt<T, N, P> {
         fn overflowing_mul(&self, other: &Self) -> (Self, bool) {
             let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
-            (Self { array }, overflow)
+            (Self::from_array(array), overflow)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstWrappingMul for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstWrappingMul for FixedUInt<T, N, P> {
         fn wrapping_mul(&self, other: &Self) -> Self {
             let (array, _) = const_mul::<T, N, false>(&self.array, &other.array, Self::WORD_BITS);
-            Self { array }
+            Self::from_array(array)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedMul for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstCheckedMul for FixedUInt<T, N, P> {
         fn checked_mul(&self, other: &Self) -> Option<Self> {
             let (res, overflow) = <Self as ConstOverflowingMul>::overflowing_mul(self, other);
             if overflow { None } else { Some(res) }
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstSaturatingMul for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstSaturatingMul for FixedUInt<T, N, P> {
         fn saturating_mul(&self, other: &Self) -> Self {
             let (res, overflow) = <Self as ConstOverflowingMul>::overflowing_mul(self, other);
-            if overflow { <Self as ConstBounded>::max_value() } else { res }
+            match P::TAG {
+                PersonalityTag::Nct => if overflow { <Self as ConstBounded>::max_value() } else { res },
+                PersonalityTag::Ct => const_ct_select(res, <Self as ConstBounded>::max_value(), overflow as u8),
+            }
         }
     }
 }
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul for FixedUInt<T, N, P> {
         type Output = Self;
         fn mul(self, other: Self) -> Self::Output {
             let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
-            if overflow {
-                maybe_panic(PanicReason::Mul);
-            }
-            Self { array }
+            maybe_panic_if::<P>(overflow, PanicReason::Mul);
+            Self::from_array(array)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul<&FixedUInt<T, N>> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul<&FixedUInt<T, N, P>> for FixedUInt<T, N, P> {
         type Output = Self;
-        fn mul(self, other: &FixedUInt<T, N>) -> Self::Output {
+        fn mul(self, other: &FixedUInt<T, N, P>) -> Self::Output {
             let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
-            if overflow {
-                maybe_panic(PanicReason::Mul);
-            }
-            Self { array }
+            maybe_panic_if::<P>(overflow, PanicReason::Mul);
+            Self::from_array(array)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul<FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn mul(self, other: FixedUInt<T, N>) -> Self::Output {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn mul(self, other: FixedUInt<T, N, P>) -> Self::Output {
             let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
-            if overflow {
-                maybe_panic(PanicReason::Mul);
-            }
-            FixedUInt { array }
+            maybe_panic_if::<P>(overflow, PanicReason::Mul);
+            FixedUInt::from_array(array)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul<&FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn mul(self, other: &FixedUInt<T, N>) -> Self::Output {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul<&FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn mul(self, other: &FixedUInt<T, N, P>) -> Self::Output {
             let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
-            if overflow {
-                maybe_panic(PanicReason::Mul);
-            }
-            FixedUInt { array }
+            maybe_panic_if::<P>(overflow, PanicReason::Mul);
+            FixedUInt::from_array(array)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Mul<&&FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn mul(self, other: &&FixedUInt<T, N>) -> Self::Output {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul<&&FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
+        fn mul(self, other: &&FixedUInt<T, N, P>) -> Self::Output {
             let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
-            if overflow {
-                maybe_panic(PanicReason::Mul);
-            }
-            FixedUInt { array }
+            maybe_panic_if::<P>(overflow, PanicReason::Mul);
+            FixedUInt::from_array(array)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::MulAssign for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::MulAssign for FixedUInt<T, N, P> {
         fn mul_assign(&mut self, other: Self) {
             let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
-            if overflow {
-                maybe_panic(PanicReason::Mul);
-            }
-            *self = Self { array };
+            maybe_panic_if::<P>(overflow, PanicReason::Mul);
+            *self = Self::from_array(array);
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::MulAssign<&FixedUInt<T, N>> for FixedUInt<T, N> {
-        fn mul_assign(&mut self, other: &FixedUInt<T, N>) {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::MulAssign<&FixedUInt<T, N, P>> for FixedUInt<T, N, P> {
+        fn mul_assign(&mut self, other: &FixedUInt<T, N, P>) {
             let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
-            if overflow {
-                maybe_panic(PanicReason::Mul);
-            }
-            *self = Self { array };
+            maybe_panic_if::<P>(overflow, PanicReason::Mul);
+            *self = Self::from_array(array);
         }
     }
 }
 
 // num_traits wrappers - delegate to const versions
-impl<T: MachineWord, const N: usize> num_traits::WrappingMul for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingMul
+    for FixedUInt<T, N, P>
+{
     fn wrapping_mul(&self, other: &Self) -> Self {
         <Self as ConstWrappingMul>::wrapping_mul(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::CheckedMul for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedMul for FixedUInt<T, N, P> {
     fn checked_mul(&self, other: &Self) -> Option<Self> {
         <Self as ConstCheckedMul>::checked_mul(self, other)
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::ops::saturating::SaturatingMul
-    for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::saturating::SaturatingMul
+    for FixedUInt<T, N, P>
 {
     fn saturating_mul(&self, other: &Self) -> Self {
         <Self as ConstSaturatingMul>::saturating_mul(self, other)
@@ -142,49 +136,49 @@ impl<T: MachineWord, const N: usize> num_traits::ops::saturating::SaturatingMul
 }
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Div for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Div for FixedUInt<T, N, Nct> {
         type Output = Self;
         fn div(self, other: Self) -> Self::Output {
-            Self { array: const_div_rem(&self.array, &other.array).0 }
+            Self::from_array(const_div_rem(&self.array, &other.array).0)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Div<&FixedUInt<T, N>> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Div<&FixedUInt<T, N, Nct>> for FixedUInt<T, N, Nct> {
         type Output = Self;
-        fn div(self, other: &FixedUInt<T, N>) -> Self::Output {
-            Self { array: const_div_rem(&self.array, &other.array).0 }
+        fn div(self, other: &FixedUInt<T, N, Nct>) -> Self::Output {
+            Self::from_array(const_div_rem(&self.array, &other.array).0)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Div<FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn div(self, other: FixedUInt<T, N>) -> Self::Output {
-            Self::Output { array: const_div_rem(&self.array, &other.array).0 }
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Div<FixedUInt<T, N, Nct>> for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
+        fn div(self, other: FixedUInt<T, N, Nct>) -> Self::Output {
+            Self::Output::from_array(const_div_rem(&self.array, &other.array).0)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Div<&FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn div(self, other: &FixedUInt<T, N>) -> Self::Output {
-            Self::Output { array: const_div_rem(&self.array, &other.array).0 }
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Div<&FixedUInt<T, N, Nct>> for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
+        fn div(self, other: &FixedUInt<T, N, Nct>) -> Self::Output {
+            Self::Output::from_array(const_div_rem(&self.array, &other.array).0)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::DivAssign for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::DivAssign for FixedUInt<T, N, Nct> {
         fn div_assign(&mut self, other: Self) {
             self.array = const_div_rem(&self.array, &other.array).0;
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::DivAssign<&FixedUInt<T, N>> for FixedUInt<T, N> {
-        fn div_assign(&mut self, other: &FixedUInt<T, N>) {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::DivAssign<&FixedUInt<T, N, Nct>> for FixedUInt<T, N, Nct> {
+        fn div_assign(&mut self, other: &FixedUInt<T, N, Nct>) {
             self.array = const_div_rem(&self.array, &other.array).0;
         }
     }
 }
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedDiv for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedDiv for FixedUInt<T, N, Nct> {
         fn checked_div(&self, other: &Self) -> Option<Self> {
             if <Self as ConstZero>::is_zero(other) {
                 None
@@ -195,56 +189,56 @@ c0nst::c0nst! {
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::CheckedDiv for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize> num_traits::CheckedDiv for FixedUInt<T, N, Nct> {
     fn checked_div(&self, other: &Self) -> Option<Self> {
         <Self as ConstCheckedDiv>::checked_div(self, other)
     }
 }
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Rem for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Rem for FixedUInt<T, N, Nct> {
         type Output = Self;
         fn rem(self, other: Self) -> Self::Output {
-            Self { array: const_div_rem(&self.array, &other.array).1 }
+            Self::from_array(const_div_rem(&self.array, &other.array).1)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Rem<&FixedUInt<T, N>> for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Rem<&FixedUInt<T, N, Nct>> for FixedUInt<T, N, Nct> {
         type Output = Self;
-        fn rem(self, other: &FixedUInt<T, N>) -> Self::Output {
-            Self { array: const_div_rem(&self.array, &other.array).1 }
+        fn rem(self, other: &FixedUInt<T, N, Nct>) -> Self::Output {
+            Self::from_array(const_div_rem(&self.array, &other.array).1)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Rem<FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn rem(self, other: FixedUInt<T, N>) -> Self::Output {
-            Self::Output { array: const_div_rem(&self.array, &other.array).1 }
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Rem<FixedUInt<T, N, Nct>> for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
+        fn rem(self, other: FixedUInt<T, N, Nct>) -> Self::Output {
+            Self::Output::from_array(const_div_rem(&self.array, &other.array).1)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Rem<&FixedUInt<T, N>> for &FixedUInt<T, N> {
-        type Output = FixedUInt<T, N>;
-        fn rem(self, other: &FixedUInt<T, N>) -> Self::Output {
-            Self::Output { array: const_div_rem(&self.array, &other.array).1 }
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::Rem<&FixedUInt<T, N, Nct>> for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
+        fn rem(self, other: &FixedUInt<T, N, Nct>) -> Self::Output {
+            Self::Output::from_array(const_div_rem(&self.array, &other.array).1)
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::RemAssign for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::RemAssign for FixedUInt<T, N, Nct> {
         fn rem_assign(&mut self, other: Self) {
             self.array = const_div_rem(&self.array, &other.array).1;
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::RemAssign<&FixedUInt<T, N>> for FixedUInt<T, N> {
-        fn rem_assign(&mut self, other: &FixedUInt<T, N>) {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst core::ops::RemAssign<&FixedUInt<T, N, Nct>> for FixedUInt<T, N, Nct> {
+        fn rem_assign(&mut self, other: &FixedUInt<T, N, Nct>) {
             self.array = const_div_rem(&self.array, &other.array).1;
         }
     }
 }
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedRem for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstCheckedRem for FixedUInt<T, N, Nct> {
         fn checked_rem(&self, other: &Self) -> Option<Self> {
             if <Self as ConstZero>::is_zero(other) {
                 None
@@ -255,7 +249,7 @@ c0nst::c0nst! {
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::CheckedRem for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize> num_traits::CheckedRem for FixedUInt<T, N, Nct> {
     fn checked_rem(&self, other: &Self) -> Option<Self> {
         <Self as ConstCheckedRem>::checked_rem(self, other)
     }
@@ -264,46 +258,46 @@ impl<T: MachineWord, const N: usize> num_traits::CheckedRem for FixedUInt<T, N> 
 // Test wrappers for const mul traits
 #[cfg(test)]
 c0nst::c0nst! {
-    pub c0nst fn const_wrapping_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-        a: &FixedUInt<T, N>,
-        b: &FixedUInt<T, N>
-    ) -> FixedUInt<T, N> {
-        <FixedUInt<T, N> as ConstWrappingMul>::wrapping_mul(a, b)
+    pub c0nst fn const_wrapping_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+        a: &FixedUInt<T, N, P>,
+        b: &FixedUInt<T, N, P>
+    ) -> FixedUInt<T, N, P> {
+        <FixedUInt<T, N, P> as ConstWrappingMul>::wrapping_mul(a, b)
     }
 
-    pub c0nst fn const_checked_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-        a: &FixedUInt<T, N>,
-        b: &FixedUInt<T, N>
-    ) -> Option<FixedUInt<T, N>> {
-        <FixedUInt<T, N> as ConstCheckedMul>::checked_mul(a, b)
+    pub c0nst fn const_checked_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+        a: &FixedUInt<T, N, P>,
+        b: &FixedUInt<T, N, P>
+    ) -> Option<FixedUInt<T, N, P>> {
+        <FixedUInt<T, N, P> as ConstCheckedMul>::checked_mul(a, b)
     }
 
-    pub c0nst fn const_saturating_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-        a: &FixedUInt<T, N>,
-        b: &FixedUInt<T, N>
-    ) -> FixedUInt<T, N> {
-        <FixedUInt<T, N> as ConstSaturatingMul>::saturating_mul(a, b)
+    pub c0nst fn const_saturating_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+        a: &FixedUInt<T, N, P>,
+        b: &FixedUInt<T, N, P>
+    ) -> FixedUInt<T, N, P> {
+        <FixedUInt<T, N, P> as ConstSaturatingMul>::saturating_mul(a, b)
     }
 
-    pub c0nst fn const_overflowing_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-        a: &FixedUInt<T, N>,
-        b: &FixedUInt<T, N>
-    ) -> (FixedUInt<T, N>, bool) {
-        <FixedUInt<T, N> as ConstOverflowingMul>::overflowing_mul(a, b)
+    pub c0nst fn const_overflowing_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+        a: &FixedUInt<T, N, P>,
+        b: &FixedUInt<T, N, P>
+    ) -> (FixedUInt<T, N, P>, bool) {
+        <FixedUInt<T, N, P> as ConstOverflowingMul>::overflowing_mul(a, b)
     }
 
     pub c0nst fn const_checked_div<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-        a: &FixedUInt<T, N>,
-        b: &FixedUInt<T, N>
-    ) -> Option<FixedUInt<T, N>> {
-        <FixedUInt<T, N> as ConstCheckedDiv>::checked_div(a, b)
+        a: &FixedUInt<T, N, Nct>,
+        b: &FixedUInt<T, N, Nct>
+    ) -> Option<FixedUInt<T, N, Nct>> {
+        <FixedUInt<T, N, Nct> as ConstCheckedDiv>::checked_div(a, b)
     }
 
     pub c0nst fn const_checked_rem<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-        a: &FixedUInt<T, N>,
-        b: &FixedUInt<T, N>
-    ) -> Option<FixedUInt<T, N>> {
-        <FixedUInt<T, N> as ConstCheckedRem>::checked_rem(a, b)
+        a: &FixedUInt<T, N, Nct>,
+        b: &FixedUInt<T, N, Nct>
+    ) -> Option<FixedUInt<T, N, Nct>> {
+        <FixedUInt<T, N, Nct> as ConstCheckedRem>::checked_rem(a, b)
     }
 }
 
@@ -403,8 +397,8 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [12, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [3, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([12, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([3, 0]);
 
             const WRAPPING_RESULT: FixedUInt<u8, 2> = const_wrapping_mul(&A, &B);
             assert_eq!(WRAPPING_RESULT.array, [36, 0]);
@@ -447,18 +441,18 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const A: FixedUInt<u8, 2> = FixedUInt { array: [36, 0] };
-            const B: FixedUInt<u8, 2> = FixedUInt { array: [5, 0] };
-            const ZERO: FixedUInt<u8, 2> = FixedUInt { array: [0, 0] };
+            const A: FixedUInt<u8, 2> = FixedUInt::from_array([36, 0]);
+            const B: FixedUInt<u8, 2> = FixedUInt::from_array([5, 0]);
+            const ZERO: FixedUInt<u8, 2> = FixedUInt::from_array([0, 0]);
 
             const CHECKED_DIV_OK: Option<FixedUInt<u8, 2>> = const_checked_div(&A, &B);
             const CHECKED_DIV_ZERO: Option<FixedUInt<u8, 2>> = const_checked_div(&A, &ZERO);
             const CHECKED_REM_OK: Option<FixedUInt<u8, 2>> = const_checked_rem(&A, &B);
             const CHECKED_REM_ZERO: Option<FixedUInt<u8, 2>> = const_checked_rem(&A, &ZERO);
 
-            assert_eq!(CHECKED_DIV_OK, Some(FixedUInt { array: [7, 0] }));
+            assert_eq!(CHECKED_DIV_OK, Some(FixedUInt::from_array([7, 0])));
             assert_eq!(CHECKED_DIV_ZERO, None);
-            assert_eq!(CHECKED_REM_OK, Some(FixedUInt { array: [1, 0] }));
+            assert_eq!(CHECKED_REM_OK, Some(FixedUInt::from_array([1, 0])));
             assert_eq!(CHECKED_REM_ZERO, None);
         }
     }

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -19,14 +19,14 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::overflowin
 c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstOverflowingMul for FixedUInt<T, N, P> {
         fn overflowing_mul(&self, other: &Self) -> (Self, bool) {
-            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::WORD_BITS);
             (Self::from_array(array), overflow)
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstWrappingMul for FixedUInt<T, N, P> {
         fn wrapping_mul(&self, other: &Self) -> Self {
-            let (array, _) = const_mul::<T, N, false>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, _) = const_mul::<T, N, false, P>(&self.array, &other.array, Self::WORD_BITS);
             Self::from_array(array)
         }
     }
@@ -53,7 +53,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul for FixedUInt<T, N, P> {
         type Output = Self;
         fn mul(self, other: Self) -> Self::Output {
-            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::WORD_BITS);
             maybe_panic_if::<P>(overflow, PanicReason::Mul);
             Self::from_array(array)
         }
@@ -62,7 +62,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul<&FixedUInt<T, N, P>> for FixedUInt<T, N, P> {
         type Output = Self;
         fn mul(self, other: &FixedUInt<T, N, P>) -> Self::Output {
-            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::WORD_BITS);
             maybe_panic_if::<P>(overflow, PanicReason::Mul);
             Self::from_array(array)
         }
@@ -71,7 +71,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn mul(self, other: FixedUInt<T, N, P>) -> Self::Output {
-            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::Output::WORD_BITS);
             maybe_panic_if::<P>(overflow, PanicReason::Mul);
             FixedUInt::from_array(array)
         }
@@ -80,7 +80,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul<&FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn mul(self, other: &FixedUInt<T, N, P>) -> Self::Output {
-            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::Output::WORD_BITS);
             maybe_panic_if::<P>(overflow, PanicReason::Mul);
             FixedUInt::from_array(array)
         }
@@ -89,7 +89,7 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Mul<&&FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn mul(self, other: &&FixedUInt<T, N, P>) -> Self::Output {
-            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::Output::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::Output::WORD_BITS);
             maybe_panic_if::<P>(overflow, PanicReason::Mul);
             FixedUInt::from_array(array)
         }
@@ -97,7 +97,7 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::MulAssign for FixedUInt<T, N, P> {
         fn mul_assign(&mut self, other: Self) {
-            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::WORD_BITS);
             maybe_panic_if::<P>(overflow, PanicReason::Mul);
             *self = Self::from_array(array);
         }
@@ -105,7 +105,7 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::MulAssign<&FixedUInt<T, N, P>> for FixedUInt<T, N, P> {
         fn mul_assign(&mut self, other: &FixedUInt<T, N, P>) {
-            let (array, overflow) = const_mul::<T, N, true>(&self.array, &other.array, Self::WORD_BITS);
+            let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::WORD_BITS);
             maybe_panic_if::<P>(overflow, PanicReason::Mul);
             *self = Self::from_array(array);
         }

--- a/src/fixeduint/multiple_impl.rs
+++ b/src/fixeduint/multiple_impl.rs
@@ -17,9 +17,10 @@
 use super::{FixedUInt, MachineWord};
 use crate::const_numtraits::{ConstCheckedAdd, ConstMultiple, ConstZero};
 use crate::machineword::ConstMachineWord;
+use crate::personality::Nct;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstMultiple for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstMultiple for FixedUInt<T, N, Nct> {
         fn is_multiple_of(&self, rhs: &Self) -> bool {
             if rhs.is_zero() {
                 false
@@ -159,16 +160,16 @@ mod tests {
 
     c0nst::c0nst! {
         pub c0nst fn const_is_multiple_of<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: &FixedUInt<T, N>,
-            b: &FixedUInt<T, N>,
+            a: &FixedUInt<T, N, Nct>,
+            b: &FixedUInt<T, N, Nct>,
         ) -> bool {
             ConstMultiple::is_multiple_of(a, b)
         }
 
         pub c0nst fn const_next_multiple_of<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            a: FixedUInt<T, N>,
-            b: FixedUInt<T, N>,
-        ) -> FixedUInt<T, N> {
+            a: FixedUInt<T, N, Nct>,
+            b: FixedUInt<T, N, Nct>,
+        ) -> FixedUInt<T, N, Nct> {
             ConstMultiple::next_multiple_of(a, b)
         }
     }
@@ -185,14 +186,14 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const TEN: U16 = FixedUInt { array: [10, 0] };
-            const FIVE: U16 = FixedUInt { array: [5, 0] };
+            const TEN: U16 = FixedUInt::from_array([10, 0]);
+            const FIVE: U16 = FixedUInt::from_array([5, 0]);
             const IS_MULT: bool = const_is_multiple_of(&TEN, &FIVE);
             assert!(IS_MULT);
 
-            const ELEVEN: U16 = FixedUInt { array: [11, 0] };
+            const ELEVEN: U16 = FixedUInt::from_array([11, 0]);
             const NEXT: U16 = const_next_multiple_of(ELEVEN, FIVE);
-            assert_eq!(NEXT, FixedUInt { array: [15, 0] });
+            assert_eq!(NEXT, FixedUInt::from_array([15, 0]));
         }
     }
 }

--- a/src/fixeduint/num_integer_impl.rs
+++ b/src/fixeduint/num_integer_impl.rs
@@ -1,10 +1,11 @@
 use super::{FixedUInt, MachineWord};
 
+use crate::personality::Nct;
 use num_traits::{PrimInt, Zero};
 
 // Most code here from num_integer crate, unsigned implementation
 
-impl<T: MachineWord, const N: usize> num_integer::Integer for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize> num_integer::Integer for FixedUInt<T, N, Nct> {
     fn div_floor(&self, other: &Self) -> Self {
         *self / *other
     }

--- a/src/fixeduint/num_traits_casts.rs
+++ b/src/fixeduint/num_traits_casts.rs
@@ -1,8 +1,8 @@
 use super::{FixedUInt, MachineWord};
-
+use crate::personality::Personality;
 use num_traits::{Bounded, FromPrimitive, ToPrimitive};
 
-impl<T: MachineWord, const N: usize> num_traits::NumCast for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::NumCast for FixedUInt<T, N, P> {
     fn from<X>(arg: X) -> Option<Self>
     where
         X: ToPrimitive,
@@ -11,7 +11,9 @@ impl<T: MachineWord, const N: usize> num_traits::NumCast for FixedUInt<T, N> {
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::ToPrimitive for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::ToPrimitive
+    for FixedUInt<T, N, P>
+{
     fn to_i64(&self) -> Option<i64> {
         None
     }
@@ -48,7 +50,9 @@ impl<T: MachineWord, const N: usize> num_traits::ToPrimitive for FixedUInt<T, N>
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::FromPrimitive for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::FromPrimitive
+    for FixedUInt<T, N, P>
+{
     fn from_i64(_: i64) -> Option<Self> {
         None
     }

--- a/src/fixeduint/num_traits_identity.rs
+++ b/src/fixeduint/num_traits_identity.rs
@@ -1,16 +1,20 @@
-use super::{const_is_zero, FixedUInt, MachineWord};
+use super::{
+    const_is_one, const_is_one_ct, const_is_zero, const_is_zero_ct, FixedUInt, MachineWord,
+};
 use crate::const_numtraits::{ConstBounded, ConstOne, ConstZero};
 use crate::machineword::ConstMachineWord;
+use crate::personality::{Personality, PersonalityTag};
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstZero for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstZero for FixedUInt<T, N, P> {
         fn zero() -> Self {
-            FixedUInt {
-                array: [T::zero(); N],
-            }
+            FixedUInt::from_array([T::zero(); N])
         }
         fn is_zero(&self) -> bool {
-            const_is_zero(&self.array)
+            match P::TAG {
+                PersonalityTag::Nct => const_is_zero(&self.array),
+                PersonalityTag::Ct => const_is_zero_ct(&self.array),
+            }
         }
         fn set_zero(&mut self) {
             let mut i = 0;
@@ -21,7 +25,7 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstOne for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstOne for FixedUInt<T, N, P> {
         fn one() -> Self {
             let mut ret = <Self as ConstZero>::zero();
             if N > 0 {
@@ -30,17 +34,10 @@ c0nst::c0nst! {
             ret
         }
         fn is_one(&self) -> bool {
-            if N == 0 || !self.array[0].is_one() {
-                return false;
+            match P::TAG {
+                PersonalityTag::Nct => const_is_one(&self.array),
+                PersonalityTag::Ct => const_is_one_ct(&self.array),
             }
-            let mut i = 1;
-            while i < N {
-                if !self.array[i].is_zero() {
-                    return false;
-                }
-                i += 1;
-            }
-            true
         }
         fn set_one(&mut self) {
             <Self as ConstZero>::set_zero(self);
@@ -50,19 +47,17 @@ c0nst::c0nst! {
         }
     }
 
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstBounded for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstBounded for FixedUInt<T, N, P> {
         fn min_value() -> Self {
             <Self as ConstZero>::zero()
         }
         fn max_value() -> Self {
-            FixedUInt {
-                array: [T::max_value(); N],
-            }
+            FixedUInt::from_array([T::max_value(); N])
         }
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::Zero for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::Zero for FixedUInt<T, N, P> {
     fn zero() -> Self {
         <Self as ConstZero>::zero()
     }
@@ -71,13 +66,13 @@ impl<T: MachineWord, const N: usize> num_traits::Zero for FixedUInt<T, N> {
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::One for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::One for FixedUInt<T, N, P> {
     fn one() -> Self {
         <Self as ConstOne>::one()
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::Bounded for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::Bounded for FixedUInt<T, N, P> {
     fn min_value() -> Self {
         <Self as ConstBounded>::min_value()
     }
@@ -89,38 +84,39 @@ impl<T: MachineWord, const N: usize> num_traits::Bounded for FixedUInt<T, N> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::personality::Nct;
 
     c0nst::c0nst! {
-        c0nst fn const_zero<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>() -> FixedUInt<T, N> {
-            <FixedUInt<T, N> as ConstZero>::zero()
+        c0nst fn const_zero<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>() -> FixedUInt<T, N, P> {
+            <FixedUInt<T, N, P> as ConstZero>::zero()
         }
 
-        c0nst fn const_one<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>() -> FixedUInt<T, N> {
-            <FixedUInt<T, N> as ConstOne>::one()
+        c0nst fn const_one<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>() -> FixedUInt<T, N, P> {
+            <FixedUInt<T, N, P> as ConstOne>::one()
         }
 
-        c0nst fn const_is_zero<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(v: &FixedUInt<T, N>) -> bool {
-            <FixedUInt<T, N> as ConstZero>::is_zero(v)
+        c0nst fn const_is_zero<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(v: &FixedUInt<T, N, P>) -> bool {
+            <FixedUInt<T, N, P> as ConstZero>::is_zero(v)
         }
 
-        c0nst fn const_is_one<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(v: &FixedUInt<T, N>) -> bool {
-            <FixedUInt<T, N> as ConstOne>::is_one(v)
+        c0nst fn const_is_one<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(v: &FixedUInt<T, N, P>) -> bool {
+            <FixedUInt<T, N, P> as ConstOne>::is_one(v)
         }
 
-        c0nst fn const_min_value<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>() -> FixedUInt<T, N> {
-            <FixedUInt<T, N> as ConstBounded>::min_value()
+        c0nst fn const_min_value<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>() -> FixedUInt<T, N, P> {
+            <FixedUInt<T, N, P> as ConstBounded>::min_value()
         }
 
-        c0nst fn const_max_value<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>() -> FixedUInt<T, N> {
-            <FixedUInt<T, N> as ConstBounded>::max_value()
+        c0nst fn const_max_value<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>() -> FixedUInt<T, N, P> {
+            <FixedUInt<T, N, P> as ConstBounded>::max_value()
         }
 
-        c0nst fn const_set_zero<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(v: &mut FixedUInt<T, N>) {
-            <FixedUInt<T, N> as ConstZero>::set_zero(v)
+        c0nst fn const_set_zero<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(v: &mut FixedUInt<T, N, P>) {
+            <FixedUInt<T, N, P> as ConstZero>::set_zero(v)
         }
 
-        c0nst fn const_set_one<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(v: &mut FixedUInt<T, N>) {
-            <FixedUInt<T, N> as ConstOne>::set_one(v)
+        c0nst fn const_set_one<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(v: &mut FixedUInt<T, N, P>) {
+            <FixedUInt<T, N, P> as ConstOne>::set_one(v)
         }
     }
 
@@ -129,18 +125,18 @@ mod tests {
         type TestInt = FixedUInt<u8, 2>;
 
         // Test zero
-        let zero = const_zero::<u8, 2>();
+        let zero = const_zero::<u8, 2, Nct>();
         assert!(const_is_zero(&zero));
         assert!(!const_is_one(&zero));
 
         // Test one
-        let one = const_one::<u8, 2>();
+        let one = const_one::<u8, 2, Nct>();
         assert!(!const_is_zero(&one));
         assert!(const_is_one(&one));
 
         // Test min/max
-        let min = const_min_value::<u8, 2>();
-        let max = const_max_value::<u8, 2>();
+        let min = const_min_value::<u8, 2, Nct>();
+        let max = const_max_value::<u8, 2, Nct>();
         assert!(const_is_zero(&min));
         assert_eq!(max.array, [255, 255]);
 
@@ -154,14 +150,14 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const ZERO: TestInt = const_zero::<u8, 2>();
-            const ONE: TestInt = const_one::<u8, 2>();
+            const ZERO: TestInt = const_zero::<u8, 2, Nct>();
+            const ONE: TestInt = const_one::<u8, 2, Nct>();
             const IS_ZERO_TRUE: bool = const_is_zero(&ZERO);
             const IS_ZERO_FALSE: bool = const_is_zero(&ONE);
             const IS_ONE_TRUE: bool = const_is_one(&ONE);
             const IS_ONE_FALSE: bool = const_is_one(&ZERO);
-            const MIN: TestInt = const_min_value::<u8, 2>();
-            const MAX: TestInt = const_max_value::<u8, 2>();
+            const MIN: TestInt = const_min_value::<u8, 2, Nct>();
+            const MAX: TestInt = const_max_value::<u8, 2, Nct>();
 
             assert_eq!(ZERO.array, [0, 0]);
             assert_eq!(ONE.array, [1, 0]);
@@ -173,12 +169,12 @@ mod tests {
             assert_eq!(MAX.array, [255, 255]);
 
             const SET_ZERO_RES: TestInt = {
-                let mut v = FixedUInt { array: [42, 0] };
+                let mut v = FixedUInt::from_array([42, 0]);
                 const_set_zero(&mut v);
                 v
             };
             const SET_ONE_RES: TestInt = {
-                let mut v = FixedUInt { array: [0, 0] };
+                let mut v = FixedUInt::from_array([0, 0]);
                 const_set_one(&mut v);
                 v
             };

--- a/src/fixeduint/power_of_two_impl.rs
+++ b/src/fixeduint/power_of_two_impl.rs
@@ -15,22 +15,55 @@
 //! Power-of-two operations for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::{ConstOne, ConstPowerOfTwo, ConstPrimInt, ConstZero};
+use crate::const_numtraits::{
+    ConstBitPrimInt, ConstBounded, ConstOne, ConstPowerOfTwo, ConstWrappingSub, ConstZero,
+};
 use crate::machineword::ConstMachineWord;
+use crate::personality::{Personality, PersonalityTag};
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstPowerOfTwo for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstPowerOfTwo for FixedUInt<T, N, P> {
         fn is_power_of_two(&self) -> bool {
-            // Standard bitwise trick: n is power of two iff n != 0 && (n & (n-1)) == 0
-            // This works because a power of two has exactly one bit set,
-            // and subtracting 1 flips all lower bits, so AND gives zero.
-            !self.is_zero() && (*self & (*self - Self::one())).is_zero()
+            match P::TAG {
+                PersonalityTag::Nct => {
+                    !self.is_zero() && (*self & (*self - Self::one())).is_zero()
+                }
+                PersonalityTag::Ct => {
+                    let a = !self.is_zero();
+                    let b = (*self & self.wrapping_sub(&Self::one())).is_zero();
+                    a & b
+                }
+            }
         }
 
         fn next_power_of_two(self) -> Self {
-            match self.checked_next_power_of_two() {
-                Some(v) => v,
-                None => panic!("FixedUInt::next_power_of_two overflow: result exceeds type capacity"),
+            match P::TAG {
+                PersonalityTag::Nct => {
+                    match self.checked_next_power_of_two() {
+                        Some(v) => v,
+                        None => panic!("FixedUInt::next_power_of_two overflow: result exceeds type capacity"),
+                    }
+                }
+                PersonalityTag::Ct => {
+                    // CT path: saturate to MAX on overflow (same convention
+                    // as SaturatingAdd/Sub/Mul). The Nct path's panic is
+                    // value-dependent and so unavailable here; silently
+                    // returning a wrong power of two would be worse than
+                    // a defined saturation sentinel.
+                    let m_one = <Self as ConstWrappingSub>::wrapping_sub(&self, &Self::one());
+                    let leading = ConstBitPrimInt::leading_zeros(m_one);
+                    let bits = Self::BIT_SIZE as u32 - leading;
+                    let shifted = Self::one() << (bits as usize);
+                    let is_zero = <Self as ConstZero>::is_zero(&self) as u8;
+                    // Overflow when bits >= BIT_SIZE (and self != 0).
+                    let overflow = ((bits >= Self::BIT_SIZE as u32) as u8) & (1u8 ^ is_zero);
+                    let saturated = crate::fixeduint::const_ct_select(
+                        shifted,
+                        <Self as ConstBounded>::max_value(),
+                        overflow,
+                    );
+                    crate::fixeduint::const_ct_select(saturated, Self::one(), is_zero)
+                }
             }
         }
 
@@ -42,7 +75,7 @@ c0nst::c0nst! {
             // needed for the next power of two, handling both power-of-two and
             // non-power-of-two inputs correctly.
             let m_one = self - Self::one();
-            let leading = ConstPrimInt::leading_zeros(m_one);
+            let leading = ConstBitPrimInt::leading_zeros(m_one);
             let bits = Self::BIT_SIZE as u32 - leading;
 
             // Check for overflow
@@ -156,15 +189,15 @@ mod tests {
     }
 
     c0nst::c0nst! {
-        pub c0nst fn const_is_power_of_two<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            v: &FixedUInt<T, N>,
+        pub c0nst fn const_is_power_of_two<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            v: &FixedUInt<T, N, P>,
         ) -> bool {
             ConstPowerOfTwo::is_power_of_two(v)
         }
 
-        pub c0nst fn const_next_power_of_two<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
-            v: FixedUInt<T, N>,
-        ) -> FixedUInt<T, N> {
+        pub c0nst fn const_next_power_of_two<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
+            v: FixedUInt<T, N, P>,
+        ) -> FixedUInt<T, N, P> {
             ConstPowerOfTwo::next_power_of_two(v)
         }
     }
@@ -179,15 +212,15 @@ mod tests {
 
         #[cfg(feature = "nightly")]
         {
-            const FOUR: U16 = FixedUInt { array: [4, 0] };
-            const FIVE: U16 = FixedUInt { array: [5, 0] };
+            const FOUR: U16 = FixedUInt::from_array([4, 0]);
+            const FIVE: U16 = FixedUInt::from_array([5, 0]);
             const IS_POW2_TRUE: bool = const_is_power_of_two(&FOUR);
             const IS_POW2_FALSE: bool = const_is_power_of_two(&FIVE);
             const NEXT_POW2: U16 = const_next_power_of_two(FIVE);
 
             assert!(IS_POW2_TRUE);
             assert!(!IS_POW2_FALSE);
-            assert_eq!(NEXT_POW2, FixedUInt { array: [8, 0] });
+            assert_eq!(NEXT_POW2, FixedUInt::from_array([8, 0]));
         }
     }
 }

--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -1,11 +1,15 @@
-use super::{const_leading_zeros, const_trailing_zeros, FixedUInt, MachineWord};
-use crate::const_numtraits::ConstPrimInt;
+use super::{
+    const_leading_zeros, const_leading_zeros_ct, const_trailing_zeros, const_trailing_zeros_ct,
+    FixedUInt, MachineWord,
+};
+use crate::const_numtraits::{ConstBitPrimInt, ConstPrimInt};
 use crate::machineword::ConstMachineWord;
 
+use crate::personality::{Nct, Personality, PersonalityTag};
 use num_traits::One;
 
 c0nst::c0nst! {
-    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstPrimInt for FixedUInt<T, N> {
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstBitPrimInt for FixedUInt<T, N, P> {
         fn count_ones(self) -> u32 {
             let mut count = 0u32;
             let mut i = 0;
@@ -25,10 +29,16 @@ c0nst::c0nst! {
             count
         }
         fn leading_zeros(self) -> u32 {
-            const_leading_zeros(&self.array)
+            match P::TAG {
+                PersonalityTag::Nct => const_leading_zeros(&self.array),
+                PersonalityTag::Ct => const_leading_zeros_ct(&self.array),
+            }
         }
         fn trailing_zeros(self) -> u32 {
-            const_trailing_zeros(&self.array)
+            match P::TAG {
+                PersonalityTag::Nct => const_trailing_zeros(&self.array),
+                PersonalityTag::Ct => const_trailing_zeros_ct(&self.array),
+            }
         }
         fn swap_bytes(self) -> Self {
             let mut ret = <Self as crate::const_numtraits::ConstZero>::zero();
@@ -87,6 +97,8 @@ c0nst::c0nst! {
         fn to_le(self) -> Self {
             self
         }
+    }
+    impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> c0nst ConstPrimInt for FixedUInt<T, N, Nct> {
         fn pow(self, exp: u32) -> Self {
             if exp == 0 {
                 return <Self as crate::const_numtraits::ConstOne>::one();
@@ -109,7 +121,7 @@ c0nst::c0nst! {
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::PrimInt for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize> num_traits::PrimInt for FixedUInt<T, N, Nct> {
     fn count_ones(self) -> u32 {
         self.array.iter().map(|&val| val.count_ones()).sum()
     }

--- a/src/fixeduint/roots_impl.rs
+++ b/src/fixeduint/roots_impl.rs
@@ -1,9 +1,10 @@
 use crate::fixeduint::FixedUInt;
 use crate::machineword::MachineWord;
+use crate::personality::Nct;
 use num_integer::Roots;
 use num_traits::{FromPrimitive, One, PrimInt, Zero};
 
-impl<T: MachineWord, const N: usize> Roots for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize> Roots for FixedUInt<T, N, Nct> {
     fn nth_root(&self, n: u32) -> Self {
         if n == 0 {
             panic!("nth_root: n must be non-zero");

--- a/src/fixeduint/string_conversion.rs
+++ b/src/fixeduint/string_conversion.rs
@@ -2,8 +2,9 @@ use core::fmt::Write;
 use num_traits::{Num, ToPrimitive, Zero};
 
 use super::{make_empty_error, make_overflow_err, make_parse_int_err, FixedUInt, MachineWord};
+use crate::personality::Nct;
 
-impl<T: MachineWord, const N: usize> num_traits::Num for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize> num_traits::Num for FixedUInt<T, N, Nct> {
     type FromStrRadixErr = core::num::ParseIntError;
     fn from_str_radix(
         input: &str,
@@ -39,7 +40,7 @@ impl<T: MachineWord, const N: usize> num_traits::Num for FixedUInt<T, N> {
     }
 }
 
-impl<T: MachineWord, const N: usize> core::fmt::UpperHex for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize> core::fmt::UpperHex for FixedUInt<T, N, Nct>
 where
     u8: core::convert::TryFrom<T>,
 {
@@ -48,7 +49,7 @@ where
     }
 }
 
-impl<T: MachineWord, const N: usize> core::fmt::LowerHex for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize> core::fmt::LowerHex for FixedUInt<T, N, Nct>
 where
     u8: core::convert::TryFrom<T>,
 {
@@ -57,7 +58,7 @@ where
     }
 }
 
-impl<T: MachineWord, const N: usize> core::fmt::Display for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize> core::fmt::Display for FixedUInt<T, N, Nct> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         const MAX_DIGITS: usize = 20;
 
@@ -95,7 +96,7 @@ impl<T: MachineWord, const N: usize> core::fmt::Display for FixedUInt<T, N> {
     }
 }
 
-impl<T: MachineWord, const N: usize> core::str::FromStr for FixedUInt<T, N> {
+impl<T: MachineWord, const N: usize> core::str::FromStr for FixedUInt<T, N, Nct> {
     type Err = core::num::ParseIntError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -5,6 +5,7 @@ use core::borrow::{Borrow, BorrowMut};
 use core::hash::Hash;
 
 use super::FixedUInt;
+use crate::personality::Personality;
 
 // Helper, holds an owned copy of returned bytes
 #[derive(Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Debug)]
@@ -14,13 +15,14 @@ pub struct BytesHolder<T: MachineWord, const N: usize> {
 
 impl<T: MachineWord, const N: usize> Default for BytesHolder<T, N> {
     fn default() -> Self {
-        Self {
-            array: core::array::from_fn(|_| T::default()),
-        }
+        Self::from_array(core::array::from_fn(|_| T::default()))
     }
 }
 
 impl<T: MachineWord, const N: usize> BytesHolder<T, N> {
+    pub(crate) fn from_array(array: [T; N]) -> Self {
+        Self { array }
+    }
     // Converts internal storage to a mutable byte slice
     fn as_byte_slice_mut(&mut self) -> &mut [u8] {
         // SAFETY: This is safe because the size of the array is the same as the size of the slice
@@ -68,26 +70,26 @@ impl<T: MachineWord, const N: usize> Hash for BytesHolder<T, N> {
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::ToBytes for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::ToBytes for FixedUInt<T, N, P>
 where
     T: core::fmt::Debug,
 {
     type Bytes = BytesHolder<T, N>;
 
     fn to_be_bytes(&self) -> Self::Bytes {
-        let mut ret = Self::Bytes { array: self.array };
+        let mut ret = Self::Bytes::from_array(self.array);
         let _ = self.to_be_bytes(ret.as_byte_slice_mut());
         ret
     }
 
     fn to_le_bytes(&self) -> Self::Bytes {
-        let mut ret = Self::Bytes { array: self.array };
+        let mut ret = Self::Bytes::from_array(self.array);
         let _ = self.to_le_bytes(ret.as_byte_slice_mut());
         ret
     }
 }
 
-impl<T: MachineWord, const N: usize> num_traits::FromBytes for FixedUInt<T, N>
+impl<T: MachineWord, const N: usize, P: Personality> num_traits::FromBytes for FixedUInt<T, N, P>
 where
     T: core::fmt::Debug,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,13 @@ pub mod const_numtraits;
 
 /// Fused multiply-accumulate row operations
 pub mod mul_acc_ops;
+pub mod personality;
 
 /// Machine word and doubleword
 mod machineword;
 
+pub use crate::const_numtraits::{ConstBitPrimInt, ConstPrimInt};
 pub use crate::fixeduint::FixedUInt;
 pub use crate::machineword::MachineWord;
 pub use crate::mul_acc_ops::MulAccOps;
+pub use crate::personality::{Ct, Nct, Personality, PersonalityTag};

--- a/src/machineword.rs
+++ b/src/machineword.rs
@@ -17,7 +17,8 @@
 
 pub use crate::const_numtraits::ConstPrimInt;
 use crate::const_numtraits::{
-    ConstOverflowingAdd, ConstOverflowingSub, ConstToBytes, ConstWideningMul,
+    ConstBorrowingSub, ConstCarryingAdd, ConstOverflowingAdd, ConstOverflowingSub, ConstToBytes,
+    ConstWideningMul,
 };
 
 c0nst::c0nst! {
@@ -27,6 +28,8 @@ c0nst::c0nst! {
         [c0nst] ConstPrimInt +
         [c0nst] ConstOverflowingAdd +
         [c0nst] ConstOverflowingSub +
+        [c0nst] ConstCarryingAdd +
+        [c0nst] ConstBorrowingSub +
         [c0nst] ConstToBytes +
         [c0nst] ConstWideningMul
     {

--- a/src/mul_acc_ops.rs
+++ b/src/mul_acc_ops.rs
@@ -15,12 +15,23 @@ pub trait MulAccOps: Sized + Copy + Default {
     /// The machine-word type used as a scalar in row operations.
     type Word: Copy + PartialOrd;
 
+    /// Return type of [`get_word`]: `Option<Word>` for `Nct` implementations,
+    /// `subtle::CtOption<Word>` for `Ct` implementations. The discriminant
+    /// shape encodes the call site's CT contract — `Option` matches via
+    /// `Some`/`None` (NCT-callable), `CtOption` exposes only `subtle`-backed
+    /// methods (CT-callable).
+    ///
+    /// [`get_word`]: MulAccOps::get_word
+    type GetWordOutput;
+
     /// Number of words in this type.
     fn word_count() -> usize;
 
     /// Access the `i`-th word (little-endian, `i = 0` is least significant).
-    /// Returns `None` if `i >= Self::word_count()`.
-    fn get_word(&self, i: usize) -> Option<Self::Word>;
+    /// Returns the personality-appropriate "maybe-a-word" type:
+    /// `Option<Self::Word>` for NCT impls (O(1) fast path),
+    /// `subtle::CtOption<Self::Word>` for CT impls (O(N) constant-time scan).
+    fn get_word(&self, i: usize) -> Self::GetWordOutput;
 
     /// **Phase 1 row**: `acc += scalar * multiplicand`
     ///

--- a/src/personality.rs
+++ b/src/personality.rs
@@ -1,0 +1,87 @@
+//! Personality typestate for [`FixedUInt`](crate::FixedUInt).
+//!
+//! The personality is a zero-size marker generic on [`FixedUInt`] that selects
+//! which implementations of operation primitives are picked at
+//! monomorphization. Two personalities ship with the crate:
+//!
+//! - [`Nct`] (default): standard "non-constant-time" implementation.
+//! - [`Ct`]: constant-time implementation. Slower bodies whose timing is
+//!   independent of operand values, defensible against an adversarial
+//!   optimizer. Used by signing paths and any code handling secret values.
+//!
+//! ## Const-eval dispatch via `match P::TAG`
+//!
+//! Composite `const fn` methods that need to dispatch on personality can
+//! `match` on the [`PersonalityTag`] associated constant:
+//!
+//! ```ignore
+//! const fn dispatched<P: Personality>(x: u32) -> u32 {
+//!     match P::TAG {
+//!         PersonalityTag::Nct => fast_body(x),
+//!         PersonalityTag::Ct  => ct_body(x),
+//!     }
+//! }
+//! ```
+//!
+//! Trait *method* calls (e.g. `P::widening_mul(x, y)`) require unstable
+//! `const_trait_impl` in const contexts and are not used by this crate. Tag
+//! dispatch works on stable today and composes through multi-level generic
+//! `const fn` chains without loss of const-eval.
+
+use core::marker::PhantomData;
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker trait for personalities. Sealed — implementations live in this
+/// crate. Downstream code uses the [`Nct`] and [`Ct`] types directly or
+/// writes `match P::TAG` dispatch using [`PersonalityTag`].
+pub trait Personality: sealed::Sealed + Copy + 'static {
+    /// Compile-time tag used by `const fn` dispatch:
+    /// `match P::TAG { PersonalityTag::Nct => …, PersonalityTag::Ct => … }`.
+    const TAG: PersonalityTag;
+}
+
+/// Compile-time tag identifying the active personality. Returned by
+/// [`Personality::TAG`] and used as the discriminant for `match P::TAG`
+/// dispatch in `const fn` bodies.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum PersonalityTag {
+    /// Non-constant-time.
+    Nct,
+    /// Constant-time. Defensible against optimizer-introduced timing leaks.
+    Ct,
+}
+
+/// Non-constant-time marker. Default personality for [`FixedUInt`].
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct Nct;
+impl sealed::Sealed for Nct {}
+impl Personality for Nct {
+    const TAG: PersonalityTag = PersonalityTag::Nct;
+}
+
+/// Constant-time marker.
+///
+/// Selects constant-time implementations of operation primitives — bodies
+/// whose execution time and memory access pattern do not depend on operand
+/// values. Appropriate for code that handles secret values (signing,
+/// scalar multiplication on secret scalars, Montgomery multiplication on
+/// secret operands).
+///
+/// Calls to `subtle::ConditionallySelectable`, `ConstantTimeEq`, and
+/// related traits are only available for [`FixedUInt`]<_, _, Ct>` — wrong-
+/// variant calls become compile errors, not silent NCT execution.
+///
+/// [`FixedUInt`]: crate::FixedUInt
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct Ct;
+impl sealed::Sealed for Ct {}
+impl Personality for Ct {
+    const TAG: PersonalityTag = PersonalityTag::Ct;
+}
+
+/// PhantomData helper for storing a personality marker as a zero-size field.
+/// Use as `_p: PersonalityMarker<P>` in struct definitions.
+pub type PersonalityMarker<P> = PhantomData<fn() -> P>;

--- a/tests/personality_integration.rs
+++ b/tests/personality_integration.rs
@@ -435,6 +435,38 @@ fn shl_works_under_both_personalities() {
 }
 
 #[test]
+fn shl_shr_u32_overflow_returns_zero() {
+    // Shl<u32>/Shr<u32> previously did `bits as usize`, truncating on
+    // 16-bit-usize targets. The fix routes through normalize_shift_amount.
+    // Regression-check the semantics: any u32 shift >= BIT_SIZE produces 0.
+    let v: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x12u8, 0x34, 0x56, 0x78]);
+    let vc: FixedUInt<u8, 4, Ct> = v.into();
+    for shift in [32u32, 33, 100, 1024, u32::MAX] {
+        assert!(num_traits::Zero::is_zero(&(v << shift)));
+        assert!(num_traits::Zero::is_zero(&(v >> shift)));
+        assert!(num_traits::Zero::is_zero(&((vc << shift).forget_ct())));
+        assert!(num_traits::Zero::is_zero(&((vc >> shift).forget_ct())));
+    }
+}
+
+#[test]
+fn resize_preserves_personality() {
+    // Regression: resize() used to return FixedUInt<T, N2> (defaulted to Nct),
+    // silently stripping Ct. Now it preserves P. The CT-typed bindings below
+    // would not type-check if resize defaulted back to Nct.
+    let c: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 2, 3, 4]).into();
+    let grown: FixedUInt<u8, 6, Ct> = c.resize();
+    let shrunk: FixedUInt<u8, 2, Ct> = c.resize();
+    assert_eq!(grown.forget_ct(), FixedUInt::from([1u8, 2, 3, 4, 0, 0]));
+    assert_eq!(shrunk.forget_ct(), FixedUInt::from([1u8, 2]));
+
+    // Nct path still resolves to Nct without needing a turbofish.
+    let n: FixedUInt<u8, 4, Nct> = FixedUInt::from([9u8, 8, 7, 6]);
+    let n2: FixedUInt<u8, 3, Nct> = n.resize();
+    assert_eq!(n2, FixedUInt::from([9u8, 8, 7]));
+}
+
+#[test]
 fn shr_works_under_both_personalities() {
     for shift in [0usize, 1, 3, 7, 8, 15, 16, 23, 24, 31] {
         let nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x12u8, 0x34, 0x56, 0x78]);

--- a/tests/personality_integration.rs
+++ b/tests/personality_integration.rs
@@ -650,12 +650,12 @@ fn ct_checked_add_returns_ctoption() {
     let a: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(100u8).into();
     let b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(200u8).into();
 
-    // No overflow: result valid.
+    // No overflow: result valid and equals the expected sum.
     let ok = a.ct_checked_add(&b);
     assert!(bool::from(ok.is_some()));
+    assert_eq!(ok.unwrap_or(a).forget_ct(), FixedUInt::from(300u16));
 
-    // Overflow: result still has a defined value (the wrapped sum), but
-    // the validity Choice is 0.
+    // Overflow: validity Choice is 0.
     let max: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0xFFFFu16).into();
     let one: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(1u8).into();
     let bad = max.ct_checked_add(&one);
@@ -668,6 +668,7 @@ fn ct_checked_sub_returns_ctoption() {
     let b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(100u8).into();
     let ok = a.ct_checked_sub(&b);
     assert!(bool::from(ok.is_some()));
+    assert_eq!(ok.unwrap_or(a).forget_ct(), FixedUInt::from(100u8));
 
     // Underflow case.
     let zero: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0u8).into();
@@ -680,14 +681,15 @@ fn ct_checked_sub_returns_ctoption() {
 fn ct_checked_mul_returns_ctoption() {
     let a: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0x100u16).into();
     let b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0x100u16).into();
-    // 0x100 * 0x100 = 0x10000, fits in u16, no overflow.
+    // 0x100 * 0x100 = 0x10000, exceeds u16::MAX → overflow.
     let near = a.ct_checked_mul(&b);
-    assert!(!bool::from(near.is_some())); // 0x10000 > u16::MAX → overflow
+    assert!(!bool::from(near.is_some()));
 
     let small_a: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(10u8).into();
     let small_b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(20u8).into();
     let ok = small_a.ct_checked_mul(&small_b);
     assert!(bool::from(ok.is_some()));
+    assert_eq!(ok.unwrap_or(small_a).forget_ct(), FixedUInt::from(200u8));
 }
 
 #[test]
@@ -730,14 +732,16 @@ fn abs_diff_works_under_both_personalities() {
 
 #[test]
 fn ct_checked_pow_returns_ctoption() {
-    // No overflow: result valid.
+    // No overflow: result valid and equals 2^8 = 256.
     let two_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(2u8).into();
     let ok = two_ct.ct_checked_pow(8);
     assert!(bool::from(ok.is_some()));
+    assert_eq!(ok.unwrap_or(two_ct).forget_ct(), FixedUInt::from(256u16));
 
     // Just-fits: 2^15 = 32768, fits in u16.
     let big = two_ct.ct_checked_pow(15);
     assert!(bool::from(big.is_some()));
+    assert_eq!(big.unwrap_or(two_ct).forget_ct(), FixedUInt::from(32768u16));
 
     // Overflow: 2^16 = 65536, exceeds u16::MAX.
     let overflow = two_ct.ct_checked_pow(16);
@@ -797,11 +801,10 @@ fn ct_debug_redacts_limb_values() {
     let ct: FixedUInt<u8, 4, Ct> = nct.into();
     let nct_dbg = format!("{:?}", nct);
     let ct_dbg = format!("{:?}", ct);
-    assert!(
-        nct_dbg.contains("222") || nct_dbg.contains("0xDE") || nct_dbg.contains("DE"),
-        "Nct debug should expose limbs (got: {})",
-        nct_dbg
-    );
+    // Only the two properties we actually care about: Nct exposes something
+    // (so the two formats are distinguishable), Ct is the exact placeholder.
+    assert!(!nct_dbg.is_empty());
+    assert_ne!(nct_dbg, ct_dbg);
     assert_eq!(ct_dbg, "FixedUInt<…>");
     // Sanity: redaction doesn't depend on byte content — all-zero is also redacted.
     let zero_ct: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(0u8).into();
@@ -847,10 +850,11 @@ fn ct_checked_next_power_of_two_returns_ctoption() {
     assert!(bool::from(r0.is_some()));
     assert_eq!(r0.unwrap_or(z).forget_ct(), FixedUInt::from(1u8));
 
-    // Just fits: 32768 = 2^15.
+    // Just fits: 32768 is itself 2^15, the next-power-of-two is itself.
     let big: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(32768u16).into();
     let rbig = big.ct_checked_next_power_of_two();
     assert!(bool::from(rbig.is_some()));
+    assert_eq!(rbig.unwrap_or(big).forget_ct(), FixedUInt::from(32768u16));
 
     // Overflow: 32769 → needs 2^16 = 65536 which is u16::MAX + 1.
     let overflow: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(32769u16).into();
@@ -868,11 +872,13 @@ fn ct_checked_next_power_of_two_returns_ctoption() {
 fn ct_checked_shl_shr_return_ctoption() {
     let v: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0x1234u16).into();
 
-    // Within range.
+    // Within range: payloads match the expected wrapping shifts.
     let ok_l = v.ct_checked_shl(4);
     assert!(bool::from(ok_l.is_some()));
+    assert_eq!(ok_l.unwrap_or(v).forget_ct(), FixedUInt::from(0x2340u16));
     let ok_r = v.ct_checked_shr(4);
     assert!(bool::from(ok_r.is_some()));
+    assert_eq!(ok_r.unwrap_or(v).forget_ct(), FixedUInt::from(0x0123u16));
 
     // Beyond bit_size (= 16 for u8*2).
     let bad_l = v.ct_checked_shl(32);

--- a/tests/personality_integration.rs
+++ b/tests/personality_integration.rs
@@ -1,0 +1,1076 @@
+use fixed_bigint::personality::{Ct, Nct};
+use fixed_bigint::{FixedUInt, MulAccOps};
+use num_traits::Zero;
+use subtle::{
+    Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
+};
+
+// ---------------------------------------------------------------------------
+// Default `P = Nct` preserves existing shape.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn existing_shape_still_compiles_under_default() {
+    // The classic two-parameter form resolves to Nct via the default.
+    let a: FixedUInt<u8, 4> = FixedUInt::from([1u8, 2, 3, 4]);
+    let b: FixedUInt<u8, 4, Nct> = a; // type-system sanity
+    assert_eq!(b, FixedUInt::from([1u8, 2, 3, 4]));
+}
+
+// ---------------------------------------------------------------------------
+// Conversions: Nct -> Ct free (safe), Ct -> Nct via explicit forget_ct.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nct_to_ct_is_free_from_impl() {
+    let n: FixedUInt<u8, 4, Nct> = FixedUInt::from([0xDEu8, 0xAD, 0xBE, 0xEF]);
+    let c: FixedUInt<u8, 4, Ct> = n.into();
+    // Round-trip via forget_ct for value equality (the variants are
+    // intentionally distinct types, so `assert_eq!(n, c)` wouldn't typecheck).
+    let n2: FixedUInt<u8, 4, Nct> = c.forget_ct();
+    assert_eq!(n, n2);
+}
+
+#[test]
+fn forget_ct_is_an_explicit_named_method() {
+    // The Ct -> Nct direction is *not* `From`/`Into` — it's a named method.
+    // The following would not compile if it were `From`:
+    //     let n: FixedUInt<u8, 4, Nct> = c.into();  // (error: no impl)
+    let c: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 2, 3, 4]).into();
+    let n: FixedUInt<u8, 4, Nct> = c.forget_ct();
+    assert_eq!(n, FixedUInt::from([1u8, 2, 3, 4]));
+}
+
+// ---------------------------------------------------------------------------
+// subtle integration — Ct variant only.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ct_variant_has_constant_time_eq() {
+    let a: FixedUInt<u32, 4, Ct> = FixedUInt::<u32, 4, Nct>::from([1u32, 2, 3, 4]).into();
+    let b: FixedUInt<u32, 4, Ct> = FixedUInt::<u32, 4, Nct>::from([1u32, 2, 3, 4]).into();
+    let c: FixedUInt<u32, 4, Ct> = FixedUInt::<u32, 4, Nct>::from([1u32, 2, 3, 5]).into();
+    assert!(bool::from(a.ct_eq(&b)));
+    assert!(!bool::from(a.ct_eq(&c)));
+}
+
+#[test]
+fn ct_variant_has_conditional_select() {
+    let a: FixedUInt<u32, 4, Ct> = FixedUInt::<u32, 4, Nct>::from([0xAAu32, 0, 0, 0]).into();
+    let b: FixedUInt<u32, 4, Ct> = FixedUInt::<u32, 4, Nct>::from([0xBBu32, 0, 0, 0]).into();
+    let pick_a = <FixedUInt<u32, 4, Ct> as ConditionallySelectable>::conditional_select(
+        &a,
+        &b,
+        Choice::from(0),
+    );
+    let pick_b = <FixedUInt<u32, 4, Ct> as ConditionallySelectable>::conditional_select(
+        &a,
+        &b,
+        Choice::from(1),
+    );
+    assert_eq!(pick_a.forget_ct(), a.forget_ct());
+    assert_eq!(pick_b.forget_ct(), b.forget_ct());
+}
+
+#[test]
+fn nct_variant_does_not_have_constant_time_eq() {
+    // The following SHOULD fail to compile if uncommented — Nct lacks the
+    // subtle impls by design:
+    //
+    //     let n: FixedUInt<u32, 4, Nct> = FixedUInt::from([1u8, 2, 3, 4]);
+    //     let _ = <FixedUInt<u32, 4, Nct> as ConstantTimeEq>::ct_eq(&n, &n);
+    //     // error: ConstantTimeEq is not implemented for FixedUInt<_, _, Nct>
+    //
+    // We can't write a runtime test that asserts a trait isn't implemented,
+    // but the compile-error fallback test was verified manually.
+}
+
+// ---------------------------------------------------------------------------
+// MulAccOps demo migration: get_word returns Option for Nct, CtOption for Ct.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mul_acc_ops_get_word_nct_returns_option() {
+    let val: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x78u8, 0x56, 0x34, 0x12]);
+    let w0 = <FixedUInt<u8, 4, Nct> as MulAccOps>::get_word(&val, 0);
+    let w3 = <FixedUInt<u8, 4, Nct> as MulAccOps>::get_word(&val, 3);
+    let oob = <FixedUInt<u8, 4, Nct> as MulAccOps>::get_word(&val, 4);
+    // Plain Option — Some/None.
+    assert_eq!(w0, Some(0x78u8));
+    assert_eq!(w3, Some(0x12u8));
+    assert_eq!(oob, None);
+}
+
+#[test]
+fn mul_acc_ops_get_word_ct_returns_ctoption() {
+    let val: FixedUInt<u8, 4, Ct> =
+        FixedUInt::<u8, 4, Nct>::from([0x78u8, 0x56, 0x34, 0x12]).into();
+    let w0 = <FixedUInt<u8, 4, Ct> as MulAccOps>::get_word(&val, 0);
+    let w3 = <FixedUInt<u8, 4, Ct> as MulAccOps>::get_word(&val, 3);
+    let oob = <FixedUInt<u8, 4, Ct> as MulAccOps>::get_word(&val, 4);
+    // CtOption — validity is a Choice, not an enum discriminant.
+    assert!(bool::from(w0.is_some()));
+    assert!(bool::from(w3.is_some()));
+    assert!(!bool::from(oob.is_some()));
+    assert_eq!(w0.unwrap_or(0u8), 0x78u8);
+    assert_eq!(w3.unwrap_or(0u8), 0x12u8);
+    // Out-of-range gives the default; validity bit says don't use it.
+    assert_eq!(oob.unwrap_or(0xAAu8), 0xAAu8);
+}
+
+// ---------------------------------------------------------------------------
+// Combined-binary scenario: Nct and Ct in the same test.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn nct_and_ct_coexist_as_distinct_types() {
+    type FastU32 = FixedUInt<u8, 4, Nct>;
+    type CtU32 = FixedUInt<u8, 4, Ct>;
+
+    let fast: FastU32 = FixedUInt::from([0x01u8, 0x02, 0x03, 0x04]);
+    let ct: CtU32 = FixedUInt::<u8, 4, Nct>::from([0x01u8, 0x02, 0x03, 0x04]).into();
+
+    // Each gets the right MulAccOps::get_word return type.
+    let _w_fast: Option<u8> = <FastU32 as MulAccOps>::get_word(&fast, 0);
+    let _w_ct: subtle::CtOption<u8> = <CtU32 as MulAccOps>::get_word(&ct, 0);
+
+    // They're distinct types — no accidental interchange. The following
+    // SHOULD fail to compile if uncommented:
+    //     let _: FastU32 = ct;  // mismatched types
+    //     let _: CtU32 = fast;  // mismatched types
+}
+
+// ---------------------------------------------------------------------------
+// Zero / One delegation still works through the personality default.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn zero_via_num_traits_still_resolves() {
+    let z: FixedUInt<u32, 4> = FixedUInt::zero();
+    assert!(z.is_zero());
+}
+
+#[test]
+fn ct_variant_supports_add() {
+    let a: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(100u8).into();
+    let b: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(50u8).into();
+    let sum = a + b;
+    assert_eq!(sum.forget_ct(), FixedUInt::from(150u8));
+}
+
+#[test]
+fn ct_variant_supports_sub() {
+    let a: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(100u8).into();
+    let b: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(30u8).into();
+    let diff = a - b;
+    assert_eq!(diff.forget_ct(), FixedUInt::from(70u8));
+}
+
+#[test]
+fn ct_variant_supports_mul() {
+    let a: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(7u8).into();
+    let b: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(13u8).into();
+    let product = a * b;
+    assert_eq!(product.forget_ct(), FixedUInt::from(91u8));
+}
+
+#[test]
+fn ct_variant_supports_bitwise() {
+    let a: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(0b1100_1010u8).into();
+    let b: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(0b1010_1100u8).into();
+    let and = a & b;
+    let or = a | b;
+    let xor = a ^ b;
+    assert_eq!(and.forget_ct(), FixedUInt::from(0b1000_1000u8));
+    assert_eq!(or.forget_ct(), FixedUInt::from(0b1110_1110u8));
+    assert_eq!(xor.forget_ct(), FixedUInt::from(0b0110_0110u8));
+}
+
+#[test]
+fn ct_variant_supports_eq_via_partialeq() {
+    let a: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(42u8).into();
+    let b: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(42u8).into();
+    let c: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(43u8).into();
+    // PartialEq works (delegates to the generalized impl).
+    assert!(a == b);
+    assert!(a != c);
+}
+
+#[test]
+fn is_zero_works_correctly_under_both_personalities() {
+    use fixed_bigint::const_numtraits::ConstZero;
+
+    let z_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0u8);
+    let nz_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(42u8);
+    // Non-zero in the high limb to exercise the difference between
+    // short-circuit (Nct) and OR-fold (Ct) bodies.
+    let high_nz_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0u8, 0, 0, 1]);
+
+    assert!(<FixedUInt<u8, 4, Nct> as ConstZero>::is_zero(&z_nct));
+    assert!(!<FixedUInt<u8, 4, Nct> as ConstZero>::is_zero(&nz_nct));
+    assert!(!<FixedUInt<u8, 4, Nct> as ConstZero>::is_zero(&high_nz_nct));
+
+    let z_ct: FixedUInt<u8, 4, Ct> = z_nct.into();
+    let nz_ct: FixedUInt<u8, 4, Ct> = nz_nct.into();
+    let high_nz_ct: FixedUInt<u8, 4, Ct> = high_nz_nct.into();
+
+    // Same answers as Nct — different code path under the hood
+    // (`match P::TAG` selects `const_is_zero_ct` here).
+    assert!(<FixedUInt<u8, 4, Ct> as ConstZero>::is_zero(&z_ct));
+    assert!(!<FixedUInt<u8, 4, Ct> as ConstZero>::is_zero(&nz_ct));
+    assert!(!<FixedUInt<u8, 4, Ct> as ConstZero>::is_zero(&high_nz_ct));
+}
+
+#[test]
+fn is_one_works_correctly_under_both_personalities() {
+    use fixed_bigint::const_numtraits::ConstOne;
+
+    let one_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(1u8);
+    let zero_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0u8);
+    let two_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(2u8);
+    // High-limb-set distinguishes short-circuit from OR-fold timing.
+    let high_set_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([1u8, 0, 0, 1]);
+
+    assert!(<FixedUInt<u8, 4, Nct> as ConstOne>::is_one(&one_nct));
+    assert!(!<FixedUInt<u8, 4, Nct> as ConstOne>::is_one(&zero_nct));
+    assert!(!<FixedUInt<u8, 4, Nct> as ConstOne>::is_one(&two_nct));
+    assert!(!<FixedUInt<u8, 4, Nct> as ConstOne>::is_one(&high_set_nct));
+
+    let one_ct: FixedUInt<u8, 4, Ct> = one_nct.into();
+    let zero_ct: FixedUInt<u8, 4, Ct> = zero_nct.into();
+    let two_ct: FixedUInt<u8, 4, Ct> = two_nct.into();
+    let high_set_ct: FixedUInt<u8, 4, Ct> = high_set_nct.into();
+
+    // Same answers as Nct — different code path under the hood
+    // (`match P::TAG` selects `const_is_one_ct` here).
+    assert!(<FixedUInt<u8, 4, Ct> as ConstOne>::is_one(&one_ct));
+    assert!(!<FixedUInt<u8, 4, Ct> as ConstOne>::is_one(&zero_ct));
+    assert!(!<FixedUInt<u8, 4, Ct> as ConstOne>::is_one(&two_ct));
+    assert!(!<FixedUInt<u8, 4, Ct> as ConstOne>::is_one(&high_set_ct));
+}
+
+#[test]
+fn nct_and_ct_arithmetic_are_distinct() {
+    // The type system prevents mixing personalities in operators — these
+    // SHOULD fail to compile if uncommented:
+    //
+    //     let n: FixedUInt<u8, 4, Nct> = FixedUInt::from(1u8);
+    //     let c: FixedUInt<u8, 4, Ct>  = FixedUInt::<u8, 4, Nct>::from(2u8).into();
+    //     let _ = n + c;  // error: mismatched types
+    //
+    // Both variants individually have arithmetic; mixing requires an
+    // explicit conversion. This is the property we want — accidentally
+    // mixing a CT value into an NCT operation can't happen silently.
+
+    // Within-personality arithmetic does work, end-to-end:
+    let n: FixedUInt<u8, 4, Nct> = FixedUInt::from(2u8) * FixedUInt::from(3u8);
+    let c: FixedUInt<u8, 4, Ct> = {
+        let a: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(2u8).into();
+        let b: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(3u8).into();
+        a * b
+    };
+    assert_eq!(n, FixedUInt::from(6u8));
+    assert_eq!(c.forget_ct(), FixedUInt::from(6u8));
+}
+
+#[test]
+fn ct_variant_supports_constant_time_greater() {
+    let small: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 0, 0, 0]).into();
+    let big: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([0u8, 0, 0, 1]).into();
+    let same: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 0, 0, 0]).into();
+
+    assert_eq!(big.ct_gt(&small).unwrap_u8(), 1);
+    assert_eq!(small.ct_gt(&big).unwrap_u8(), 0);
+    assert_eq!(small.ct_gt(&same).unwrap_u8(), 0); // equal is not strictly greater
+}
+
+#[test]
+fn ct_variant_supports_constant_time_less() {
+    let small: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 0, 0, 0]).into();
+    let big: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([0u8, 0, 0, 1]).into();
+    let same: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 0, 0, 0]).into();
+
+    assert_eq!(small.ct_lt(&big).unwrap_u8(), 1);
+    assert_eq!(big.ct_lt(&small).unwrap_u8(), 0);
+    assert_eq!(small.ct_lt(&same).unwrap_u8(), 0); // equal is not strictly less
+}
+
+#[test]
+fn ct_compare_decides_on_high_limb_first() {
+    // Demonstrates correctness of the high-to-low scan: the decision
+    // is locked by the first differing limb, even if a lower limb
+    // would have suggested the opposite ordering.
+    let a: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([255u8, 0, 0, 1]).into();
+    let b: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([0u8, 0, 0, 2]).into();
+    // a's low limb is huge but b's high limb is bigger — b > a wins.
+    assert_eq!(b.ct_gt(&a).unwrap_u8(), 1);
+    assert_eq!(a.ct_gt(&b).unwrap_u8(), 0);
+}
+
+#[test]
+fn nct_variant_does_not_have_ct_gt() {
+    // `ConstantTimeGreater` is only impl'd on the Ct variant — uncommenting
+    // this would fail to compile, which is the additive-API guarantee.
+    //
+    //     let n: FixedUInt<u8, 4, Nct> = FixedUInt::from(1u8);
+    //     let _ = n.ct_gt(&n);  // error: method `ct_gt` is not in scope
+}
+
+#[test]
+fn leading_zeros_works_under_both_personalities() {
+    use fixed_bigint::ConstBitPrimInt;
+
+    // Zero: full word_bits * N leading zeros.
+    let z_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0u8);
+    let z_ct: FixedUInt<u8, 4, Ct> = z_nct.into();
+    assert_eq!(z_nct.leading_zeros(), 32);
+    assert_eq!(z_ct.leading_zeros(), 32);
+
+    // Single low-limb value: leading_zeros depends only on that limb plus
+    // the empty high limbs.
+    let low_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x80u8, 0, 0, 0]);
+    let low_ct: FixedUInt<u8, 4, Ct> = low_nct.into();
+    assert_eq!(low_nct.leading_zeros(), 24); // 3 zero high limbs + 0 in MSB of 0x80
+    assert_eq!(low_ct.leading_zeros(), 24);
+
+    // High-limb-set: 0 leading zeros at the very top.
+    let high_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0, 0, 0, 0x80u8]);
+    let high_ct: FixedUInt<u8, 4, Ct> = high_nct.into();
+    assert_eq!(high_nct.leading_zeros(), 0);
+    assert_eq!(high_ct.leading_zeros(), 0);
+
+    // Middle: 0x01 in second-from-top limb.
+    let mid_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0, 0, 0x01u8, 0]);
+    let mid_ct: FixedUInt<u8, 4, Ct> = mid_nct.into();
+    assert_eq!(mid_nct.leading_zeros(), 15); // 1 full zero high limb + 7 zeros in 0x01
+    assert_eq!(mid_ct.leading_zeros(), 15);
+}
+
+#[test]
+fn trailing_zeros_works_under_both_personalities() {
+    use fixed_bigint::ConstBitPrimInt;
+
+    // Zero: full width.
+    let z_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0u8);
+    let z_ct: FixedUInt<u8, 4, Ct> = z_nct.into();
+    assert_eq!(z_nct.trailing_zeros(), 32);
+    assert_eq!(z_ct.trailing_zeros(), 32);
+
+    // 0x01 in lowest limb: 0 trailing zeros.
+    let one_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(1u8);
+    let one_ct: FixedUInt<u8, 4, Ct> = one_nct.into();
+    assert_eq!(one_nct.trailing_zeros(), 0);
+    assert_eq!(one_ct.trailing_zeros(), 0);
+
+    // 0x80 in lowest limb: 7 trailing zeros.
+    let high_bit_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0x80u8);
+    let high_bit_ct: FixedUInt<u8, 4, Ct> = high_bit_nct.into();
+    assert_eq!(high_bit_nct.trailing_zeros(), 7);
+    assert_eq!(high_bit_ct.trailing_zeros(), 7);
+
+    // 0x01 in third limb: 16 trailing zeros (two empty limbs + 0 within 0x01).
+    let mid_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0, 0, 0x01u8, 0]);
+    let mid_ct: FixedUInt<u8, 4, Ct> = mid_nct.into();
+    assert_eq!(mid_nct.trailing_zeros(), 16);
+    assert_eq!(mid_ct.trailing_zeros(), 16);
+
+    // 0x80 in top limb: 31 trailing zeros (3 empty + 7 within 0x80).
+    let top_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0, 0, 0, 0x80u8]);
+    let top_ct: FixedUInt<u8, 4, Ct> = top_nct.into();
+    assert_eq!(top_nct.trailing_zeros(), 31);
+    assert_eq!(top_ct.trailing_zeros(), 31);
+}
+
+#[test]
+fn bit_length_works_under_both_personalities() {
+    // bit_length = total_bits - leading_zeros, so it inherits the dispatch.
+    let z_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0u8);
+    let z_ct: FixedUInt<u8, 4, Ct> = z_nct.into();
+    assert_eq!(z_nct.bit_length(), 0);
+    assert_eq!(z_ct.bit_length(), 0);
+
+    let v_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0, 0, 0x01u8, 0]);
+    let v_ct: FixedUInt<u8, 4, Ct> = v_nct.into();
+    assert_eq!(v_nct.bit_length(), 17); // top bit at position 16 → length 17
+    assert_eq!(v_ct.bit_length(), 17);
+
+    let full_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0xFF, 0xFF, 0xFF, 0xFFu8]);
+    let full_ct: FixedUInt<u8, 4, Ct> = full_nct.into();
+    assert_eq!(full_nct.bit_length(), 32);
+    assert_eq!(full_ct.bit_length(), 32);
+}
+
+#[test]
+fn shl_works_under_both_personalities() {
+    // Direct sanity: small shifts produce the same value.
+    for shift in [0usize, 1, 3, 7, 8, 15, 16, 23, 24, 31] {
+        let nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x12u8, 0x34, 0x56, 0x78]);
+        let ct: FixedUInt<u8, 4, Ct> = nct.into();
+        let nct_shifted = nct << shift;
+        let ct_shifted = ct << shift;
+        assert_eq!(
+            nct_shifted,
+            ct_shifted.forget_ct(),
+            "shl mismatch at shift={}",
+            shift
+        );
+    }
+
+    // Edge cases at and above bit_size (32 for u8*4).
+    for shift in [32usize, 33, 47, 64, 100, 1024] {
+        let nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x12u8, 0x34, 0x56, 0x78]);
+        let ct: FixedUInt<u8, 4, Ct> = nct.into();
+        let nct_shifted = nct << shift;
+        let ct_shifted = ct << shift;
+        assert_eq!(
+            nct_shifted,
+            ct_shifted.forget_ct(),
+            "shl mismatch at oversized shift={}",
+            shift
+        );
+        // For shifts >= bit_size, both bodies must zero the result.
+        assert!(num_traits::Zero::is_zero(&nct_shifted));
+        assert!(num_traits::Zero::is_zero(&ct_shifted.forget_ct()));
+    }
+}
+
+#[test]
+fn shr_works_under_both_personalities() {
+    for shift in [0usize, 1, 3, 7, 8, 15, 16, 23, 24, 31] {
+        let nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x12u8, 0x34, 0x56, 0x78]);
+        let ct: FixedUInt<u8, 4, Ct> = nct.into();
+        let nct_shifted = nct >> shift;
+        let ct_shifted = ct >> shift;
+        assert_eq!(
+            nct_shifted,
+            ct_shifted.forget_ct(),
+            "shr mismatch at shift={}",
+            shift
+        );
+    }
+
+    for shift in [32usize, 33, 47, 64, 100, 1024] {
+        let nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x12u8, 0x34, 0x56, 0x78]);
+        let ct: FixedUInt<u8, 4, Ct> = nct.into();
+        let nct_shifted = nct >> shift;
+        let ct_shifted = ct >> shift;
+        assert_eq!(
+            nct_shifted,
+            ct_shifted.forget_ct(),
+            "shr mismatch at oversized shift={}",
+            shift
+        );
+        assert!(num_traits::Zero::is_zero(&nct_shifted));
+        assert!(num_traits::Zero::is_zero(&ct_shifted.forget_ct()));
+    }
+}
+
+#[test]
+fn is_power_of_two_works_under_both_personalities() {
+    use fixed_bigint::const_numtraits::ConstPowerOfTwo;
+
+    // Zero is not a power of two — exercises the `n == 0` short-circuit path
+    // on Nct and the unconditional fallback on Ct.
+    let z_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0u8);
+    let z_ct: FixedUInt<u8, 4, Ct> = z_nct.into();
+    assert!(!z_nct.is_power_of_two());
+    assert!(!z_ct.is_power_of_two());
+
+    // Exact powers of two — both arms agree.
+    for v in [1u8, 2, 4, 8, 16, 32, 64, 128] {
+        let n: FixedUInt<u8, 4, Nct> = FixedUInt::from(v);
+        let c: FixedUInt<u8, 4, Ct> = n.into();
+        assert!(n.is_power_of_two(), "Nct: {} should be a power of two", v);
+        assert!(c.is_power_of_two(), "Ct: {} should be a power of two", v);
+    }
+
+    // Powers of two in higher limbs.
+    let high_pow_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0u8, 0, 0, 0x40]); // 2^30
+    let high_pow_ct: FixedUInt<u8, 4, Ct> = high_pow_nct.into();
+    assert!(high_pow_nct.is_power_of_two());
+    assert!(high_pow_ct.is_power_of_two());
+
+    // Non-powers of two — both arms agree.
+    for v in [3u8, 5, 6, 7, 9, 15, 100, 255] {
+        let n: FixedUInt<u8, 4, Nct> = FixedUInt::from(v);
+        let c: FixedUInt<u8, 4, Ct> = n.into();
+        assert!(
+            !n.is_power_of_two(),
+            "Nct: {} should not be a power of two",
+            v
+        );
+        assert!(
+            !c.is_power_of_two(),
+            "Ct: {} should not be a power of two",
+            v
+        );
+    }
+
+    // Non-power-of-two with bits in multiple limbs.
+    let multi_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x01u8, 0, 0, 0x01]);
+    let multi_ct: FixedUInt<u8, 4, Ct> = multi_nct.into();
+    assert!(!multi_nct.is_power_of_two());
+    assert!(!multi_ct.is_power_of_two());
+}
+
+#[test]
+fn pow_works_on_nct() {
+    use num_traits::PrimInt;
+
+    let cases: [(u8, u32, u32); 7] = [
+        (2, 0, 1),
+        (2, 1, 2),
+        (2, 4, 16),
+        (2, 7, 128),
+        (3, 5, 243),
+        (5, 3, 125),
+        (10, 4, 10000),
+    ];
+    for (base, exp, expected) in cases {
+        let n: FixedUInt<u32, 4, Nct> = FixedUInt::from(base as u32);
+        let want: FixedUInt<u32, 4, Nct> = FixedUInt::from(expected);
+        assert_eq!(
+            PrimInt::pow(n, exp),
+            want,
+            "Nct {} ^ {} = {}",
+            base,
+            exp,
+            expected
+        );
+    }
+}
+
+#[test]
+fn pow_handles_exp_zero_and_one_on_nct() {
+    use num_traits::PrimInt;
+
+    let zero_nct: FixedUInt<u32, 4, Nct> = FixedUInt::from(0u32);
+    let one: FixedUInt<u32, 4, Nct> = FixedUInt::from(1u32);
+    assert_eq!(PrimInt::pow(zero_nct, 0), one);
+
+    let x_nct: FixedUInt<u32, 4, Nct> = FixedUInt::from(42u32);
+    assert_eq!(PrimInt::pow(x_nct, 1), x_nct);
+}
+
+#[test]
+fn ct_add_wraps_instead_of_panicking() {
+    // Under Nct, Add+overflow panics in debug. Under Ct, it should wrap
+    // silently — the maybe_panic call is bypassed by `maybe_panic_if`.
+    let max_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0xFFFFu16).into();
+    let one_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(1u8).into();
+    // Would panic under Nct (overflow); under Ct it wraps to 0.
+    let result = max_ct + one_ct;
+    assert_eq!(
+        result.forget_ct(),
+        FixedUInt::<u8, 2, Nct>::from(0u8),
+        "Ct add should wrap"
+    );
+}
+
+#[test]
+fn ct_sub_wraps_instead_of_panicking() {
+    let zero_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0u8).into();
+    let one_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(1u8).into();
+    // 0 - 1 would underflow-panic under Nct; under Ct it wraps to MAX.
+    let result = zero_ct - one_ct;
+    assert_eq!(
+        result.forget_ct(),
+        FixedUInt::<u8, 2, Nct>::from(0xFFFFu16),
+        "Ct sub should wrap"
+    );
+}
+
+#[test]
+fn ct_saturating_add_uses_ct_select() {
+    use num_traits::SaturatingAdd;
+
+    // Below saturation: behaves identically.
+    let a_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(100u8).into();
+    let b_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(200u8).into();
+    let sum = SaturatingAdd::saturating_add(&a_ct, &b_ct);
+    assert_eq!(sum.forget_ct(), FixedUInt::<u8, 2, Nct>::from(300u16));
+
+    // At saturation: same result as Nct (max_value), different code path.
+    let max_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0xFFFFu16).into();
+    let one_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(1u8).into();
+    let sat = SaturatingAdd::saturating_add(&max_ct, &one_ct);
+    assert_eq!(sat.forget_ct(), FixedUInt::<u8, 2, Nct>::from(0xFFFFu16));
+}
+
+#[test]
+fn ct_saturating_sub_uses_ct_select() {
+    use num_traits::SaturatingSub;
+
+    let a_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(200u8).into();
+    let b_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(100u8).into();
+    let diff = SaturatingSub::saturating_sub(&a_ct, &b_ct);
+    assert_eq!(diff.forget_ct(), FixedUInt::<u8, 2, Nct>::from(100u8));
+
+    // Underflow saturates to zero.
+    let zero_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0u8).into();
+    let one_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(1u8).into();
+    let sat = SaturatingSub::saturating_sub(&zero_ct, &one_ct);
+    assert_eq!(sat.forget_ct(), FixedUInt::<u8, 2, Nct>::from(0u8));
+}
+
+#[test]
+fn ct_checked_add_returns_ctoption() {
+    let a: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(100u8).into();
+    let b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(200u8).into();
+
+    // No overflow: result valid.
+    let ok = a.ct_checked_add(&b);
+    assert!(bool::from(ok.is_some()));
+
+    // Overflow: result still has a defined value (the wrapped sum), but
+    // the validity Choice is 0.
+    let max: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0xFFFFu16).into();
+    let one: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(1u8).into();
+    let bad = max.ct_checked_add(&one);
+    assert!(!bool::from(bad.is_some()));
+}
+
+#[test]
+fn ct_checked_sub_returns_ctoption() {
+    let a: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(200u8).into();
+    let b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(100u8).into();
+    let ok = a.ct_checked_sub(&b);
+    assert!(bool::from(ok.is_some()));
+
+    // Underflow case.
+    let zero: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0u8).into();
+    let one: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(1u8).into();
+    let bad = zero.ct_checked_sub(&one);
+    assert!(!bool::from(bad.is_some()));
+}
+
+#[test]
+fn ct_checked_mul_returns_ctoption() {
+    let a: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0x100u16).into();
+    let b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0x100u16).into();
+    // 0x100 * 0x100 = 0x10000, fits in u16, no overflow.
+    let near = a.ct_checked_mul(&b);
+    assert!(!bool::from(near.is_some())); // 0x10000 > u16::MAX → overflow
+
+    let small_a: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(10u8).into();
+    let small_b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(20u8).into();
+    let ok = small_a.ct_checked_mul(&small_b);
+    assert!(bool::from(ok.is_some()));
+}
+
+#[test]
+fn abs_diff_works_under_both_personalities() {
+    use fixed_bigint::const_numtraits::ConstAbsDiff;
+
+    let cases: [(u8, u8, u8); 6] = [
+        (10, 3, 7), // a > b
+        (3, 10, 7), // a < b
+        (5, 5, 0),  // equal
+        (0, 100, 100),
+        (255, 0, 255),
+        (200, 100, 100),
+    ];
+
+    for (a, b, expected) in cases {
+        let an: FixedUInt<u8, 2, Nct> = FixedUInt::from(a);
+        let bn: FixedUInt<u8, 2, Nct> = FixedUInt::from(b);
+        let ac: FixedUInt<u8, 2, Ct> = an.into();
+        let bc: FixedUInt<u8, 2, Ct> = bn.into();
+        let want: FixedUInt<u8, 2, Nct> = FixedUInt::from(expected);
+        assert_eq!(
+            ConstAbsDiff::abs_diff(an, bn),
+            want,
+            "Nct abs_diff({}, {}) = {}",
+            a,
+            b,
+            expected
+        );
+        assert_eq!(
+            ConstAbsDiff::abs_diff(ac, bc).forget_ct(),
+            want,
+            "Ct abs_diff({}, {}) = {}",
+            a,
+            b,
+            expected
+        );
+    }
+}
+
+#[test]
+fn ct_checked_pow_returns_ctoption() {
+    // No overflow: result valid.
+    let two_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(2u8).into();
+    let ok = two_ct.ct_checked_pow(8);
+    assert!(bool::from(ok.is_some()));
+
+    // Just-fits: 2^15 = 32768, fits in u16.
+    let big = two_ct.ct_checked_pow(15);
+    assert!(bool::from(big.is_some()));
+
+    // Overflow: 2^16 = 65536, exceeds u16::MAX.
+    let overflow = two_ct.ct_checked_pow(16);
+    assert!(!bool::from(overflow.is_some()));
+
+    // Overflow via base, not exponent: 256^2 = 65536.
+    let base_overflow_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(256u16).into();
+    let bo = base_overflow_ct.ct_checked_pow(2);
+    assert!(!bool::from(bo.is_some()));
+
+    // Exp = 0 always succeeds, returns 1.
+    let any_ct: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(42u8).into();
+    let one = any_ct.ct_checked_pow(0);
+    assert!(bool::from(one.is_some()));
+    assert_eq!(one.unwrap_or(any_ct).forget_ct(), FixedUInt::from(1u8));
+}
+
+#[test]
+fn ct_partial_eq_uses_or_fold() {
+    // Nct array equality short-circuits at first differing limb. Ct
+    // OR-folds all XOR-diffs so equality timing is independent of where
+    // values differ. Same answer; different code path.
+    let a_ct: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 2, 3, 4]).into();
+    let same_ct: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 2, 3, 4]).into();
+    let low_diff_ct: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([2u8, 2, 3, 4]).into();
+    let high_diff_ct: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from([1u8, 2, 3, 5]).into();
+    assert_eq!(a_ct, same_ct);
+    assert_ne!(a_ct, low_diff_ct); // differs in limb 0
+    assert_ne!(a_ct, high_diff_ct); // differs in limb 3 (high)
+}
+
+#[test]
+fn ct_display_and_hex_do_not_compile() {
+    // These would expose limb values; the restriction to Nct-only means
+    // they now fail to compile on Ct values. Verified manually; we can't
+    // runtime-test that something doesn't compile.
+    //
+    //     let c: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(42u8).into();
+    //     let _ = format!("{}", c);    // error: Display not impl for Ct
+    //     let _ = format!("{:x}", c);  // error: LowerHex not impl for Ct
+    //     let _ = format!("{:X}", c);  // error: UpperHex not impl for Ct
+    //
+    // To format a Ct value the caller must `forget_ct()` first — making
+    // the leak an explicit, greppable decision rather than an accident.
+    let c: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(42u8).into();
+    let nct = c.forget_ct();
+    assert_eq!(format!("{}", nct), "42");
+    assert_eq!(format!("{:x}", nct), "2a");
+}
+
+#[test]
+fn ct_debug_redacts_limb_values() {
+    // Nct: standard derived-style Debug exposes limbs (intentional, for
+    // development convenience). Ct: redacted to a placeholder so panic
+    // messages / dbg! / logs can never leak secret values.
+    let nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0xDE, 0xAD, 0xBE, 0xEF]);
+    let ct: FixedUInt<u8, 4, Ct> = nct.into();
+    let nct_dbg = format!("{:?}", nct);
+    let ct_dbg = format!("{:?}", ct);
+    assert!(
+        nct_dbg.contains("222") || nct_dbg.contains("0xDE") || nct_dbg.contains("DE"),
+        "Nct debug should expose limbs (got: {})",
+        nct_dbg
+    );
+    assert_eq!(ct_dbg, "FixedUInt<…>");
+    // Sanity: redaction doesn't depend on byte content — all-zero is also redacted.
+    let zero_ct: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(0u8).into();
+    assert_eq!(format!("{:?}", zero_ct), "FixedUInt<…>");
+}
+
+#[test]
+fn next_power_of_two_works_under_both_personalities() {
+    use fixed_bigint::const_numtraits::ConstPowerOfTwo;
+    for (input, expected) in [
+        (0u16, 1u16),
+        (1, 1),
+        (2, 2),
+        (3, 4),
+        (5, 8),
+        (100, 128),
+        (128, 128),
+    ] {
+        let n: FixedUInt<u8, 2, Nct> = FixedUInt::from(input);
+        let c: FixedUInt<u8, 2, Ct> = n.into();
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(n),
+            FixedUInt::from(expected),
+            "Nct next_power_of_two({}) = {}",
+            input,
+            expected,
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(c).forget_ct(),
+            FixedUInt::from(expected),
+            "Ct next_power_of_two({}) = {}",
+            input,
+            expected,
+        );
+    }
+}
+
+#[test]
+fn ct_checked_next_power_of_two_returns_ctoption() {
+    // Zero → 1, valid.
+    let z: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0u8).into();
+    let r0 = z.ct_checked_next_power_of_two();
+    assert!(bool::from(r0.is_some()));
+    assert_eq!(r0.unwrap_or(z).forget_ct(), FixedUInt::from(1u8));
+
+    // Just fits: 32768 = 2^15.
+    let big: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(32768u16).into();
+    let rbig = big.ct_checked_next_power_of_two();
+    assert!(bool::from(rbig.is_some()));
+
+    // Overflow: 32769 → needs 2^16 = 65536 which is u16::MAX + 1.
+    let overflow: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(32769u16).into();
+    let rov = overflow.ct_checked_next_power_of_two();
+    assert!(!bool::from(rov.is_some()));
+
+    // 100 → 128.
+    let v: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(100u8).into();
+    let rv = v.ct_checked_next_power_of_two();
+    assert!(bool::from(rv.is_some()));
+    assert_eq!(rv.unwrap_or(v).forget_ct(), FixedUInt::from(128u8));
+}
+
+#[test]
+fn ct_checked_shl_shr_return_ctoption() {
+    let v: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0x1234u16).into();
+
+    // Within range.
+    let ok_l = v.ct_checked_shl(4);
+    assert!(bool::from(ok_l.is_some()));
+    let ok_r = v.ct_checked_shr(4);
+    assert!(bool::from(ok_r.is_some()));
+
+    // Beyond bit_size (= 16 for u8*2).
+    let bad_l = v.ct_checked_shl(32);
+    assert!(!bool::from(bad_l.is_some()));
+    let bad_r = v.ct_checked_shr(32);
+    assert!(!bool::from(bad_r.is_some()));
+}
+
+#[test]
+fn ct_checked_composes_with_conditional_select() {
+    use subtle::ConditionallySelectable;
+
+    // The motivating shape: try a CT add; if it overflows, fall back to
+    // a known-safe value. All decisions branch-free.
+    let max: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(0xFFFFu16).into();
+    let one: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(1u8).into();
+    let fallback: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(42u8).into();
+
+    let attempt = max.ct_checked_add(&one);
+    // CtOption::unwrap_or under the hood is conditional_select between the
+    // contained value and the fallback, gated by the validity Choice.
+    let result = attempt.unwrap_or(fallback);
+
+    assert_eq!(
+        result.forget_ct(),
+        FixedUInt::<u8, 2, Nct>::from(42u8),
+        "overflow → fallback"
+    );
+
+    // No-overflow path: keep the result.
+    let a: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(10u8).into();
+    let b: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(20u8).into();
+    let ok = a.ct_checked_add(&b);
+    let kept = ok.unwrap_or(fallback);
+    let _ = ConditionallySelectable::conditional_select(&kept, &fallback, subtle::Choice::from(0));
+    assert_eq!(kept.forget_ct(), FixedUInt::<u8, 2, Nct>::from(30u8));
+}
+
+#[test]
+fn ct_shr_by_trailing_zeros_pattern() {
+    // The motivating modular-inverse use case: shr by tz(x), where
+    // tz is a secret count. Both halves of the operation are CT under
+    // Ct personality. Verifies the pieces compose correctly.
+    use fixed_bigint::ConstBitPrimInt;
+
+    // Pick a value with a known trailing-zero count.
+    // 0x10000000 = bit 28 set, so trailing_zeros == 28.
+    let v_ct: FixedUInt<u8, 4, Ct> =
+        FixedUInt::<u8, 4, Nct>::from([0x00u8, 0x00, 0x00, 0x10]).into();
+    let tz = v_ct.trailing_zeros();
+    assert_eq!(tz, 28);
+
+    // shr by tz should normalize v_ct to its odd part (which is 1 here).
+    let normalized: FixedUInt<u8, 4, Ct> = v_ct >> (tz as usize);
+    let one: FixedUInt<u8, 4, Nct> = FixedUInt::from(1u8);
+    assert_eq!(normalized.forget_ct(), one);
+}
+
+#[test]
+fn ct_montgomery_conditional_subtract_pattern() {
+    // The motivating use case: "if x >= N, subtract N" — the standard
+    // Montgomery reduction tail. The CT idiom composes `ct_lt` with
+    // `ConditionallySelectable`, never branching on a magnitude bit.
+    //
+    // Pick N = 100, then check that both inputs land in [0, N).
+    let n_val: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(100u8).into();
+
+    let cases: [(u8, u8); 4] = [
+        (50, 50),   // x < N: no subtraction
+        (100, 0),   // x == N: subtract once (>=, not >)
+        (150, 50),  // x > N: subtract once
+        (200, 100), // x > N: subtract once
+    ];
+
+    for (x, expected) in cases {
+        let x_ct: FixedUInt<u8, 4, Ct> = FixedUInt::<u8, 4, Nct>::from(x).into();
+        // wrapping_sub is the CT-friendly subtractor — it never branches on
+        // the result, so we compute the difference unconditionally and let
+        // `conditional_select` discard it when geq is false.
+        let diff_ct: FixedUInt<u8, 4, Ct> = num_traits::WrappingSub::wrapping_sub(&x_ct, &n_val);
+
+        // geq = !lt  — both x > N and x == N should trigger subtraction
+        let lt: Choice = x_ct.ct_lt(&n_val);
+        let geq: Choice = !lt;
+
+        // CT pick: if geq then diff else x
+        let result: FixedUInt<u8, 4, Ct> = FixedUInt::conditional_select(&x_ct, &diff_ct, geq);
+
+        let expected_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(expected);
+        assert_eq!(
+            result.forget_ct(),
+            expected_nct,
+            "x = {} expected {} got {:?}",
+            x,
+            expected,
+            result.forget_ct()
+        );
+    }
+}
+
+#[test]
+fn shl_assign_dispatches_under_both_personalities() {
+    // Regression: assigns previously hard-wired the Nct shifter even on Ct,
+    // leaking the secret shift amount. Verify behavioural parity with the
+    // non-assign form across both arms.
+    for shift in [0usize, 1, 7, 8, 15, 24, 31, 32, 33, 64, 1024] {
+        let nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x12u8, 0x34, 0x56, 0x78]);
+        let ct: FixedUInt<u8, 4, Ct> = nct.into();
+        let mut nct_a = nct;
+        let mut ct_a = ct;
+        nct_a <<= shift;
+        ct_a <<= shift;
+        assert_eq!(
+            nct_a,
+            ct_a.forget_ct(),
+            "shl_assign mismatch shift={}",
+            shift
+        );
+        assert_eq!(
+            nct_a,
+            nct << shift,
+            "shl_assign vs shl mismatch shift={}",
+            shift
+        );
+    }
+}
+
+#[test]
+fn shr_assign_dispatches_under_both_personalities() {
+    for shift in [0usize, 1, 7, 8, 15, 24, 31, 32, 33, 64, 1024] {
+        let nct: FixedUInt<u8, 4, Nct> = FixedUInt::from([0x12u8, 0x34, 0x56, 0x78]);
+        let ct: FixedUInt<u8, 4, Ct> = nct.into();
+        let mut nct_a = nct;
+        let mut ct_a = ct;
+        nct_a >>= shift;
+        ct_a >>= shift;
+        assert_eq!(
+            nct_a,
+            ct_a.forget_ct(),
+            "shr_assign mismatch shift={}",
+            shift
+        );
+        assert_eq!(
+            nct_a,
+            nct >> shift,
+            "shr_assign vs shr mismatch shift={}",
+            shift
+        );
+    }
+}
+
+#[test]
+fn ord_on_ct_agrees_with_nct() {
+    // Regression: Ord::cmp on Ct used to call the short-circuiting const_cmp;
+    // it now dispatches to a full-width scan via match P::TAG. Result must
+    // still match Nct's ordering across positions where the decisive limb
+    // varies.
+    let cases: [([u8; 4], [u8; 4]); 6] = [
+        ([1, 2, 3, 4], [1, 2, 3, 4]),    // equal
+        ([1, 2, 3, 4], [1, 2, 3, 5]),    // differs at top (Less)
+        ([1, 2, 3, 5], [1, 2, 3, 4]),    // differs at top (Greater)
+        ([255, 0, 0, 1], [0, 0, 0, 2]),  // low-limb noise; top decides
+        ([0, 0, 0xFF, 0], [0, 0, 0, 1]), // differs at second-from-top
+        ([0xAA, 0xBB, 0xCC, 0xDD], [0xAA, 0xBB, 0xCC, 0xDD]),
+    ];
+    for (a, b) in cases {
+        let an: FixedUInt<u8, 4, Nct> = FixedUInt::from(a);
+        let bn: FixedUInt<u8, 4, Nct> = FixedUInt::from(b);
+        let ac: FixedUInt<u8, 4, Ct> = an.into();
+        let bc: FixedUInt<u8, 4, Ct> = bn.into();
+        assert_eq!(ac.cmp(&bc), an.cmp(&bn), "cmp mismatch a={:?} b={:?}", a, b);
+        assert_eq!(
+            ac.partial_cmp(&bc),
+            an.partial_cmp(&bn),
+            "partial_cmp mismatch a={:?} b={:?}",
+            a,
+            b
+        );
+        // Cross-check against the CT-Choice comparators.
+        assert_eq!(
+            (ac.cmp(&bc) == core::cmp::Ordering::Greater),
+            bool::from(ac.ct_gt(&bc)),
+            "cmp/ct_gt disagree a={:?} b={:?}",
+            a,
+            b
+        );
+        assert_eq!(
+            (ac.cmp(&bc) == core::cmp::Ordering::Less),
+            bool::from(ac.ct_lt(&bc)),
+            "cmp/ct_lt disagree a={:?} b={:?}",
+            a,
+            b
+        );
+    }
+}
+
+#[test]
+fn next_power_of_two_saturates_to_max_on_ct_overflow() {
+    use fixed_bigint::const_numtraits::{ConstBounded, ConstPowerOfTwo};
+
+    // u16 type with Ct personality. Inputs whose next_power_of_two exceeds
+    // u16::MAX should saturate to MAX, not silently return 0.
+    let max_u16: FixedUInt<u8, 2, Ct> = <FixedUInt<u8, 2, Ct> as ConstBounded>::max_value();
+
+    for input in [0x8001u16, 0xC000, 0xFFFF] {
+        let v: FixedUInt<u8, 2, Ct> = FixedUInt::<u8, 2, Nct>::from(input).into();
+        let r = ConstPowerOfTwo::next_power_of_two(v);
+        assert_eq!(
+            r.forget_ct(),
+            max_u16.forget_ct(),
+            "Ct next_power_of_two({:#x}) should saturate to MAX",
+            input
+        );
+    }
+
+    // Non-overflow inputs still produce the exact power of two on both arms.
+    for (input, expected) in [(0u16, 1u16), (1, 1), (5, 8), (100, 128), (32768, 32768)] {
+        let n: FixedUInt<u8, 2, Nct> = FixedUInt::from(input);
+        let c: FixedUInt<u8, 2, Ct> = n.into();
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(n),
+            FixedUInt::from(expected),
+            "Nct next_power_of_two({})",
+            input
+        );
+        assert_eq!(
+            ConstPowerOfTwo::next_power_of_two(c).forget_ct(),
+            FixedUInt::from(expected),
+            "Ct next_power_of_two({})",
+            input
+        );
+    }
+}

--- a/tests/personality_negative_guarantees.rs
+++ b/tests/personality_negative_guarantees.rs
@@ -1,0 +1,35 @@
+//! Compile-time enforcement of the personality typestate's negative
+//! guarantees. Each `assert_not_impl_any!` fails the build if the listed
+//! trait is implemented for the listed type, so a regression in the
+//! trait-bound surface fails CI instead of silently passing the
+//! commented-out "SHOULD fail to compile" blocks in
+//! `tests/personality_integration.rs`.
+
+use core::fmt::{Display, LowerHex, UpperHex};
+use fixed_bigint::personality::{Ct, Nct};
+use fixed_bigint::FixedUInt;
+use static_assertions::assert_not_impl_any;
+use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
+
+// Nct lacks the CT comparison traits — those are reserved for Ct so
+// secret-handling call sites must opt in via the typestate.
+assert_not_impl_any!(FixedUInt<u32, 4, Nct>: ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess);
+
+// Ct cannot be formatted with Display / LowerHex / UpperHex — these
+// would expose limb contents in panics, logs, or `dbg!`. Callers must
+// `forget_ct()` first, making the leak explicit and greppable.
+assert_not_impl_any!(FixedUInt<u32, 4, Ct>: Display, LowerHex, UpperHex);
+
+// Ct -> Nct is not `From`/`Into`. Going from CT to non-CT is a privilege
+// escalation and must use the named `forget_ct()` method.
+assert_not_impl_any!(FixedUInt<u32, 4, Nct>: From<FixedUInt<u32, 4, Ct>>);
+
+// Nct -> Ct, in contrast, is `From`/`Into` (lossless invariant
+// tightening). This regular `#[test]` doubles as a positive-direction
+// sanity check so a future change that accidentally removed that impl
+// would surface here too.
+#[test]
+fn nct_to_ct_into_is_available() {
+    let n: FixedUInt<u32, 4, Nct> = FixedUInt::from([1u32, 2, 3, 4]);
+    let _c: FixedUInt<u32, 4, Ct> = n.into();
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a personality-parameterized FixedUInt with constant-time and non-constant-time variants, wiring constant-time behavior through arithmetic/bit operations and traits while preserving existing Nct APIs by default.

New Features:
- Add a third generic parameter P: Personality to FixedUInt with default Nct, enabling an explicit Ct constant-time variant for sensitive uses.
- Provide constant-time helper APIs on FixedUInt<Ct> such as ct_checked_add/sub/mul/shl/shr/next_power_of_two/pow that return subtle::CtOption results for branch-free error handling.
- Integrate FixedUInt<Ct> with the subtle crate by implementing ConstantTimeEq, ConditionallySelectable, ConstantTimeGreater and ConstantTimeLess for the Ct variant.
- Expose a new personality module and re-export Ct, Nct, Personality, PersonalityTag, and ConstBitPrimInt to let callers select timing behavior at the type level.

Enhancements:
- Refactor core FixedUInt arithmetic, bit-level operations, and const helpers (add/sub/mul, shifts, leading/trailing zeros, comparisons, is_zero/is_one, power-of-two logic) to dispatch on PersonalityTag, using CT implementations for Ct and preserving fast short-circuiting for Nct.
- Adjust trait impls (num_traits, PrimInt, Euclid, Div/Rem, formatting, bytes/identity traits) so that value-revealing or division-based functionality remains Nct-only while CT-safe primitives work for both personalities.
- Change shift, resize, and widening/carrying-mul code paths to be personality-aware, ensuring Ct variants avoid data-dependent branching and maintain constant-time iteration counts.
- Tighten Debug/Display behavior so Ct FixedUInt redacts limb contents in Debug output and does not implement formatting traits that would leak internal values.
- Extend MachineWord and const_numtraits with ConstBitPrimInt, CT-friendly widening/carrying helpers, and personality-driven panic/overflow handling (maybe_panic_if) to support the new CT paths.
- Update mul-accumulate abstractions so MulAccOps::get_word returns Option for Nct and subtle::CtOption for Ct, preserving existing fast callers while enabling CT-safe scans.

Build:
- Bump crate version from 0.2.5 to 0.3.0 and add the subtle dependency to support constant-time traits and CtOption.

Tests:
- Add extensive personality_integration tests that exercise Nct/Ct coexistence, conversions, subtle integration, CT helpers, arithmetic/bit ops, ordering, shifts, power-of-two, and formatting redaction across both personalities.
- Update existing fixeduint tests to construct values via from_array and to work with personality-aware const helpers and test wrappers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable "personality" modes (default Nct and constant-time Ct) that alter behavior and expose CT-safe APIs; Ct redacts debug output while Nct preserves normal formatting.
  * Many numeric, bit/shift, checked/math, and byte/formatting APIs now respect personality semantics.

* **Tests**
  * Added extensive unit and integration tests covering both personalities, CT guarantees, and regressions.

* **Documentation**
  * README updated with MSRV badge and a new "Constant time" section.

* **Chores**
  * Crate version bumped to 0.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->