### PR TITLE
Add ct-verify: asm-grep harness for constant-time primitives

### DIFF
--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -13,26 +13,26 @@ jobs:
         include:
           # Priority 1: Cortex-M3/M4
           - triple: thumbv7em-none-eabi
-            toolchain: "1.83"
+            toolchain: "1.85"
           - triple: thumbv7m-none-eabi
-            toolchain: "1.83"
+            toolchain: "1.85"
           # Priority 2: Cortex-M0
           - triple: thumbv6m-none-eabi
-            toolchain: "1.83"
+            toolchain: "1.85"
           # Priority 3: 32-bit RISC-V
           - triple: riscv32imc-unknown-none-elf
-            toolchain: "1.83"
+            toolchain: "1.85"
           - triple: riscv32imac-unknown-none-elf
-            toolchain: "1.83"
+            toolchain: "1.85"
           # Priority 5: aarch64
           - triple: aarch64-unknown-linux-gnu
-            toolchain: "1.83"
+            toolchain: "1.85"
           # Priority 6: x86_64
           - triple: x86_64-unknown-linux-gnu
-            toolchain: "1.83"
+            toolchain: "1.85"
           # Priority 4: AVR (nightly-only, needs build-std + target-cpu).
           - triple: avr-none
-            toolchain: nightly
+            toolchain: nightly-2026-05-30
             extra_components: rust-src
             extra_rustflags: "-C target-cpu=atmega328p"
             extra_cargo_args: "-Z build-std=core"
@@ -55,7 +55,9 @@ jobs:
 
       - name: Run ct-driver
         env:
-          RUSTFLAGS: ${{ matrix.extra_rustflags }}
+          # Scope target-specific rustflags to the cross-target build
+          # only — leaks into the host ct-driver compile otherwise.
+          CARGO_TARGET_AVR_NONE_RUSTFLAGS: ${{ matrix.extra_rustflags }}
         run: cargo run --release -p ct-driver -- --target ${{ matrix.triple }} --json-out target/ct-report/${{ matrix.triple }}.json
 
       - name: Upload report

--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -48,7 +48,11 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          targets: ${{ matrix.triple }}
+          # AVR is tier 3 — rust-std isn't published as a downloadable
+          # component, so `rustup target add avr-none` fails. We build
+          # core from source via -Z build-std=core (see rust-src below)
+          # so the precompiled std isn't needed.
+          targets: ${{ matrix.triple == 'avr-none' && '' || matrix.triple }}
           components: llvm-tools-preview${{ matrix.extra_components && ', ' || '' }}${{ matrix.extra_components }}
 
       - name: Cargo cache

--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -38,7 +38,6 @@ jobs:
             toolchain: nightly
             extra_components: rust-src
             extra_rustflags: "-C target-cpu=atmega328p"
-            extra_cargo_args: "-Z build-std=core"
     runs-on: ubuntu-latest
     name: ${{ matrix.triple }}
     steps:

--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -31,8 +31,11 @@ jobs:
           - triple: x86_64-unknown-linux-gnu
             toolchain: "1.85"
           # Priority 4: AVR (nightly-only, needs build-std + target-cpu).
+          # Bare `nightly` because rust-std for avr-none isn't published
+          # on every nightly date — a pinned date risks the AVR job
+          # failing at component install rather than at verification.
           - triple: avr-none
-            toolchain: nightly-2026-05-30
+            toolchain: nightly
             extra_components: rust-src
             extra_rustflags: "-C target-cpu=atmega328p"
             extra_cargo_args: "-Z build-std=core"

--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -1,0 +1,67 @@
+name: CT Verify
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ct:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Priority 1: Cortex-M3/M4
+          - triple: thumbv7em-none-eabi
+            toolchain: "1.83"
+          - triple: thumbv7m-none-eabi
+            toolchain: "1.83"
+          # Priority 2: Cortex-M0
+          - triple: thumbv6m-none-eabi
+            toolchain: "1.83"
+          # Priority 3: 32-bit RISC-V
+          - triple: riscv32imc-unknown-none-elf
+            toolchain: "1.83"
+          - triple: riscv32imac-unknown-none-elf
+            toolchain: "1.83"
+          # Priority 5: aarch64
+          - triple: aarch64-unknown-linux-gnu
+            toolchain: "1.83"
+          # Priority 6: x86_64
+          - triple: x86_64-unknown-linux-gnu
+            toolchain: "1.83"
+          # Priority 4: AVR (nightly-only, needs build-std + target-cpu).
+          - triple: avr-none
+            toolchain: nightly
+            extra_components: rust-src
+            extra_rustflags: "-C target-cpu=atmega328p"
+            extra_cargo_args: "-Z build-std=core"
+    runs-on: ubuntu-latest
+    name: ${{ matrix.triple }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          targets: ${{ matrix.triple }}
+          components: llvm-tools-preview${{ matrix.extra_components && ', ' || '' }}${{ matrix.extra_components }}
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ct-verify-${{ matrix.triple }}
+
+      - name: Run ct-driver
+        env:
+          RUSTFLAGS: ${{ matrix.extra_rustflags }}
+        run: cargo run --release -p ct-driver -- --target ${{ matrix.triple }} --json-out target/ct-report/${{ matrix.triple }}.json
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ct-report-${{ matrix.triple }}
+          path: target/ct-report/
+          retention-days: 30

--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -52,7 +52,12 @@ jobs:
           # component, so `rustup target add avr-none` fails. We build
           # core from source via -Z build-std=core (see rust-src below)
           # so the precompiled std isn't needed.
-          targets: ${{ matrix.triple == 'avr-none' && '' || matrix.triple }}
+          #
+          # NB: GitHub Actions ternary needs polarity-flip here. The
+          # natural `X == 'avr-none' && '' || X` short-circuits to X
+          # because `''` is falsy in `||`. The form below resolves to
+          # `''` on AVR and `X` everywhere else.
+          targets: ${{ matrix.triple != 'avr-none' && matrix.triple || '' }}
           components: llvm-tools-preview${{ matrix.extra_components && ', ' || '' }}${{ matrix.extra_components }}
 
       - name: Cargo cache

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,18 @@
+[workspace]
+members = [".", "ct-verify/ct-fixtures", "ct-verify/ct-driver"]
+resolver = "2"
+
+# Pinned release profile: deterministic codegen so a passing PR locks
+# the inspection output.
+[profile.release]
+lto = "fat"
+codegen-units = 1
+opt-level = "z"
+panic = "abort"
+debug = false
+overflow-checks = false
+incremental = false
+
 [package]
 name = "fixed-bigint"
 version = "0.3.0"

--- a/ct-verify/README.md
+++ b/ct-verify/README.md
@@ -1,0 +1,19 @@
+# ct-verify
+
+A small cross-target asm-grep gate for the constant-time primitives in
+`fixed-bigint`. The fixtures crate emits one `#[no_mangle] pub extern "C"`
+symbol per `(operation, T, N)` instantiation we want to check, with
+`core::hint::black_box` at both ends so the optimizer can't fold the
+body away. The driver cross-builds that crate, disassembles the
+resulting archive with `llvm-objdump`, and flags any forbidden
+conditional control transfer it finds inside the fixture wrappers —
+`b.<cond>` and friends on Thumb, `beq`/`bne`/... on RISC-V, `br<cc>`
+and the skip-if-bit family on AVR, `b.<cond>`/`cbz`/`tbz` on AArch64,
+`j<cc>` on x86-64. A handful of negative-control fixtures exercise
+non-CT operations and are required to trip the gate — they're the
+harness's self-test.
+
+To run it: `cargo run --release -p ct-driver` checks the host target;
+`--target <triple>` checks a cross target (you'll need the matching
+`rustup target add` first, plus the `llvm-tools-preview` component for
+`llvm-objdump`). `--list-targets` shows what's supported.

--- a/ct-verify/ct-driver/Cargo.toml
+++ b/ct-verify/ct-driver/Cargo.toml
@@ -14,6 +14,5 @@ path = "src/main.rs"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-which = "6"
 
 [dev-dependencies]

--- a/ct-verify/ct-driver/Cargo.toml
+++ b/ct-verify/ct-driver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ct-driver"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.85"
 publish = false
 description = "Cross-target disassembly + branch-grep driver for fixed-bigint CT verify."
 

--- a/ct-verify/ct-driver/Cargo.toml
+++ b/ct-verify/ct-driver/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ct-driver"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.73"
+publish = false
+description = "Cross-target disassembly + branch-grep driver for fixed-bigint CT verify."
+
+[[bin]]
+name = "ct-driver"
+path = "src/main.rs"
+
+[dependencies]
+regex = "1.10"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+which = "6"
+
+[dev-dependencies]

--- a/ct-verify/ct-driver/src/main.rs
+++ b/ct-verify/ct-driver/src/main.rs
@@ -1,0 +1,360 @@
+//! CT-verify driver.
+//!
+//! Workflow per target:
+//!   1. cargo build --release --target=<triple> -p ct-fixtures
+//!   2. find the resulting libct_fixtures.a
+//!   3. llvm-objdump --disassemble + filter to in-scope symbols
+//!   4. run per-target mnemonic check (forbidden / allowed / thumb IT)
+//!   5. emit JSON report
+//!   6. exit non-zero if any ct_fix__* fixture has a violation
+//!      OR any nct_fix__neg__* fixture has zero violations
+
+mod mnemonics;
+mod parse;
+mod report;
+mod target;
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+
+use crate::parse::{Patterns, Violation};
+use crate::report::{Report, ViolationOut};
+use crate::target::{lookup, TargetSpec, TARGETS};
+
+#[derive(Default)]
+struct Args {
+    target: Option<String>,
+    json_out: Option<PathBuf>,
+    list_targets: bool,
+    skip_build: bool,
+    archive_override: Option<PathBuf>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut args = Args::default();
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--target" => {
+                args.target = Some(it.next().ok_or("--target requires a triple")?);
+            }
+            "--json-out" => {
+                args.json_out = Some(PathBuf::from(
+                    it.next().ok_or("--json-out requires a path")?,
+                ));
+            }
+            "--list-targets" => args.list_targets = true,
+            "--skip-build" => args.skip_build = true,
+            "--archive" => {
+                args.archive_override =
+                    Some(PathBuf::from(it.next().ok_or("--archive requires a path")?));
+            }
+            "-h" | "--help" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {}", other)),
+        }
+    }
+    Ok(args)
+}
+
+fn print_help() {
+    eprintln!(
+        "ct-driver — disassemble ct-fixtures and gate on forbidden conditional branches.\n\
+         \n\
+         Usage:\n\
+           ct-driver --target <TRIPLE> [--json-out <PATH>] [--skip-build] [--archive <PATH>]\n\
+           ct-driver --list-targets\n\
+           ct-driver -h | --help\n\
+         \n\
+         Options:\n\
+           --target <TRIPLE>   Cargo target triple to verify (use --list-targets for the list).\n\
+                               If omitted, the host triple (rustc -vV → host) is used.\n\
+           --json-out <PATH>   Write JSON report to PATH (also written to stdout in human form).\n\
+           --skip-build        Don't run cargo build; reuse the existing libct_fixtures.a.\n\
+           --archive <PATH>    Override the path to libct_fixtures.a (for debugging).\n\
+         \n\
+         Exit code 0 = clean. Non-zero = ct violations OR negative controls didn't trip."
+    );
+}
+
+fn main() -> ExitCode {
+    let args = match parse_args() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            print_help();
+            return ExitCode::from(2);
+        }
+    };
+
+    if args.list_targets {
+        for t in TARGETS {
+            println!(
+                "[{}] {}  (toolchain: {})",
+                t.priority, t.triple, t.toolchain
+            );
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    let triple = args
+        .target
+        .clone()
+        .unwrap_or_else(|| host_triple().unwrap_or_else(|| "x86_64-unknown-linux-gnu".to_string()));
+
+    let Some(spec) = lookup(&triple) else {
+        eprintln!(
+            "error: unknown target triple '{}'. Use --list-targets to see supported ones.",
+            triple
+        );
+        return ExitCode::from(2);
+    };
+
+    // 1. Build (unless skipped).
+    if !args.skip_build {
+        if let Err(e) = cargo_build_fixtures(spec) {
+            eprintln!("error: cargo build failed: {}", e);
+            return ExitCode::from(3);
+        }
+    }
+
+    // 2. Locate the staticlib.
+    let archive = if let Some(p) = args.archive_override.clone() {
+        p
+    } else {
+        match find_archive(spec) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("error: locating libct_fixtures.a: {}", e);
+                return ExitCode::from(3);
+            }
+        }
+    };
+
+    // 3. Disassemble.
+    let objdump_text = match run_objdump(spec, &archive) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: llvm-objdump failed: {}", e);
+            return ExitCode::from(3);
+        }
+    };
+
+    // 4. Parse + scan.
+    let blocks = parse::split_blocks(&objdump_text);
+    let pat = Patterns::build(spec);
+
+    let mut ct_fixture_count: usize = 0;
+    let mut ct_violations: Vec<Violation> = Vec::new();
+    let mut neg_tripped: BTreeSet<String> = BTreeSet::new();
+    let mut neg_seen: BTreeSet<String> = BTreeSet::new();
+
+    for block in &blocks {
+        if !parse::is_in_scope_symbol(&block.symbol) {
+            continue;
+        }
+        let violations = parse::scan_block(block, spec, &pat);
+
+        if parse::is_positive_fixture(&block.symbol) {
+            ct_fixture_count += 1;
+            ct_violations.extend(violations);
+        } else if parse::is_negative_control(&block.symbol) {
+            // For negative controls, count unique top-level fixture names
+            // (one fixture per "nct_fix__neg__<op>__<T>__N<n>" prefix).
+            // Strip any leading underscore.
+            let canonical = block.symbol.trim_start_matches('_').to_string();
+            neg_seen.insert(canonical.clone());
+            if !violations.is_empty() {
+                neg_tripped.insert(canonical);
+            }
+        }
+    }
+    let neg_fixture_count = neg_seen.len();
+    let neg_failed: Vec<String> = neg_seen.difference(&neg_tripped).cloned().collect();
+
+    // 5. Emit report.
+    let report = Report {
+        target: triple.clone(),
+        fixtures_checked: ct_fixture_count,
+        negative_controls_checked: neg_fixture_count,
+        ct_violations: ct_violations.into_iter().map(ViolationOut::from).collect(),
+        negative_controls_failed_to_trip: neg_failed,
+    };
+    report.print_human();
+
+    if let Some(path) = args.json_out.as_ref() {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match std::fs::File::create(path) {
+            Ok(f) => {
+                if let Err(e) = serde_json::to_writer_pretty(f, &report) {
+                    eprintln!("warning: writing JSON report failed: {}", e);
+                }
+            }
+            Err(e) => eprintln!("warning: creating JSON report file failed: {}", e),
+        }
+    }
+
+    if report.exit_code() == 0 {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn host_triple() -> Option<String> {
+    let out = Command::new("rustc").arg("-vV").output().ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    for line in s.lines() {
+        if let Some(rest) = line.strip_prefix("host: ") {
+            return Some(rest.trim().to_string());
+        }
+    }
+    None
+}
+
+fn cargo_build_fixtures(spec: &TargetSpec) -> Result<(), String> {
+    let host = host_triple().unwrap_or_default();
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.arg("build")
+        .arg("--release")
+        .arg("-p")
+        .arg("ct-fixtures");
+
+    // Only pass --target if it differs from host (otherwise we end up
+    // building in `target/release/` rather than `target/<triple>/release/`,
+    // which find_archive accounts for, but passing --target=host is also
+    // fine and produces the per-triple path).
+    if spec.triple != host {
+        cmd.arg("--target").arg(spec.triple);
+    }
+    for a in spec.extra_cargo_args {
+        cmd.arg(a);
+    }
+
+    eprintln!(
+        "[ct-driver] cargo {}",
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let status = cmd.status().map_err(|e| e.to_string())?;
+    if !status.success() {
+        return Err(format!("cargo build exited with {}", status));
+    }
+    Ok(())
+}
+
+fn workspace_target_dir() -> PathBuf {
+    // Find the workspace target dir. We're a workspace member at
+    // `<root>/ct-verify/ct-driver/`, so target dir is `<root>/target/`.
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Walk up two levels: ct-driver -> ct-verify -> root, then add target.
+    let root = manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf())
+        .unwrap_or(manifest);
+    root.join("target")
+}
+
+fn find_archive(spec: &TargetSpec) -> Result<PathBuf, String> {
+    let host = host_triple().unwrap_or_default();
+    let target_dir = workspace_target_dir();
+    let archive_subpath = "release/libct_fixtures.a";
+
+    let candidates: Vec<PathBuf> = if spec.triple == host {
+        vec![
+            target_dir.join(archive_subpath),
+            target_dir.join(spec.triple).join(archive_subpath),
+        ]
+    } else {
+        vec![target_dir.join(spec.triple).join(archive_subpath)]
+    };
+
+    for c in &candidates {
+        if c.exists() {
+            return Ok(c.clone());
+        }
+    }
+    Err(format!(
+        "could not find libct_fixtures.a — tried: {}",
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
+fn llvm_objdump_path() -> Result<PathBuf, String> {
+    // Try `rust-objdump` (from llvm-tools-preview component) first, then
+    // fall back to bare `llvm-objdump`.
+    if let Ok(out) = Command::new("rustc").arg("--print").arg("sysroot").output() {
+        if out.status.success() {
+            let sysroot = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            // The llvm-tools-preview component installs binaries under
+            //   <sysroot>/lib/rustlib/<host>/bin/llvm-objdump
+            let host = host_triple().unwrap_or_default();
+            let candidate = Path::new(&sysroot)
+                .join("lib")
+                .join("rustlib")
+                .join(&host)
+                .join("bin")
+                .join("llvm-objdump");
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+
+    if which::which("llvm-objdump").is_ok() {
+        return Ok(PathBuf::from("llvm-objdump"));
+    }
+    if which::which("rust-objdump").is_ok() {
+        return Ok(PathBuf::from("rust-objdump"));
+    }
+    Err(
+        "llvm-objdump not found. Install llvm-tools-preview rustup component or cargo-binutils."
+            .to_string(),
+    )
+}
+
+fn run_objdump(spec: &TargetSpec, archive: &Path) -> Result<String, String> {
+    let tool = llvm_objdump_path()?;
+    let arch_flag = arch_flag_for(spec.triple);
+
+    let mut cmd = Command::new(&tool);
+    cmd.arg("--disassemble")
+        .arg("--no-show-raw-insn")
+        .arg("--no-leading-addr");
+    if let Some(arch) = arch_flag {
+        cmd.arg(format!("--triple={}", arch));
+    }
+    cmd.arg(archive);
+
+    let out = cmd.output().map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err(format!(
+            "llvm-objdump failed: status={} stderr={}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+fn arch_flag_for(triple: &str) -> Option<&'static str> {
+    // llvm-objdump usually infers the architecture from the object file,
+    // but for some targets (notably AVR) we need to be explicit.
+    if triple.starts_with("avr-") {
+        Some("avr")
+    } else {
+        None
+    }
+}

--- a/ct-verify/ct-driver/src/main.rs
+++ b/ct-verify/ct-driver/src/main.rs
@@ -304,8 +304,7 @@ fn find_archive(spec: &TargetSpec) -> Result<PathBuf, String> {
 }
 
 fn llvm_objdump_path() -> Result<PathBuf, String> {
-    // Try `rust-objdump` (from llvm-tools-preview component) first, then
-    // fall back to bare `llvm-objdump`.
+    // Prefer the llvm-tools-preview component (matches the toolchain).
     if let Ok(out) = Command::new("rustc").arg("--print").arg("sysroot").output() {
         if out.status.success() {
             let sysroot = String::from_utf8_lossy(&out.stdout).trim().to_string();
@@ -323,17 +322,9 @@ fn llvm_objdump_path() -> Result<PathBuf, String> {
             }
         }
     }
-
-    if which::which("llvm-objdump").is_ok() {
-        return Ok(PathBuf::from("llvm-objdump"));
-    }
-    if which::which("rust-objdump").is_ok() {
-        return Ok(PathBuf::from("rust-objdump"));
-    }
-    Err(
-        "llvm-objdump not found. Install llvm-tools-preview rustup component or cargo-binutils."
-            .to_string(),
-    )
+    // Fall back to PATH lookup at exec time. If neither name resolves
+    // run_objdump will surface a clear "No such file" error.
+    Ok(PathBuf::from("llvm-objdump"))
 }
 
 fn run_objdump(spec: &TargetSpec, archive: &Path) -> Result<String, String> {

--- a/ct-verify/ct-driver/src/main.rs
+++ b/ct-verify/ct-driver/src/main.rs
@@ -199,6 +199,17 @@ fn main() -> ExitCode {
         }
     }
 
+    // Empty fixture sets mean the harness lost contact with the
+    // archive — silent self-test failure. Treat as hard fail.
+    if ct_fixture_count == 0 {
+        eprintln!("error: no ct_fix__* fixtures found in archive — harness self-test failed");
+        return ExitCode::FAILURE;
+    }
+    if neg_fixture_count == 0 {
+        eprintln!("error: no nct_fix__neg__* negative controls found in archive — harness self-test failed");
+        return ExitCode::FAILURE;
+    }
+
     if report.exit_code() == 0 {
         ExitCode::SUCCESS
     } else {

--- a/ct-verify/ct-driver/src/mnemonics.rs
+++ b/ct-verify/ct-driver/src/mnemonics.rs
@@ -38,8 +38,17 @@ pub const THUMB_ALLOWED: &[&str] = &[
 // RISC-V has no conditional move or predicate execution. Every branch
 // changes PC. CT code must be xor/and/mask-based; any conditional
 // branch in a Ct primitive is a violation.
+//
+// The gt/le/gtu/leu alternatives cover LLVM-printed pseudo-mnemonic
+// aliases (bgt, ble, bgtu, bleu, bgtz, blez) — `llvm-objdump` prints
+// these by default rather than the canonical bge/blt operand-swapped
+// forms, so a Ct regression that lowered to one of them would
+// otherwise slip past the gate.
 
-pub const RISCV_FORBIDDEN: &[&str] = &[r"^b(eq|ne|lt|ge|ltu|geu)z?$", r"^c\.b(eqz|nez)$"];
+pub const RISCV_FORBIDDEN: &[&str] = &[
+    r"^b(eq|ne|lt|ge|gt|le|ltu|geu|gtu|leu)z?$",
+    r"^c\.b(eqz|nez)$",
+];
 
 // =============================================================================
 // AVR (atmega328p)

--- a/ct-verify/ct-driver/src/mnemonics.rs
+++ b/ct-verify/ct-driver/src/mnemonics.rs
@@ -1,0 +1,87 @@
+//! Per-architecture forbidden / allowed mnemonic regex tables.
+//!
+//! These are raw regex strings, anchored at start/end of the mnemonic
+//! field (the first whitespace-delimited token after the leading
+//! address on each disassembly line). The parser splits on whitespace
+//! and uses `regex::Regex::is_match` on the mnemonic alone.
+
+// =============================================================================
+// Thumb (Cortex-M0 / M3 / M4 / M7 / M33 / M55) — armv6m, armv7m, armv7em
+// =============================================================================
+//
+// Conditional PC-relative branches: b.eq, b.ne, b.cs, b.hs, b.cc, b.lo,
+//   b.mi, b.pl, b.vs, b.vc, b.hi, b.ls, b.ge, b.lt, b.gt, b.le
+//   — plus the .n / .w width suffixes that llvm-objdump emits.
+// Compare-and-branch: cbz, cbnz (armv7m+ only, not armv6m).
+// Table branch: tbb, tbh (armv7m+ only).
+//
+// Allowed (CT-friendly): IT-block predicate execution. The parser tracks
+// IT state separately and only flags conditional mnemonics that appear
+// *outside* an active IT window.
+
+pub const THUMB_FORBIDDEN: &[&str] = &[
+    r"^b(eq|ne|cs|hs|cc|lo|mi|pl|vs|vc|hi|ls|ge|lt|gt|le)(\.[nw])?$",
+    r"^cbn?z$",
+    r"^tb[bh]$",
+];
+
+pub const THUMB_ALLOWED: &[&str] = &[
+    // IT block headers. Inside the IT window the parser allows the
+    // following conditional mnemonics (handled in parse::it_state).
+    r"^it[te]{0,3}$",
+];
+
+// =============================================================================
+// RISC-V (riscv32imc, riscv32imac, riscv32imafc, etc.)
+// =============================================================================
+//
+// RISC-V has no conditional move or predicate execution. Every branch
+// changes PC. CT code must be xor/and/mask-based; any conditional
+// branch in a Ct primitive is a violation.
+
+pub const RISCV_FORBIDDEN: &[&str] = &[r"^b(eq|ne|lt|ge|ltu|geu)z?$", r"^c\.b(eqz|nez)$"];
+
+// =============================================================================
+// AVR (atmega328p)
+// =============================================================================
+//
+// AVR's conditional branches are br<cc>, and there are also "skip next
+// instruction" mnemonics (sbic, sbis, sbrc, sbrs, cpse) — these aren't
+// PC-relative jumps in the usual sense, but they ARE data-dependent
+// control flow (the next instruction may or may not execute), so we
+// flag them.
+
+pub const AVR_FORBIDDEN: &[&str] = &[
+    r"^br(cc|cs|eq|ge|hc|hs|id|ie|lo|lt|mi|ne|pl|sh|tc|ts|vc|vs)$",
+    r"^s(bic|bis|brc|brs)$",
+    r"^cpse$",
+];
+
+// =============================================================================
+// AArch64 (Cortex-A, Apple Silicon, M-series datacenter, etc.)
+// =============================================================================
+//
+// Forbidden: b.<cond>, cbz/cbnz, tbz/tbnz.
+// Allowed: csel / csinc / csinv / csneg / cset / csetm / ccmp / ccmn —
+// the conditional-select family is branch-free and is the CT idiom.
+
+pub const AARCH64_FORBIDDEN: &[&str] = &[
+    r"^b\.(eq|ne|cs|hs|cc|lo|mi|pl|vs|vc|hi|ls|ge|lt|gt|le|al|nv)$",
+    r"^cbn?z$",
+    r"^tbn?z$",
+];
+
+pub const AARCH64_ALLOWED: &[&str] = &[r"^cs(el|inc|inv|neg|et|etm)$", r"^ccmp[en]?$", r"^ccmn$"];
+
+// =============================================================================
+// x86_64
+// =============================================================================
+//
+// Forbidden: the full j<cc> family.
+// Allowed: cmov<cc> (conditional-move), set<cc> (flag→byte, branch-free),
+// sbb (subtract-with-borrow, used in the borrow-as-mask idiom).
+
+pub const X86_64_FORBIDDEN: &[&str] =
+    &[r"^j(e|ne|z|nz|a|ae|b|be|c|nc|g|ge|l|le|o|no|s|ns|p|np|pe|po|cxz|ecxz|rcxz)$"];
+
+pub const X86_64_ALLOWED: &[&str] = &[r"^cmov[a-z]+$", r"^set[a-z]+$", r"^sbb[bwlq]?$"];

--- a/ct-verify/ct-driver/src/parse.rs
+++ b/ct-verify/ct-driver/src/parse.rs
@@ -7,10 +7,24 @@
 //! direction classifier.
 
 use std::collections::VecDeque;
+use std::sync::LazyLock;
 
 use regex::Regex;
 
 use crate::target::TargetSpec;
+
+// Symbol header regex: `<symbol_name>:`. llvm-objdump emits two shapes,
+//   `0000000000000020 <_symbol_name>:`        (without --no-leading-addr)
+//   `<_symbol_name>:`                         (with --no-leading-addr)
+// — both end with `<sym>:`.
+static HEADER_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<([^>]+)>:\s*$").unwrap());
+
+// Instruction line: leading whitespace, then optional `address:`, then the
+// mnemonic, then operands. With --no-leading-addr the address is still
+// emitted (relative). Be permissive: strip the leading `address:` if
+// present, take the first whitespace-delimited token as the mnemonic.
+static INSN_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*(?:([0-9a-fA-F]+):)?\s+(\S+)(?:\s+(.*))?$").unwrap());
 
 /// One disassembled function block.
 #[derive(Debug)]
@@ -29,33 +43,6 @@ pub struct Insn {
 
 /// Parse the entire objdump output into function blocks.
 pub fn split_blocks(objdump_out: &str) -> Vec<FunctionBlock> {
-    // A new function starts when we see a line that ends with `:` and
-    // looks like a symbol header. llvm-objdump emits two shapes:
-    //
-    //   `0000000000000020 <_symbol_name>:`        (with --no-leading-addr off)
-    //   `<_symbol_name>:`                          (with --no-leading-addr on)
-    //
-    // We accept both by looking for `<sym>:` at end of line.
-    //
-    // Each subsequent indented line is an instruction. Indented lines
-    // with `:` in them are jump targets within the function.
-
-    // Symbol header regex: `<symbol_name>:`
-    let header_re = Regex::new(r"<([^>]+)>:\s*$").unwrap();
-
-    // Instruction line: leading whitespace, then `address:` then the
-    // mnemonic, then operands. With --no-leading-addr the address is
-    // still emitted (it's just relative).
-    //
-    // After `--no-show-raw-insn --no-leading-addr` llvm-objdump emits:
-    //   `<TAB>mnemonic<TAB>operands`
-    //
-    // But often we get the form `<addr>: <TAB>mnemonic ...` even with
-    // --no-leading-addr depending on tool version. Be permissive:
-    //   - strip the leading address+colon if present
-    //   - take the first whitespace-delimited token as the mnemonic
-    let insn_re = Regex::new(r"^\s*(?:([0-9a-fA-F]+):)?\s+(\S+)(?:\s+(.*))?$").unwrap();
-
     let mut blocks: Vec<FunctionBlock> = Vec::new();
     let mut current: Option<FunctionBlock> = None;
     let mut implicit_offset: u64 = 0;
@@ -70,7 +57,7 @@ pub fn split_blocks(objdump_out: &str) -> Vec<FunctionBlock> {
             continue;
         }
 
-        if let Some(caps) = header_re.captures(line) {
+        if let Some(caps) = HEADER_RE.captures(line) {
             // Flush previous block.
             if let Some(b) = current.take() {
                 blocks.push(b);
@@ -88,15 +75,20 @@ pub fn split_blocks(objdump_out: &str) -> Vec<FunctionBlock> {
             continue;
         };
 
-        if let Some(caps) = insn_re.captures(line) {
-            let offset = caps
+        if let Some(caps) = INSN_RE.captures(line) {
+            let offset = if let Some(parsed) = caps
                 .get(1)
                 .and_then(|m| u64::from_str_radix(m.as_str(), 16).ok())
-                .unwrap_or_else(|| {
-                    let o = implicit_offset;
-                    implicit_offset += 4; // arbitrary default; only used when address column is missing
-                    o
-                });
+            {
+                // Keep implicit_offset in sync so a subsequent
+                // address-less line continues from the right place.
+                implicit_offset = parsed + 4;
+                parsed
+            } else {
+                let o = implicit_offset;
+                implicit_offset += 4; // arbitrary default; only used when address column is missing
+                o
+            };
             let mnemonic = caps
                 .get(2)
                 .map(|m| m.as_str().to_ascii_lowercase())
@@ -220,10 +212,6 @@ pub fn scan_block(block: &FunctionBlock, spec: &TargetSpec, pat: &Patterns) -> V
                 line: insn.full_line.clone(),
                 context: recent.iter().cloned().collect(),
             });
-
-            if it_remaining > 0 {
-                it_remaining -= 1;
-            }
             continue;
         }
 

--- a/ct-verify/ct-driver/src/parse.rs
+++ b/ct-verify/ct-driver/src/parse.rs
@@ -1,0 +1,279 @@
+//! Disassembly parser.
+//!
+//! Takes the textual output of `llvm-objdump --disassemble
+//! --no-show-raw-insn --no-leading-addr` and splits it into per-symbol
+//! function blocks. Then for each block runs the per-target mnemonic
+//! check + the thumb IT-state machine + the unconditional-branch
+//! direction classifier.
+
+use std::collections::VecDeque;
+
+use regex::Regex;
+
+use crate::target::TargetSpec;
+
+/// One disassembled function block.
+#[derive(Debug)]
+pub struct FunctionBlock {
+    pub symbol: String,
+    /// Each line: (offset_hex_string, mnemonic, full_line_text).
+    pub insns: Vec<Insn>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Insn {
+    pub offset: u64,
+    pub mnemonic: String,
+    pub full_line: String,
+}
+
+/// Parse the entire objdump output into function blocks.
+pub fn split_blocks(objdump_out: &str) -> Vec<FunctionBlock> {
+    // A new function starts when we see a line that ends with `:` and
+    // looks like a symbol header. llvm-objdump emits two shapes:
+    //
+    //   `0000000000000020 <_symbol_name>:`        (with --no-leading-addr off)
+    //   `<_symbol_name>:`                          (with --no-leading-addr on)
+    //
+    // We accept both by looking for `<sym>:` at end of line.
+    //
+    // Each subsequent indented line is an instruction. Indented lines
+    // with `:` in them are jump targets within the function.
+
+    // Symbol header regex: `<symbol_name>:`
+    let header_re = Regex::new(r"<([^>]+)>:\s*$").unwrap();
+
+    // Instruction line: leading whitespace, then `address:` then the
+    // mnemonic, then operands. With --no-leading-addr the address is
+    // still emitted (it's just relative).
+    //
+    // After `--no-show-raw-insn --no-leading-addr` llvm-objdump emits:
+    //   `<TAB>mnemonic<TAB>operands`
+    //
+    // But often we get the form `<addr>: <TAB>mnemonic ...` even with
+    // --no-leading-addr depending on tool version. Be permissive:
+    //   - strip the leading address+colon if present
+    //   - take the first whitespace-delimited token as the mnemonic
+    let insn_re = Regex::new(r"^\s*(?:([0-9a-fA-F]+):)?\s+(\S+)(?:\s+(.*))?$").unwrap();
+
+    let mut blocks: Vec<FunctionBlock> = Vec::new();
+    let mut current: Option<FunctionBlock> = None;
+    let mut implicit_offset: u64 = 0;
+
+    for line in objdump_out.lines() {
+        // Skip dividers and headers from the archive listing.
+        if line.is_empty()
+            || line.starts_with("Disassembly")
+            || line.starts_with(';')
+            || line.contains(":\tfile format ")
+        {
+            continue;
+        }
+
+        if let Some(caps) = header_re.captures(line) {
+            // Flush previous block.
+            if let Some(b) = current.take() {
+                blocks.push(b);
+            }
+            let sym = caps.get(1).unwrap().as_str().to_string();
+            current = Some(FunctionBlock {
+                symbol: sym,
+                insns: Vec::new(),
+            });
+            implicit_offset = 0;
+            continue;
+        }
+
+        let Some(block) = current.as_mut() else {
+            continue;
+        };
+
+        if let Some(caps) = insn_re.captures(line) {
+            let offset = caps
+                .get(1)
+                .and_then(|m| u64::from_str_radix(m.as_str(), 16).ok())
+                .unwrap_or_else(|| {
+                    let o = implicit_offset;
+                    implicit_offset += 4; // arbitrary default; only used when address column is missing
+                    o
+                });
+            let mnemonic = caps
+                .get(2)
+                .map(|m| m.as_str().to_ascii_lowercase())
+                .unwrap_or_default();
+            // Skip lines that aren't actually instructions (e.g.,
+            // `...` continuation lines from llvm-objdump).
+            if mnemonic.is_empty() || mnemonic == "..." {
+                continue;
+            }
+            block.insns.push(Insn {
+                offset,
+                mnemonic,
+                full_line: line.trim_end().to_string(),
+            });
+        }
+    }
+
+    if let Some(b) = current.take() {
+        blocks.push(b);
+    }
+    blocks
+}
+
+/// One detected branch violation.
+#[allow(dead_code)] // `mnemonic` is used by `report.rs::ViolationOut` via `From`.
+#[derive(Debug, Clone)]
+pub struct Violation {
+    pub symbol: String,
+    pub offset: u64,
+    pub mnemonic: String,
+    pub line: String,
+    /// The previous 2 instructions + the violating one, for review.
+    pub context: Vec<String>,
+}
+
+/// Compiled regex set for a target.
+pub struct Patterns {
+    pub forbidden: Vec<Regex>,
+    pub allowed: Vec<Regex>,
+}
+
+impl Patterns {
+    pub fn build(spec: &TargetSpec) -> Self {
+        Self {
+            forbidden: spec
+                .forbidden
+                .iter()
+                .map(|p| Regex::new(p).expect("bad forbidden regex"))
+                .collect(),
+            allowed: spec
+                .allowed_cmov
+                .iter()
+                .map(|p| Regex::new(p).expect("bad allowed regex"))
+                .collect(),
+        }
+    }
+
+    pub fn forbidden_matches(&self, mnemonic: &str) -> bool {
+        self.forbidden.iter().any(|r| r.is_match(mnemonic))
+    }
+
+    pub fn allowed_matches(&self, mnemonic: &str) -> bool {
+        self.allowed.iter().any(|r| r.is_match(mnemonic))
+    }
+}
+
+/// Scan one block for violations, applying the per-target rules.
+pub fn scan_block(block: &FunctionBlock, spec: &TargetSpec, pat: &Patterns) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    let mut recent: VecDeque<String> = VecDeque::with_capacity(3);
+
+    // IT-state machine for thumb. `it_remaining > 0` means the next
+    // `it_remaining` insns are predicated. A forbidden conditional
+    // inside an active IT window is allowed.
+    let mut it_remaining: u32 = 0;
+
+    for insn in &block.insns {
+        recent.push_back(insn.full_line.clone());
+        if recent.len() > 3 {
+            recent.pop_front();
+        }
+
+        let m = insn.mnemonic.as_str();
+
+        // Thumb IT-block tracking. `it`, `itt`, `ite`, `ittt`, `itte`,
+        // etc. — the trailing t/e letters describe whether the next
+        // 1..4 instructions execute on true or false. We just need the
+        // count.
+        if spec.thumb_it_blocks && m.starts_with("it") && m.len() <= 5 {
+            // it = 1 conditional, itt = 2, ittt = 3, itttt = 4.
+            let n = m.len().saturating_sub(1) as u32; // "it" → 1, "itt" → 2, ...
+            it_remaining = n;
+            continue;
+        }
+
+        if pat.allowed_matches(m) {
+            // Explicit allowlist hit (csel/cmov/IT etc.) — not a violation.
+            if it_remaining > 0 {
+                it_remaining -= 1;
+            }
+            continue;
+        }
+
+        if pat.forbidden_matches(m) {
+            // Forbidden mnemonic. If it's inside an active IT window,
+            // it's actually allowed (predicate execution, branch-free).
+            if it_remaining > 0 {
+                it_remaining -= 1;
+                continue;
+            }
+
+            // Unconditional `b` is also caught by forbidden patterns if
+            // any author adds it there; the default tables don't list
+            // it as forbidden, so we don't special-case it here. The
+            // user-controlled regex set is sovereign.
+
+            violations.push(Violation {
+                symbol: block.symbol.clone(),
+                offset: insn.offset,
+                mnemonic: insn.mnemonic.clone(),
+                line: insn.full_line.clone(),
+                context: recent.iter().cloned().collect(),
+            });
+
+            if it_remaining > 0 {
+                it_remaining -= 1;
+            }
+            continue;
+        }
+
+        // Non-conditional instruction (mov, add, ldr, bl, ...). If we
+        // were in an IT window, count it down.
+        if it_remaining > 0 {
+            it_remaining -= 1;
+        }
+    }
+
+    violations
+}
+
+/// Decide which symbols the driver inspects.
+///
+/// **v1 scope**: only the fixture wrappers themselves
+/// (`ct_fix__*` and `nct_fix__*`). Helper symbols compiled into the
+/// staticlib are NOT inspected here, for two reasons:
+///
+/// 1. **No call-graph reachability**: a helper like
+///    `<FixedUInt as Integer>::gcd` exists in the archive because the
+///    crate compiled it, not because any Ct fixture calls it. We can't
+///    tell, from one symbol's mangled name, whether it's actually on a
+///    Ct call path.
+/// 2. **Public-parameter loop bounds**: helpers like
+///    `<FixedUInt as ConditionallySelectable>::conditional_select`
+///    contain a `for i in 0..N` loop that compiles to
+///    `cmp i, #N; b.lt`. That's a forbidden mnemonic by raw regex but
+///    perfectly CT-safe in context (N is a compile-time constant). A
+///    static-pattern check can't distinguish that from a real
+///    data-dependent branch without taint analysis.
+///
+/// The trade-off: we don't catch branch-injection regressions in a
+/// helper that's never called from a fixture.
+pub fn is_in_scope_symbol(sym: &str) -> bool {
+    if sym.starts_with("ct_fix__") || sym.starts_with("_ct_fix__") {
+        return true;
+    }
+    if sym.starts_with("nct_fix__") || sym.starts_with("_nct_fix__") {
+        return true;
+    }
+    false
+}
+
+/// True if a `nct_fix__neg__*` symbol — the negative controls.
+pub fn is_negative_control(sym: &str) -> bool {
+    sym.starts_with("nct_fix__neg__") || sym.starts_with("_nct_fix__neg__")
+}
+
+/// True if a `ct_fix__*` symbol — the positive fixtures.
+pub fn is_positive_fixture(sym: &str) -> bool {
+    sym.starts_with("ct_fix__") || sym.starts_with("_ct_fix__")
+}

--- a/ct-verify/ct-driver/src/report.rs
+++ b/ct-verify/ct-driver/src/report.rs
@@ -1,0 +1,82 @@
+//! Report shape (JSON + human).
+//!
+//! The driver emits one JSON file per target plus a stdout summary.
+
+use serde::Serialize;
+
+use crate::parse::Violation;
+
+#[derive(Debug, Serialize)]
+pub struct Report {
+    pub target: String,
+    pub fixtures_checked: usize,
+    pub negative_controls_checked: usize,
+    pub ct_violations: Vec<ViolationOut>,
+    pub negative_controls_failed_to_trip: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ViolationOut {
+    pub symbol: String,
+    pub offset: String, // hex
+    pub insn: String,
+    pub context: Vec<String>,
+}
+
+impl From<Violation> for ViolationOut {
+    fn from(v: Violation) -> Self {
+        Self {
+            symbol: v.symbol,
+            offset: format!("0x{:x}", v.offset),
+            insn: v.line.trim().to_string(),
+            context: v.context,
+        }
+    }
+}
+
+impl Report {
+    pub fn exit_code(&self) -> i32 {
+        if !self.ct_violations.is_empty() || !self.negative_controls_failed_to_trip.is_empty() {
+            1
+        } else {
+            0
+        }
+    }
+
+    pub fn print_human(&self) {
+        println!("==== CT-verify report for {} ====", self.target);
+        println!(
+            "  ct_fix__*       fixtures checked: {}",
+            self.fixtures_checked
+        );
+        println!(
+            "  nct_fix__neg__* controls checked: {}",
+            self.negative_controls_checked
+        );
+        if self.ct_violations.is_empty() {
+            println!("  Ct violations:                    0  ✓");
+        } else {
+            println!(
+                "  Ct violations:                    {}  ✗",
+                self.ct_violations.len()
+            );
+            for v in &self.ct_violations {
+                println!("    [{}] {} {}", v.offset, v.symbol, v.insn);
+                for ctx in &v.context {
+                    println!("        | {}", ctx.trim());
+                }
+            }
+        }
+        if self.negative_controls_failed_to_trip.is_empty() {
+            println!("  Negative controls tripped:        all ✓");
+        } else {
+            println!(
+                "  Negative controls FAILED to trip: {}  ✗",
+                self.negative_controls_failed_to_trip.len()
+            );
+            for s in &self.negative_controls_failed_to_trip {
+                println!("    {} (expected ≥1 forbidden mnemonic, found 0)", s);
+            }
+        }
+    }
+}

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -4,14 +4,13 @@
 use crate::mnemonics;
 
 #[allow(dead_code)]
-// `priority`, `toolchain`, and `allow_unconditional_back_edge`
-// are documentation-only fields used by `--list-targets` and
-// the README cross-reference.
+// `priority` and `toolchain` are documentation-only fields used by
+// `--list-targets`.
 #[derive(Debug, Clone, Copy)]
 pub struct TargetSpec {
     pub triple: &'static str,
     pub priority: u8,
-    /// "stable" | "1.83" | "nightly-YYYY-MM-DD". The driver doesn't
+    /// "stable" | "1.85" | "nightly-YYYY-MM-DD". The driver doesn't
     /// switch toolchains itself — CI sets up the right one and the
     /// triple drives `cargo build --target=<triple>`. The pin is here
     /// for documentation and so the driver can warn if the active
@@ -26,12 +25,6 @@ pub struct TargetSpec {
     pub allowed_cmov: &'static [&'static str],
     /// Engage the thumb IT-state machine.
     pub thumb_it_blocks: bool,
-    /// Loop back-edges look like unconditional jumps. The Ct primitives
-    /// only iterate compile-time bounds (`N`, `usize::BITS`); back-
-    /// edges to earlier addresses in the same function are CT-safe and
-    /// the parser allows them. Set false to flag all unconditional `b`
-    /// (rarely needed).
-    pub allow_unconditional_back_edge: bool,
     /// Extra cargo args needed for this target (e.g., `-Z build-std=core`
     /// for AVR).
     pub extra_cargo_args: &'static [&'static str],
@@ -43,102 +36,86 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "thumbv7em-none-eabi",
         priority: 1,
-        toolchain: "1.83",
+        toolchain: "1.85",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: true,
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &[],
     },
     TargetSpec {
         triple: "thumbv7m-none-eabi",
         priority: 1,
-        toolchain: "1.83",
+        toolchain: "1.85",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: true,
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &[],
     },
     // Priority 2: Cortex-M0
     TargetSpec {
         triple: "thumbv6m-none-eabi",
         priority: 2,
-        toolchain: "1.83",
+        toolchain: "1.85",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: false, // armv6m has no IT; no allowlist needed
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &[],
     },
     // Priority 3: 32-bit RISC-V
     TargetSpec {
         triple: "riscv32imc-unknown-none-elf",
         priority: 3,
-        toolchain: "1.83",
+        toolchain: "1.85",
         forbidden: mnemonics::RISCV_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &[],
     },
     TargetSpec {
         triple: "riscv32imac-unknown-none-elf",
         priority: 3,
-        toolchain: "1.83",
+        toolchain: "1.85",
         forbidden: mnemonics::RISCV_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &[],
     },
     // Priority 4: 8-bit AVR (nightly-only, needs build-std + target-cpu).
-    //
     // Modern rustc uses the `avr-none` triple and requires an explicit
     // `-C target-cpu=<mcu>`. The CI workflow sets RUSTFLAGS accordingly
     // and passes -Z build-std=core via extra_cargo_args.
-    //
-    // Known limitation: AVR has no conditional-select instruction so any
-    // Ct primitive that uses an `if cond { a } else { b }` pattern at the
-    // source level emits a real `brne` branch. `ConstCarryingAdd::carrying_add`
-    // is the one such primitive shipped today; its fixtures are
-    // cfg-gated off on AVR (see fixtures_cat_c.rs).
     TargetSpec {
         triple: "avr-none",
         priority: 4,
-        toolchain: "nightly",
+        toolchain: "nightly-2026-05-30",
         forbidden: mnemonics::AVR_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &["-Z", "build-std=core"],
     },
     // Priority 5: aarch64
     TargetSpec {
         triple: "aarch64-unknown-linux-gnu",
         priority: 5,
-        toolchain: "1.83",
+        toolchain: "1.85",
         forbidden: mnemonics::AARCH64_FORBIDDEN,
         allowed_cmov: mnemonics::AARCH64_ALLOWED,
         thumb_it_blocks: false,
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &[],
     },
     // Priority 6: x86_64
     TargetSpec {
         triple: "x86_64-unknown-linux-gnu",
         priority: 6,
-        toolchain: "1.83",
+        toolchain: "1.85",
         forbidden: mnemonics::X86_64_FORBIDDEN,
         allowed_cmov: mnemonics::X86_64_ALLOWED,
         thumb_it_blocks: false,
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &[],
     },
-    // Host fallback: aarch64-apple-darwin. Same
-    // mnemonic tables as aarch64-linux. The CI matrix doesn't run this;
-    // it's here so `cargo run -p ct-driver` works on macOS dev boxes
-    // without --target.
+    // Host fallback: aarch64-apple-darwin. Same mnemonic tables as
+    // aarch64-linux. The CI matrix doesn't run this; it's here so
+    // `cargo run -p ct-driver` works on macOS dev boxes without --target.
     TargetSpec {
         triple: "aarch64-apple-darwin",
         priority: 99,
@@ -146,7 +123,6 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::AARCH64_FORBIDDEN,
         allowed_cmov: mnemonics::AARCH64_ALLOWED,
         thumb_it_blocks: false,
-        allow_unconditional_back_edge: true,
         extra_cargo_args: &[],
     },
 ];

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -1,0 +1,156 @@
+//! Per-target specifications: triple, toolchain pin, and the mnemonic
+//! tables used by the parser.
+
+use crate::mnemonics;
+
+#[allow(dead_code)]
+// `priority`, `toolchain`, and `allow_unconditional_back_edge`
+// are documentation-only fields used by `--list-targets` and
+// the README cross-reference.
+#[derive(Debug, Clone, Copy)]
+pub struct TargetSpec {
+    pub triple: &'static str,
+    pub priority: u8,
+    /// "stable" | "1.83" | "nightly-YYYY-MM-DD". The driver doesn't
+    /// switch toolchains itself — CI sets up the right one and the
+    /// triple drives `cargo build --target=<triple>`. The pin is here
+    /// for documentation and so the driver can warn if the active
+    /// toolchain doesn't match.
+    pub toolchain: &'static str,
+    /// Regexes that, when they match the mnemonic at any insn line of
+    /// any fixture's body, count as a violation.
+    pub forbidden: &'static [&'static str],
+    /// Regexes that, when matched, are explicitly OK even though they
+    /// look conditional. E.g., aarch64 `csel` / x64 `cmovcc` / thumb
+    /// `IT` predicate execution.
+    pub allowed_cmov: &'static [&'static str],
+    /// Engage the thumb IT-state machine.
+    pub thumb_it_blocks: bool,
+    /// Loop back-edges look like unconditional jumps. The Ct primitives
+    /// only iterate compile-time bounds (`N`, `usize::BITS`); back-
+    /// edges to earlier addresses in the same function are CT-safe and
+    /// the parser allows them. Set false to flag all unconditional `b`
+    /// (rarely needed).
+    pub allow_unconditional_back_edge: bool,
+    /// Extra cargo args needed for this target (e.g., `-Z build-std=core`
+    /// for AVR).
+    pub extra_cargo_args: &'static [&'static str],
+}
+
+/// All targets we know how to verify, in priority order.
+pub const TARGETS: &[TargetSpec] = &[
+    // Priority 1: Cortex-M3/M4
+    TargetSpec {
+        triple: "thumbv7em-none-eabi",
+        priority: 1,
+        toolchain: "1.83",
+        forbidden: mnemonics::THUMB_FORBIDDEN,
+        allowed_cmov: mnemonics::THUMB_ALLOWED,
+        thumb_it_blocks: true,
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &[],
+    },
+    TargetSpec {
+        triple: "thumbv7m-none-eabi",
+        priority: 1,
+        toolchain: "1.83",
+        forbidden: mnemonics::THUMB_FORBIDDEN,
+        allowed_cmov: mnemonics::THUMB_ALLOWED,
+        thumb_it_blocks: true,
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &[],
+    },
+    // Priority 2: Cortex-M0
+    TargetSpec {
+        triple: "thumbv6m-none-eabi",
+        priority: 2,
+        toolchain: "1.83",
+        forbidden: mnemonics::THUMB_FORBIDDEN,
+        allowed_cmov: mnemonics::THUMB_ALLOWED,
+        thumb_it_blocks: false, // armv6m has no IT; no allowlist needed
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &[],
+    },
+    // Priority 3: 32-bit RISC-V
+    TargetSpec {
+        triple: "riscv32imc-unknown-none-elf",
+        priority: 3,
+        toolchain: "1.83",
+        forbidden: mnemonics::RISCV_FORBIDDEN,
+        allowed_cmov: &[],
+        thumb_it_blocks: false,
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &[],
+    },
+    TargetSpec {
+        triple: "riscv32imac-unknown-none-elf",
+        priority: 3,
+        toolchain: "1.83",
+        forbidden: mnemonics::RISCV_FORBIDDEN,
+        allowed_cmov: &[],
+        thumb_it_blocks: false,
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &[],
+    },
+    // Priority 4: 8-bit AVR (nightly-only, needs build-std + target-cpu).
+    //
+    // Modern rustc uses the `avr-none` triple and requires an explicit
+    // `-C target-cpu=<mcu>`. The CI workflow sets RUSTFLAGS accordingly
+    // and passes -Z build-std=core via extra_cargo_args.
+    //
+    // Known limitation: AVR has no conditional-select instruction so any
+    // Ct primitive that uses an `if cond { a } else { b }` pattern at the
+    // source level emits a real `brne` branch. `ConstCarryingAdd::carrying_add`
+    // is the one such primitive shipped today; its fixtures are
+    // cfg-gated off on AVR (see fixtures_cat_c.rs).
+    TargetSpec {
+        triple: "avr-none",
+        priority: 4,
+        toolchain: "nightly",
+        forbidden: mnemonics::AVR_FORBIDDEN,
+        allowed_cmov: &[],
+        thumb_it_blocks: false,
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &["-Z", "build-std=core"],
+    },
+    // Priority 5: aarch64
+    TargetSpec {
+        triple: "aarch64-unknown-linux-gnu",
+        priority: 5,
+        toolchain: "1.83",
+        forbidden: mnemonics::AARCH64_FORBIDDEN,
+        allowed_cmov: mnemonics::AARCH64_ALLOWED,
+        thumb_it_blocks: false,
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &[],
+    },
+    // Priority 6: x86_64
+    TargetSpec {
+        triple: "x86_64-unknown-linux-gnu",
+        priority: 6,
+        toolchain: "1.83",
+        forbidden: mnemonics::X86_64_FORBIDDEN,
+        allowed_cmov: mnemonics::X86_64_ALLOWED,
+        thumb_it_blocks: false,
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &[],
+    },
+    // Host fallback: aarch64-apple-darwin. Same
+    // mnemonic tables as aarch64-linux. The CI matrix doesn't run this;
+    // it's here so `cargo run -p ct-driver` works on macOS dev boxes
+    // without --target.
+    TargetSpec {
+        triple: "aarch64-apple-darwin",
+        priority: 99,
+        toolchain: "stable",
+        forbidden: mnemonics::AARCH64_FORBIDDEN,
+        allowed_cmov: mnemonics::AARCH64_ALLOWED,
+        thumb_it_blocks: false,
+        allow_unconditional_back_edge: true,
+        extra_cargo_args: &[],
+    },
+];
+
+pub fn lookup(triple: &str) -> Option<&'static TargetSpec> {
+    TARGETS.iter().find(|t| t.triple == triple)
+}

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -87,7 +87,7 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "avr-none",
         priority: 4,
-        toolchain: "nightly-2026-05-30",
+        toolchain: "nightly",
         forbidden: mnemonics::AVR_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ct-fixtures"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.73"
+publish = false
+description = "Inspection fixtures for the fixed-bigint CT-verify harness."
+
+[lib]
+# staticlib so embedded targets emit a .a we can disassemble without
+# needing a linker script or runtime. rlib so the future ct-fixtures-mcu
+# companion (DWT-on-hardware) can link the same symbols as a regular
+# Rust dependency.
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+fixed-bigint = { path = "../.." }
+subtle = { version = "2.6", default-features = false }
+
+# Profile settings live at the workspace root (cargo only honors them there).

--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -1,0 +1,254 @@
+//! Category A: methods migrated via `match P::TAG` where the Ct arm is a
+//! distinct body. Phase 3c–g + 3i–m in the original migration commits.
+//!
+//! Each op is exercised at five (T, N) diagonals:
+//!   (u8, 16), (u16, 16), (u32, 4), (u32, 16), (u64, 4)
+
+use fixed_bigint::const_numtraits::{
+    ConstAbsDiff, ConstBitPrimInt, ConstOne, ConstPowerOfTwo, ConstSaturatingAdd,
+    ConstSaturatingMul, ConstSaturatingSub, ConstUnboundedShift, ConstZero,
+};
+use fixed_bigint::{Ct, FixedUInt};
+
+use crate::{ct_fix_bin, ct_fix_count, ct_fix_pred, ct_fix_shift, ct_fix_un};
+
+// =============================================================================
+// ConstSaturatingAdd / Sub / Mul
+// =============================================================================
+
+macro_rules! emit_sat_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = ConstSaturatingAdd::saturating_add(&x, &y);
+            *r.words()
+        });
+    };
+}
+emit_sat_add!(ct_fix__A__sat_add__u8__N16, u8, 16);
+emit_sat_add!(ct_fix__A__sat_add__u16__N16, u16, 16);
+emit_sat_add!(ct_fix__A__sat_add__u32__N4, u32, 4);
+emit_sat_add!(ct_fix__A__sat_add__u32__N16, u32, 16);
+emit_sat_add!(ct_fix__A__sat_add__u64__N4, u64, 4);
+
+macro_rules! emit_sat_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = ConstSaturatingSub::saturating_sub(&x, &y);
+            *r.words()
+        });
+    };
+}
+emit_sat_sub!(ct_fix__A__sat_sub__u8__N16, u8, 16);
+emit_sat_sub!(ct_fix__A__sat_sub__u16__N16, u16, 16);
+emit_sat_sub!(ct_fix__A__sat_sub__u32__N4, u32, 4);
+emit_sat_sub!(ct_fix__A__sat_sub__u32__N16, u32, 16);
+emit_sat_sub!(ct_fix__A__sat_sub__u64__N4, u64, 4);
+
+macro_rules! emit_sat_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = ConstSaturatingMul::saturating_mul(&x, &y);
+            *r.words()
+        });
+    };
+}
+emit_sat_mul!(ct_fix__A__sat_mul__u8__N16, u8, 16);
+emit_sat_mul!(ct_fix__A__sat_mul__u16__N16, u16, 16);
+emit_sat_mul!(ct_fix__A__sat_mul__u32__N4, u32, 4);
+emit_sat_mul!(ct_fix__A__sat_mul__u32__N16, u32, 16);
+emit_sat_mul!(ct_fix__A__sat_mul__u64__N4, u64, 4);
+
+// =============================================================================
+// core::ops::Shl<usize> / Shr<usize> (Phase 3e barrel shifter)
+// =============================================================================
+
+macro_rules! emit_shl_usize {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, usize, |a, n| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let r = x << n;
+            *r.words()
+        });
+    };
+}
+emit_shl_usize!(ct_fix__A__shl_usize__u8__N16, u8, 16);
+emit_shl_usize!(ct_fix__A__shl_usize__u16__N16, u16, 16);
+emit_shl_usize!(ct_fix__A__shl_usize__u32__N4, u32, 4);
+emit_shl_usize!(ct_fix__A__shl_usize__u32__N16, u32, 16);
+emit_shl_usize!(ct_fix__A__shl_usize__u64__N4, u64, 4);
+
+macro_rules! emit_shr_usize {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, usize, |a, n| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let r = x >> n;
+            *r.words()
+        });
+    };
+}
+emit_shr_usize!(ct_fix__A__shr_usize__u8__N16, u8, 16);
+emit_shr_usize!(ct_fix__A__shr_usize__u16__N16, u16, 16);
+emit_shr_usize!(ct_fix__A__shr_usize__u32__N4, u32, 4);
+emit_shr_usize!(ct_fix__A__shr_usize__u32__N16, u32, 16);
+emit_shr_usize!(ct_fix__A__shr_usize__u64__N4, u64, 4);
+
+// =============================================================================
+// ConstUnboundedShift::unbounded_shl / unbounded_shr (Phase 3i)
+// =============================================================================
+
+macro_rules! emit_unbounded_shl {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, u32, |a, n| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let r = ConstUnboundedShift::unbounded_shl(x, n);
+            *r.words()
+        });
+    };
+}
+emit_unbounded_shl!(ct_fix__A__unbounded_shl__u8__N16, u8, 16);
+emit_unbounded_shl!(ct_fix__A__unbounded_shl__u16__N16, u16, 16);
+emit_unbounded_shl!(ct_fix__A__unbounded_shl__u32__N4, u32, 4);
+emit_unbounded_shl!(ct_fix__A__unbounded_shl__u32__N16, u32, 16);
+emit_unbounded_shl!(ct_fix__A__unbounded_shl__u64__N4, u64, 4);
+
+macro_rules! emit_unbounded_shr {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, u32, |a, n| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let r = ConstUnboundedShift::unbounded_shr(x, n);
+            *r.words()
+        });
+    };
+}
+emit_unbounded_shr!(ct_fix__A__unbounded_shr__u8__N16, u8, 16);
+emit_unbounded_shr!(ct_fix__A__unbounded_shr__u16__N16, u16, 16);
+emit_unbounded_shr!(ct_fix__A__unbounded_shr__u32__N4, u32, 4);
+emit_unbounded_shr!(ct_fix__A__unbounded_shr__u32__N16, u32, 16);
+emit_unbounded_shr!(ct_fix__A__unbounded_shr__u64__N4, u64, 4);
+
+// =============================================================================
+// ConstAbsDiff::abs_diff (Phase 3l)
+// =============================================================================
+
+macro_rules! emit_abs_diff {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = ConstAbsDiff::abs_diff(x, y);
+            *r.words()
+        });
+    };
+}
+emit_abs_diff!(ct_fix__A__abs_diff__u8__N16, u8, 16);
+emit_abs_diff!(ct_fix__A__abs_diff__u16__N16, u16, 16);
+emit_abs_diff!(ct_fix__A__abs_diff__u32__N4, u32, 4);
+emit_abs_diff!(ct_fix__A__abs_diff__u32__N16, u32, 16);
+emit_abs_diff!(ct_fix__A__abs_diff__u64__N4, u64, 4);
+
+// =============================================================================
+// ConstPowerOfTwo::is_power_of_two (Phase 3f) — predicate
+// =============================================================================
+
+macro_rules! emit_is_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            ConstPowerOfTwo::is_power_of_two(&x) as u8
+        });
+    };
+}
+emit_is_pow2!(ct_fix__A__is_pow2__u8__N16, u8, 16);
+emit_is_pow2!(ct_fix__A__is_pow2__u16__N16, u16, 16);
+emit_is_pow2!(ct_fix__A__is_pow2__u32__N4, u32, 4);
+emit_is_pow2!(ct_fix__A__is_pow2__u32__N16, u32, 16);
+emit_is_pow2!(ct_fix__A__is_pow2__u64__N4, u64, 4);
+
+// =============================================================================
+// ConstPowerOfTwo::next_power_of_two (Phase 3m)
+// =============================================================================
+
+macro_rules! emit_next_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let r = ConstPowerOfTwo::next_power_of_two(x);
+            *r.words()
+        });
+    };
+}
+emit_next_pow2!(ct_fix__A__next_pow2__u8__N16, u8, 16);
+emit_next_pow2!(ct_fix__A__next_pow2__u16__N16, u16, 16);
+emit_next_pow2!(ct_fix__A__next_pow2__u32__N4, u32, 4);
+emit_next_pow2!(ct_fix__A__next_pow2__u32__N16, u32, 16);
+emit_next_pow2!(ct_fix__A__next_pow2__u64__N4, u64, 4);
+
+// =============================================================================
+// ConstBitPrimInt::leading_zeros / trailing_zeros (Phase 3c/3d)
+// =============================================================================
+
+macro_rules! emit_lz {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_count!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            ConstBitPrimInt::leading_zeros(x)
+        });
+    };
+}
+emit_lz!(ct_fix__A__leading_zeros__u8__N16, u8, 16);
+emit_lz!(ct_fix__A__leading_zeros__u16__N16, u16, 16);
+emit_lz!(ct_fix__A__leading_zeros__u32__N4, u32, 4);
+emit_lz!(ct_fix__A__leading_zeros__u32__N16, u32, 16);
+emit_lz!(ct_fix__A__leading_zeros__u64__N4, u64, 4);
+
+macro_rules! emit_tz {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_count!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            ConstBitPrimInt::trailing_zeros(x)
+        });
+    };
+}
+emit_tz!(ct_fix__A__trailing_zeros__u8__N16, u8, 16);
+emit_tz!(ct_fix__A__trailing_zeros__u16__N16, u16, 16);
+emit_tz!(ct_fix__A__trailing_zeros__u32__N4, u32, 4);
+emit_tz!(ct_fix__A__trailing_zeros__u32__N16, u32, 16);
+emit_tz!(ct_fix__A__trailing_zeros__u64__N4, u64, 4);
+
+// =============================================================================
+// ConstZero::is_zero / ConstOne::is_one (Phase 2 / 3a)
+// =============================================================================
+
+macro_rules! emit_is_zero {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            ConstZero::is_zero(&x) as u8
+        });
+    };
+}
+emit_is_zero!(ct_fix__A__is_zero__u8__N16, u8, 16);
+emit_is_zero!(ct_fix__A__is_zero__u16__N16, u16, 16);
+emit_is_zero!(ct_fix__A__is_zero__u32__N4, u32, 4);
+emit_is_zero!(ct_fix__A__is_zero__u32__N16, u32, 16);
+emit_is_zero!(ct_fix__A__is_zero__u64__N4, u64, 4);
+
+macro_rules! emit_is_one {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            ConstOne::is_one(&x) as u8
+        });
+    };
+}
+emit_is_one!(ct_fix__A__is_one__u8__N16, u8, 16);
+emit_is_one!(ct_fix__A__is_one__u16__N16, u16, 16);
+emit_is_one!(ct_fix__A__is_one__u32__N4, u32, 4);
+emit_is_one!(ct_fix__A__is_one__u32__N16, u32, 16);
+emit_is_one!(ct_fix__A__is_one__u64__N4, u64, 4);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
@@ -1,0 +1,250 @@
+//! Category B: Ct-only direct impls. These methods don't exist on Nct.
+//!
+//! Includes the inherent `ct_checked_*` methods, the four `subtle::*`
+//! trait impls, and `forget_ct` (the Ct → Nct explicit downgrade).
+
+use fixed_bigint::{Ct, FixedUInt, Nct};
+use subtle::{ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
+
+use crate::{
+    ct_fix_bin, ct_fix_checked_bin, ct_fix_checked_scalar, ct_fix_checked_un, ct_fix_pred,
+    ct_fix_pred2, ct_fix_un,
+};
+
+// =============================================================================
+// subtle::ConstantTimeEq / ConstantTimeGreater / ConstantTimeLess on Ct
+// =============================================================================
+
+macro_rules! emit_ct_eq {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            x.ct_eq(&y).unwrap_u8()
+        });
+    };
+}
+emit_ct_eq!(ct_fix__B__ct_eq__u8__N16, u8, 16);
+emit_ct_eq!(ct_fix__B__ct_eq__u16__N16, u16, 16);
+emit_ct_eq!(ct_fix__B__ct_eq__u32__N4, u32, 4);
+emit_ct_eq!(ct_fix__B__ct_eq__u32__N16, u32, 16);
+emit_ct_eq!(ct_fix__B__ct_eq__u64__N4, u64, 4);
+
+macro_rules! emit_ct_gt {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            x.ct_gt(&y).unwrap_u8()
+        });
+    };
+}
+emit_ct_gt!(ct_fix__B__ct_gt__u8__N16, u8, 16);
+emit_ct_gt!(ct_fix__B__ct_gt__u16__N16, u16, 16);
+emit_ct_gt!(ct_fix__B__ct_gt__u32__N4, u32, 4);
+emit_ct_gt!(ct_fix__B__ct_gt__u32__N16, u32, 16);
+emit_ct_gt!(ct_fix__B__ct_gt__u64__N4, u64, 4);
+
+macro_rules! emit_ct_lt {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            x.ct_lt(&y).unwrap_u8()
+        });
+    };
+}
+emit_ct_lt!(ct_fix__B__ct_lt__u8__N16, u8, 16);
+emit_ct_lt!(ct_fix__B__ct_lt__u16__N16, u16, 16);
+emit_ct_lt!(ct_fix__B__ct_lt__u32__N4, u32, 4);
+emit_ct_lt!(ct_fix__B__ct_lt__u32__N16, u32, 16);
+emit_ct_lt!(ct_fix__B__ct_lt__u64__N4, u64, 4);
+
+// =============================================================================
+// subtle::ConditionallySelectable::conditional_select on Ct
+//
+// Different signature: takes a Choice. We pass an extra u8 (0 or 1) as
+// the third arg, convert to Choice inside.
+// =============================================================================
+
+macro_rules! emit_cond_select {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            choice: u8,
+            out_ptr: *mut [$T; $N],
+        ) {
+            let a_arr = core::hint::black_box(unsafe { *a_ptr });
+            let b_arr = core::hint::black_box(unsafe { *b_ptr });
+            let c = core::hint::black_box(choice);
+            let x = FixedUInt::<$T, $N, Ct>::from(a_arr);
+            let y = FixedUInt::<$T, $N, Ct>::from(b_arr);
+            let r = FixedUInt::<$T, $N, Ct>::conditional_select(&x, &y, subtle::Choice::from(c));
+            let result = core::hint::black_box(*r.words());
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+    };
+}
+emit_cond_select!(ct_fix__B__cond_select__u8__N16, u8, 16);
+emit_cond_select!(ct_fix__B__cond_select__u16__N16, u16, 16);
+emit_cond_select!(ct_fix__B__cond_select__u32__N4, u32, 4);
+emit_cond_select!(ct_fix__B__cond_select__u32__N16, u32, 16);
+emit_cond_select!(ct_fix__B__cond_select__u64__N4, u64, 4);
+
+// =============================================================================
+// ct_checked_add / sub / mul (Phase 3j)
+// =============================================================================
+
+macro_rules! emit_ct_checked_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let res = x.ct_checked_add(&y);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
+            (*value.words(), valid)
+        });
+    };
+}
+emit_ct_checked_add!(ct_fix__B__ct_checked_add__u8__N16, u8, 16);
+emit_ct_checked_add!(ct_fix__B__ct_checked_add__u16__N16, u16, 16);
+emit_ct_checked_add!(ct_fix__B__ct_checked_add__u32__N4, u32, 4);
+emit_ct_checked_add!(ct_fix__B__ct_checked_add__u32__N16, u32, 16);
+emit_ct_checked_add!(ct_fix__B__ct_checked_add__u64__N4, u64, 4);
+
+macro_rules! emit_ct_checked_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let res = x.ct_checked_sub(&y);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
+            (*value.words(), valid)
+        });
+    };
+}
+emit_ct_checked_sub!(ct_fix__B__ct_checked_sub__u8__N16, u8, 16);
+emit_ct_checked_sub!(ct_fix__B__ct_checked_sub__u16__N16, u16, 16);
+emit_ct_checked_sub!(ct_fix__B__ct_checked_sub__u32__N4, u32, 4);
+emit_ct_checked_sub!(ct_fix__B__ct_checked_sub__u32__N16, u32, 16);
+emit_ct_checked_sub!(ct_fix__B__ct_checked_sub__u64__N4, u64, 4);
+
+macro_rules! emit_ct_checked_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let res = x.ct_checked_mul(&y);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
+            (*value.words(), valid)
+        });
+    };
+}
+emit_ct_checked_mul!(ct_fix__B__ct_checked_mul__u8__N16, u8, 16);
+emit_ct_checked_mul!(ct_fix__B__ct_checked_mul__u16__N16, u16, 16);
+emit_ct_checked_mul!(ct_fix__B__ct_checked_mul__u32__N4, u32, 4);
+emit_ct_checked_mul!(ct_fix__B__ct_checked_mul__u32__N16, u32, 16);
+emit_ct_checked_mul!(ct_fix__B__ct_checked_mul__u64__N4, u64, 4);
+
+// =============================================================================
+// ct_checked_shl / shr / pow (Phase 3k / 3l)
+// =============================================================================
+
+macro_rules! emit_ct_checked_shl {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_scalar!($name, $T, $N, u32, |a, s| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let res = x.ct_checked_shl(s);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
+            (*value.words(), valid)
+        });
+    };
+}
+emit_ct_checked_shl!(ct_fix__B__ct_checked_shl__u8__N16, u8, 16);
+emit_ct_checked_shl!(ct_fix__B__ct_checked_shl__u16__N16, u16, 16);
+emit_ct_checked_shl!(ct_fix__B__ct_checked_shl__u32__N4, u32, 4);
+emit_ct_checked_shl!(ct_fix__B__ct_checked_shl__u32__N16, u32, 16);
+emit_ct_checked_shl!(ct_fix__B__ct_checked_shl__u64__N4, u64, 4);
+
+macro_rules! emit_ct_checked_shr {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_scalar!($name, $T, $N, u32, |a, s| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let res = x.ct_checked_shr(s);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
+            (*value.words(), valid)
+        });
+    };
+}
+emit_ct_checked_shr!(ct_fix__B__ct_checked_shr__u8__N16, u8, 16);
+emit_ct_checked_shr!(ct_fix__B__ct_checked_shr__u16__N16, u16, 16);
+emit_ct_checked_shr!(ct_fix__B__ct_checked_shr__u32__N4, u32, 4);
+emit_ct_checked_shr!(ct_fix__B__ct_checked_shr__u32__N16, u32, 16);
+emit_ct_checked_shr!(ct_fix__B__ct_checked_shr__u64__N4, u64, 4);
+
+macro_rules! emit_ct_checked_pow {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_scalar!($name, $T, $N, u32, |a, e| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let res = x.ct_checked_pow(e);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
+            (*value.words(), valid)
+        });
+    };
+}
+emit_ct_checked_pow!(ct_fix__B__ct_checked_pow__u8__N16, u8, 16);
+emit_ct_checked_pow!(ct_fix__B__ct_checked_pow__u16__N16, u16, 16);
+emit_ct_checked_pow!(ct_fix__B__ct_checked_pow__u32__N4, u32, 4);
+emit_ct_checked_pow!(ct_fix__B__ct_checked_pow__u32__N16, u32, 16);
+emit_ct_checked_pow!(ct_fix__B__ct_checked_pow__u64__N4, u64, 4);
+
+// =============================================================================
+// ct_checked_next_power_of_two (Phase 3m)
+// =============================================================================
+
+macro_rules! emit_ct_checked_npot {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_un!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let res = x.ct_checked_next_power_of_two();
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
+            (*value.words(), valid)
+        });
+    };
+}
+emit_ct_checked_npot!(ct_fix__B__ct_checked_npot__u8__N16, u8, 16);
+emit_ct_checked_npot!(ct_fix__B__ct_checked_npot__u16__N16, u16, 16);
+emit_ct_checked_npot!(ct_fix__B__ct_checked_npot__u32__N4, u32, 4);
+emit_ct_checked_npot!(ct_fix__B__ct_checked_npot__u32__N16, u32, 16);
+emit_ct_checked_npot!(ct_fix__B__ct_checked_npot__u64__N4, u64, 4);
+
+// =============================================================================
+// forget_ct: trivially branch-free (it's a memcpy / from_array), but
+// include it as a regression watch in case someone adds a debug_assert.
+// =============================================================================
+
+macro_rules! emit_forget_ct {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let n: FixedUInt<$T, $N, Nct> = x.forget_ct();
+            *n.words()
+        });
+    };
+}
+emit_forget_ct!(ct_fix__B__forget_ct__u8__N16, u8, 16);
+emit_forget_ct!(ct_fix__B__forget_ct__u16__N16, u16, 16);
+emit_forget_ct!(ct_fix__B__forget_ct__u32__N4, u32, 4);
+emit_forget_ct!(ct_fix__B__forget_ct__u32__N16, u32, 16);
+emit_forget_ct!(ct_fix__B__forget_ct__u64__N4, u64, 4);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
@@ -1,0 +1,215 @@
+//! Category C: methods that are always CT-by-construction (generic over
+//! P) — fixed-N limb loops, no operand-dependent branches. We exercise
+//! them under `Ct` here as a regression watch: if a future LLVM
+//! optimization or refactor introduces a data-dependent branch into one
+//! of these "obviously CT" bodies, the harness catches it.
+
+use core::ops::{BitAnd, BitOr, BitXor, Not};
+
+use fixed_bigint::const_numtraits::{
+    ConstBitPrimInt, ConstCarryingAdd, ConstMidpoint, ConstOverflowingAdd, ConstWrappingMul,
+};
+use fixed_bigint::{Ct, FixedUInt};
+
+use crate::{ct_fix_bin, ct_fix_count, ct_fix_un};
+
+// =============================================================================
+// Bitwise: Not / BitAnd / BitOr / BitXor
+// =============================================================================
+
+macro_rules! emit_not {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let r = Not::not(x);
+            *r.words()
+        });
+    };
+}
+emit_not!(ct_fix__C__not__u8__N16, u8, 16);
+emit_not!(ct_fix__C__not__u32__N4, u32, 4);
+emit_not!(ct_fix__C__not__u32__N16, u32, 16);
+emit_not!(ct_fix__C__not__u64__N4, u64, 4);
+
+macro_rules! emit_bitand {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = BitAnd::bitand(x, y);
+            *r.words()
+        });
+    };
+}
+emit_bitand!(ct_fix__C__bitand__u8__N16, u8, 16);
+emit_bitand!(ct_fix__C__bitand__u32__N4, u32, 4);
+emit_bitand!(ct_fix__C__bitand__u32__N16, u32, 16);
+emit_bitand!(ct_fix__C__bitand__u64__N4, u64, 4);
+
+macro_rules! emit_bitor {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = BitOr::bitor(x, y);
+            *r.words()
+        });
+    };
+}
+emit_bitor!(ct_fix__C__bitor__u8__N16, u8, 16);
+emit_bitor!(ct_fix__C__bitor__u32__N4, u32, 4);
+emit_bitor!(ct_fix__C__bitor__u32__N16, u32, 16);
+emit_bitor!(ct_fix__C__bitor__u64__N4, u64, 4);
+
+macro_rules! emit_bitxor {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = BitXor::bitxor(x, y);
+            *r.words()
+        });
+    };
+}
+emit_bitxor!(ct_fix__C__bitxor__u8__N16, u8, 16);
+emit_bitxor!(ct_fix__C__bitxor__u32__N4, u32, 4);
+emit_bitxor!(ct_fix__C__bitxor__u32__N16, u32, 16);
+emit_bitxor!(ct_fix__C__bitxor__u64__N4, u64, 4);
+
+// =============================================================================
+// Overflowing / wrapping arithmetic (always-CT carry chain)
+// =============================================================================
+
+macro_rules! emit_overflowing_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        // Overflowing returns (Self, bool). We discard the bool to keep
+        // the ABI simple; the body's branch-freeness is what we check.
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let (r, _ov) = ConstOverflowingAdd::overflowing_add(&x, &y);
+            *r.words()
+        });
+    };
+}
+emit_overflowing_add!(ct_fix__C__overflowing_add__u8__N16, u8, 16);
+emit_overflowing_add!(ct_fix__C__overflowing_add__u32__N4, u32, 4);
+emit_overflowing_add!(ct_fix__C__overflowing_add__u32__N16, u32, 16);
+emit_overflowing_add!(ct_fix__C__overflowing_add__u64__N4, u64, 4);
+
+macro_rules! emit_wrapping_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = ConstWrappingMul::wrapping_mul(&x, &y);
+            *r.words()
+        });
+    };
+}
+emit_wrapping_mul!(ct_fix__C__wrapping_mul__u8__N16, u8, 16);
+emit_wrapping_mul!(ct_fix__C__wrapping_mul__u32__N4, u32, 4);
+emit_wrapping_mul!(ct_fix__C__wrapping_mul__u32__N16, u32, 16);
+emit_wrapping_mul!(ct_fix__C__wrapping_mul__u64__N4, u64, 4);
+
+// =============================================================================
+// Carrying add (ConstCarryingAdd) — explicit external carry input
+// =============================================================================
+
+macro_rules! emit_carrying_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        // Take `bool` directly in the ABI. Going through `carry_in: u8`
+        // and `!= 0` introduces a `cpi/brne` on AVR (no `setne`-style
+        // instruction) — but that's a wrapper artifact, not a property
+        // of `ConstCarryingAdd::carrying_add` itself. We pass the bool
+        // straight through `black_box` so any branch the gate then
+        // detects is inside the primitive, where it belongs.
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            carry: bool,
+            out_ptr: *mut [$T; $N],
+        ) -> u8 {
+            let a_arr = core::hint::black_box(unsafe { *a_ptr });
+            let b_arr = core::hint::black_box(unsafe { *b_ptr });
+            let c = core::hint::black_box(carry);
+            let x = FixedUInt::<$T, $N, Ct>::from(a_arr);
+            let y = FixedUInt::<$T, $N, Ct>::from(b_arr);
+            let (r, co) = ConstCarryingAdd::carrying_add(x, y, c);
+            let result = core::hint::black_box(*r.words());
+            unsafe {
+                *out_ptr = result;
+            }
+            core::hint::black_box(co as u8)
+        }
+    };
+}
+emit_carrying_add!(ct_fix__C__carrying_add__u8__N16, u8, 16);
+emit_carrying_add!(ct_fix__C__carrying_add__u32__N4, u32, 4);
+emit_carrying_add!(ct_fix__C__carrying_add__u32__N16, u32, 16);
+emit_carrying_add!(ct_fix__C__carrying_add__u64__N4, u64, 4);
+
+// =============================================================================
+// Midpoint
+// =============================================================================
+
+macro_rules! emit_midpoint {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let r = ConstMidpoint::midpoint(x, y);
+            *r.words()
+        });
+    };
+}
+emit_midpoint!(ct_fix__C__midpoint__u8__N16, u8, 16);
+emit_midpoint!(ct_fix__C__midpoint__u32__N4, u32, 4);
+emit_midpoint!(ct_fix__C__midpoint__u32__N16, u32, 16);
+emit_midpoint!(ct_fix__C__midpoint__u64__N4, u64, 4);
+
+// =============================================================================
+// Bit counts: count_ones / count_zeros / swap_bytes / reverse_bits
+// =============================================================================
+
+macro_rules! emit_count_ones {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_count!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            ConstBitPrimInt::count_ones(x)
+        });
+    };
+}
+emit_count_ones!(ct_fix__C__count_ones__u8__N16, u8, 16);
+emit_count_ones!(ct_fix__C__count_ones__u32__N4, u32, 4);
+emit_count_ones!(ct_fix__C__count_ones__u32__N16, u32, 16);
+emit_count_ones!(ct_fix__C__count_ones__u64__N4, u64, 4);
+
+macro_rules! emit_swap_bytes {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let r = ConstBitPrimInt::swap_bytes(x);
+            *r.words()
+        });
+    };
+}
+emit_swap_bytes!(ct_fix__C__swap_bytes__u8__N16, u8, 16);
+emit_swap_bytes!(ct_fix__C__swap_bytes__u32__N4, u32, 4);
+emit_swap_bytes!(ct_fix__C__swap_bytes__u32__N16, u32, 16);
+emit_swap_bytes!(ct_fix__C__swap_bytes__u64__N4, u64, 4);
+
+macro_rules! emit_reverse_bits {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let r = ConstBitPrimInt::reverse_bits(x);
+            *r.words()
+        });
+    };
+}
+emit_reverse_bits!(ct_fix__C__reverse_bits__u8__N16, u8, 16);
+emit_reverse_bits!(ct_fix__C__reverse_bits__u32__N4, u32, 4);
+emit_reverse_bits!(ct_fix__C__reverse_bits__u32__N16, u32, 16);
+emit_reverse_bits!(ct_fix__C__reverse_bits__u64__N4, u64, 4);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
@@ -170,7 +170,7 @@ emit_midpoint!(ct_fix__C__midpoint__u32__N16, u32, 16);
 emit_midpoint!(ct_fix__C__midpoint__u64__N4, u64, 4);
 
 // =============================================================================
-// Bit counts: count_ones / count_zeros / swap_bytes / reverse_bits
+// Bit counts: count_ones / swap_bytes / reverse_bits
 // =============================================================================
 
 macro_rules! emit_count_ones {

--- a/ct-verify/ct-fixtures/src/fixtures_neg.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_neg.rs
@@ -1,0 +1,98 @@
+//! Negative controls. Each fixture here exercises an Nct-side primitive
+//! that has well-known data-dependent control flow. The driver runs the
+//! same disassembly + grep on these and asserts each produces **at least
+//! one** forbidden mnemonic. If a negative control produces zero
+//! violations, the harness itself is broken — the most likely causes:
+//!
+//! - The compiler unexpectedly inlined the body away or constant-folded
+//!   through black_box (unlikely but possible after a major rustc bump).
+//! - The forbidden-mnemonic regex table for this target is missing the
+//!   spelling produced here (e.g., LLVM uses `.n` suffix but the regex
+//!   only matches without it).
+//! - The symbol got stripped by linker GC.
+//!
+//! Three controls cover three independent failure axes:
+//!   - `nct_div`: long-division (per-bit comparison branches)
+//!   - `nct_ilog10`: magnitude-bound while-loop with `>=` comparisons
+//!   - `nct_gcd`: Stein's algorithm — magnitude-comparing branches
+//!     plus secret-dependent shift-by-trailing-zeros
+//!
+//! All three are guaranteed to emit conditional branches on any target
+//! we care about. If any of them passes the gate, fix the gate.
+
+use fixed_bigint::{FixedUInt, Nct};
+
+use crate::ct_fix_bin;
+
+// =============================================================================
+// nct_div: long division. Per-bit dispatch in `const_div_rem`.
+// =============================================================================
+
+macro_rules! emit_nct_div {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Nct>::from(a);
+            let y = FixedUInt::<$T, $N, Nct>::from(b);
+            // Guard against /0 panic — the fixture body itself isn't on
+            // a hot path; we just need codegen.
+            let safe = if y == FixedUInt::<$T, $N, Nct>::from([0; $N]) {
+                FixedUInt::<$T, $N, Nct>::from([1; $N])
+            } else {
+                y
+            };
+            let r = x / safe;
+            *r.words()
+        });
+    };
+}
+emit_nct_div!(nct_fix__neg__nct_div__u32__N4, u32, 4);
+emit_nct_div!(nct_fix__neg__nct_div__u32__N16, u32, 16);
+
+// =============================================================================
+// nct_ilog10: while (n >= 10) { n /= 10; count += 1; } — magnitude-bound
+// loop plus `>=` comparison on a value derived from input.
+// =============================================================================
+
+#[no_mangle]
+pub extern "C" fn nct_fix__neg__nct_ilog10__u32__N4(a_ptr: *const [u32; 4]) -> u32 {
+    use fixed_bigint::const_numtraits::ConstIlog;
+    let a_arr = core::hint::black_box(unsafe { *a_ptr });
+    let x = FixedUInt::<u32, 4, Nct>::from(a_arr);
+    // ilog10 panics on zero — guard with a safe value.
+    let safe = if x == FixedUInt::<u32, 4, Nct>::from([0u32; 4]) {
+        FixedUInt::<u32, 4, Nct>::from([1u32; 4])
+    } else {
+        x
+    };
+    let result = ConstIlog::ilog10(safe);
+    core::hint::black_box(result)
+}
+
+// =============================================================================
+// nct_gcd: Stein's algorithm. Subtraction + comparison loop.
+// =============================================================================
+
+macro_rules! emit_nct_gcd {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            use fixed_bigint::num_integer::Integer;
+            // Guard the gcd(0, _) case AND emit a data-dependent branch
+            // inside the fixture body itself. Integer::gcd's actual
+            // implementation lives in a separate helper symbol; this
+            // guard ensures the wrapper has visible forbidden mnemonics
+            // regardless of whether the helper call is on the
+            // driver's scan list.
+            let zero: [$T; $N] = [0; $N];
+            let one: [$T; $N] = [1; $N];
+            if a == zero || b == zero {
+                *FixedUInt::<$T, $N, Nct>::from(one).words()
+            } else {
+                let x = FixedUInt::<$T, $N, Nct>::from(a);
+                let y = FixedUInt::<$T, $N, Nct>::from(b);
+                let r = Integer::gcd(&x, &y);
+                *r.words()
+            }
+        });
+    };
+}
+emit_nct_gcd!(nct_fix__neg__nct_gcd__u32__N4, u32, 4);

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -1,0 +1,220 @@
+//! Inspection fixtures for the fixed-bigint CT-verify harness.
+//!
+//! Each fixture is a `#[no_mangle] pub extern "C"` symbol that exercises
+//! one Ct primitive at one concrete `(T, N)` instantiation. The driver
+//! crate (`ct-driver`) cross-builds this library for each target in the
+//! priority list, disassembles the resulting archive, and grep-checks
+//! every `ct_fix__*` symbol for forbidden conditional-control-transfer
+//! mnemonics.
+//!
+//! # Naming
+//!
+//! `ct_fix__<cat>__<op>__<T>__N<n>` — `cat` ∈ {A, B, C}, `op` is a short
+//! operation tag, `T` is the limb word type, `N` is the limb count.
+//!
+//! Negative controls deliberately exercise Nct primitives that MUST trip
+//! the gate; they use the `nct_fix__neg__*` prefix so the driver can
+//! distinguish them and assert each one produces ≥ 1 violation.
+
+#![no_std]
+#![allow(non_snake_case)]
+// Tier-2 / no_std targets ship without panic-strategy unwind libs; we
+// hardcode `panic = "abort"` in the release profile, so the lang-item is
+// satisfied at codegen time. The `#[panic_handler]` below covers debug.
+#![cfg_attr(not(test), allow(unused_imports))]
+
+mod fixtures_cat_a;
+mod fixtures_cat_b;
+mod fixtures_cat_c;
+mod fixtures_neg;
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+
+// =============================================================================
+// Fixture macros. Every fixture in this crate is one of these shapes.
+// =============================================================================
+
+/// Binary fixture: (T,N) × (T,N) → (T,N).
+///
+/// Used for: arithmetic ops (sat_add/sub/mul, ct_eq stored as out array,
+/// ct_gt/lt stored as scalar), bitwise ops (and/or/xor), wrapping/over-
+/// flowing arithmetic that doesn't need the overflow bit separately, etc.
+#[macro_export]
+macro_rules! ct_fix_bin {
+    ($name:ident, $T:ty, $N:literal, |$a:ident, $b:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            out_ptr: *mut [$T; $N],
+        ) {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let $b = core::hint::black_box(unsafe { *b_ptr });
+            let result: [$T; $N] = $body;
+            let result = core::hint::black_box(result);
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+    };
+}
+
+/// Unary fixture: (T,N) → (T,N).
+///
+/// Used for: not, reverse_bits, swap_bytes, to_be/le, from_be/le,
+/// is_power_of_two→out_zero/one (we encode as array; the predicate
+/// variant `ct_fix_pred` is preferred when the output is just a bool).
+#[macro_export]
+macro_rules! ct_fix_un {
+    ($name:ident, $T:ty, $N:literal, |$a:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(a_ptr: *const [$T; $N], out_ptr: *mut [$T; $N]) {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let result: [$T; $N] = $body;
+            let result = core::hint::black_box(result);
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+    };
+}
+
+/// Predicate fixture: (T,N) → u8.
+///
+/// Used for: is_zero, is_one, is_power_of_two — and for ct_eq/ct_gt/ct_lt
+/// when the test wants the Choice return type folded to u8 via
+/// `.unwrap_u8()`. Output is always wrapped in black_box.
+#[macro_export]
+macro_rules! ct_fix_pred {
+    ($name:ident, $T:ty, $N:literal, |$a:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(a_ptr: *const [$T; $N]) -> u8 {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let result: u8 = $body;
+            core::hint::black_box(result)
+        }
+    };
+}
+
+/// Binary predicate fixture: (T,N) × (T,N) → u8.
+#[macro_export]
+macro_rules! ct_fix_pred2 {
+    ($name:ident, $T:ty, $N:literal, |$a:ident, $b:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(a_ptr: *const [$T; $N], b_ptr: *const [$T; $N]) -> u8 {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let $b = core::hint::black_box(unsafe { *b_ptr });
+            let result: u8 = $body;
+            core::hint::black_box(result)
+        }
+    };
+}
+
+/// Bit-count fixture: (T,N) → u32.
+///
+/// Used for: count_ones, count_zeros, leading_zeros, trailing_zeros,
+/// bit_length.
+#[macro_export]
+macro_rules! ct_fix_count {
+    ($name:ident, $T:ty, $N:literal, |$a:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(a_ptr: *const [$T; $N]) -> u32 {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let result: u32 = $body;
+            core::hint::black_box(result)
+        }
+    };
+}
+
+/// Shift fixture: (T,N) × scalar → (T,N).
+///
+/// Used for: shl, shr (variable-amount shift), unbounded_shl/shr.
+/// `$NT` is `usize` for Shl<usize>/Shr<usize> or `u32` for the
+/// Unbounded variants.
+#[macro_export]
+macro_rules! ct_fix_shift {
+    ($name:ident, $T:ty, $N:literal, $NT:ty, |$a:ident, $n:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(a_ptr: *const [$T; $N], n_val: $NT, out_ptr: *mut [$T; $N]) {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let $n = core::hint::black_box(n_val);
+            let result: [$T; $N] = $body;
+            let result = core::hint::black_box(result);
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+    };
+}
+
+/// Checked-binary fixture: (T,N) × (T,N) → (T,N) + u8 validity.
+///
+/// Used for: `ct_checked_add/sub/mul`. The CtOption is split into the
+/// always-defined value (written to `out_ptr`) and the validity Choice
+/// (returned as u8). Both are wrapped in black_box.
+#[macro_export]
+macro_rules! ct_fix_checked_bin {
+    ($name:ident, $T:ty, $N:literal, |$a:ident, $b:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            out_ptr: *mut [$T; $N],
+        ) -> u8 {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let $b = core::hint::black_box(unsafe { *b_ptr });
+            let (value, valid): ([$T; $N], u8) = $body;
+            let value = core::hint::black_box(value);
+            let valid = core::hint::black_box(valid);
+            unsafe {
+                *out_ptr = value;
+            }
+            valid
+        }
+    };
+}
+
+/// Checked-unary-with-scalar fixture: (T,N) × u32 → (T,N) + u8 validity.
+///
+/// Used for: `ct_checked_shl/shr` (the scalar is u32 bits) and
+/// `ct_checked_pow` (the scalar is u32 exp).
+#[macro_export]
+macro_rules! ct_fix_checked_scalar {
+    ($name:ident, $T:ty, $N:literal, $ST:ty, |$a:ident, $s:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(a_ptr: *const [$T; $N], s_val: $ST, out_ptr: *mut [$T; $N]) -> u8 {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let $s = core::hint::black_box(s_val);
+            let (value, valid): ([$T; $N], u8) = $body;
+            let value = core::hint::black_box(value);
+            let valid = core::hint::black_box(valid);
+            unsafe {
+                *out_ptr = value;
+            }
+            valid
+        }
+    };
+}
+
+/// Checked-unary fixture: (T,N) → (T,N) + u8 validity.
+///
+/// Used for: `ct_checked_next_power_of_two`.
+#[macro_export]
+macro_rules! ct_fix_checked_un {
+    ($name:ident, $T:ty, $N:literal, |$a:ident| $body:block) => {
+        #[no_mangle]
+        pub extern "C" fn $name(a_ptr: *const [$T; $N], out_ptr: *mut [$T; $N]) -> u8 {
+            let $a = core::hint::black_box(unsafe { *a_ptr });
+            let (value, valid): ([$T; $N], u8) = $body;
+            let value = core::hint::black_box(value);
+            let valid = core::hint::black_box(valid);
+            unsafe {
+                *out_ptr = value;
+            }
+            valid
+        }
+    };
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new ct-verify workspace with a driver and fixtures to statically check fixed-bigint constant-time primitives across multiple architectures using disassembly-based branch pattern matching.

New Features:
- Add ct-fixtures crate defining no_std, black-boxed inspection fixtures and macros for fixed-bigint constant-time operations and negative controls.
- Add ct-driver binary that builds ct-fixtures for a chosen target, disassembles the static library with llvm-objdump, scans for forbidden conditional control-flow mnemonics, and emits human-readable and JSON reports.
- Support multiple target architectures with per-target mnemonic allow/deny tables and specs, including Thumb, RISC-V, AVR, AArch64, and x86_64.
- Add a GitHub Actions workflow to run ct-driver across a matrix of targets and upload per-target verification reports.

Build:
- Convert the repository into a Cargo workspace and pin the release profile for deterministic ct-verify codegen.

Documentation:
- Document the ct-verify harness and usage in a new README under ct-verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-target verification CLI: builds targets, disassembles artifacts, scans for constant-time violations, prints human summaries, emits per-target JSON reports, and returns meaningful exit codes.

* **CI**
  * GitHub Actions workflow runs verification across a matrix of targets on push/PR and uploads per-target reports as artifacts.

* **Documentation**
  * Added usage, supported-targets, and run instructions.

* **Tests/Fixtures**
  * Added extensive positive and negative constant-time fixtures covering arithmetic, bit ops, shifts, conditional-selects, checked/carrying variants, and data-dependent negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->