### PR TITLE
Apply black_box to Ct per-limb select

### DIFF
--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -13,23 +13,23 @@ jobs:
         include:
           # Priority 1: Cortex-M3/M4
           - triple: thumbv7em-none-eabi
-            toolchain: "1.85"
+            toolchain: "1.86"
           - triple: thumbv7m-none-eabi
-            toolchain: "1.85"
+            toolchain: "1.86"
           # Priority 2: Cortex-M0
           - triple: thumbv6m-none-eabi
-            toolchain: "1.85"
+            toolchain: "1.86"
           # Priority 3: 32-bit RISC-V
           - triple: riscv32imc-unknown-none-elf
-            toolchain: "1.85"
+            toolchain: "1.86"
           - triple: riscv32imac-unknown-none-elf
-            toolchain: "1.85"
+            toolchain: "1.86"
           # Priority 5: aarch64
           - triple: aarch64-unknown-linux-gnu
-            toolchain: "1.85"
+            toolchain: "1.86"
           # Priority 6: x86_64
           - triple: x86_64-unknown-linux-gnu
-            toolchain: "1.85"
+            toolchain: "1.86"
           # Priority 4: AVR (nightly-only, needs build-std + target-cpu).
           # Bare `nightly` because rust-std for avr-none isn't published
           # on every nightly date — a pinned date risks the AVR job

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.73", stable, nightly]
+        rust: ["1.86", stable, nightly]
 
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.3.0"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2018"
-rust-version = "1.73"
+rust-version = "1.86"
 description = """
 Fixed-size big integer implementation for Rust
 """

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crate](https://img.shields.io/crates/v/fixed-bigint.svg)](https://crates.io/crates/fixed-bigint)
 [![documentation](https://docs.rs/fixed-bigint/badge.svg)](https://docs.rs/fixed-bigint/)
-[![minimum rustc 1.73](https://img.shields.io/badge/rustc-1.73+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.86](https://img.shields.io/badge/rustc-1.86+-red.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![build status](https://github.com/kaidokert/fixed-bigint-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/kaidokert/fixed-bigint-rs/actions)
 [![Coverage Status](https://coveralls.io/repos/github/kaidokert/fixed-bigint-rs/badge.svg?branch=main)](https://coveralls.io/github/kaidokert/fixed-bigint-rs?branch=main)
 ![Crates.io MSRV](https://img.shields.io/crates/msrv/fixed-bigint)

--- a/ct-verify/ct-driver/Cargo.toml
+++ b/ct-verify/ct-driver/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ct-driver"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.86"
 publish = false
 description = "Cross-target disassembly + branch-grep driver for fixed-bigint CT verify."
 

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -10,7 +10,7 @@ use crate::mnemonics;
 pub struct TargetSpec {
     pub triple: &'static str,
     pub priority: u8,
-    /// "stable" | "1.85" | "nightly-YYYY-MM-DD". The driver doesn't
+    /// "stable" | "1.86" | "nightly-YYYY-MM-DD". The driver doesn't
     /// switch toolchains itself — CI sets up the right one and the
     /// triple drives `cargo build --target=<triple>`. The pin is here
     /// for documentation and so the driver can warn if the active
@@ -36,7 +36,7 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "thumbv7em-none-eabi",
         priority: 1,
-        toolchain: "1.85",
+        toolchain: "1.86",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: true,
@@ -45,7 +45,7 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "thumbv7m-none-eabi",
         priority: 1,
-        toolchain: "1.85",
+        toolchain: "1.86",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: true,
@@ -55,7 +55,7 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "thumbv6m-none-eabi",
         priority: 2,
-        toolchain: "1.85",
+        toolchain: "1.86",
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: false, // armv6m has no IT; no allowlist needed
@@ -65,7 +65,7 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "riscv32imc-unknown-none-elf",
         priority: 3,
-        toolchain: "1.85",
+        toolchain: "1.86",
         forbidden: mnemonics::RISCV_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,
@@ -74,7 +74,7 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "riscv32imac-unknown-none-elf",
         priority: 3,
-        toolchain: "1.85",
+        toolchain: "1.86",
         forbidden: mnemonics::RISCV_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,
@@ -97,7 +97,7 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "aarch64-unknown-linux-gnu",
         priority: 5,
-        toolchain: "1.85",
+        toolchain: "1.86",
         forbidden: mnemonics::AARCH64_FORBIDDEN,
         allowed_cmov: mnemonics::AARCH64_ALLOWED,
         thumb_it_blocks: false,
@@ -107,7 +107,7 @@ pub const TARGETS: &[TargetSpec] = &[
     TargetSpec {
         triple: "x86_64-unknown-linux-gnu",
         priority: 6,
-        toolchain: "1.85",
+        toolchain: "1.86",
         forbidden: mnemonics::X86_64_FORBIDDEN,
         allowed_cmov: mnemonics::X86_64_ALLOWED,
         thumb_it_blocks: false,

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ct-fixtures"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.86"
 publish = false
 description = "Inspection fixtures for the fixed-bigint CT-verify harness."
 

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -814,7 +814,9 @@ c0nst::c0nst! {
             let mut shifted = *target;
             const_shl_impl(&mut shifted, amount);
             // Spread bit k of `bits` to a full-T mask: 0 if cleared, T::MAX if set.
-            let bit_k = ((bits >> k) & 1) as u8;
+            // `black_box` is load-bearing — see `const_ct_select` for the
+            // address-select rewrite it defeats.
+            let bit_k = core::hint::black_box(((bits >> k) & 1) as u8);
             let bit_k_t = <T as core::convert::From<u8>>::from(bit_k);
             let mask = <T as core::ops::Mul>::mul(bit_k_t, <T as ConstBounded>::max_value());
             // CT-select per limb: target[i] ^= mask & (target[i] ^ shifted[i])
@@ -851,7 +853,8 @@ c0nst::c0nst! {
             let amount = 1usize << k;
             let mut shifted = *target;
             const_shr_impl(&mut shifted, amount);
-            let bit_k = ((bits >> k) & 1) as u8;
+            // See `const_shl_ct` / `const_ct_select` for why `black_box` is here.
+            let bit_k = core::hint::black_box(((bits >> k) & 1) as u8);
             let bit_k_t = <T as core::convert::From<u8>>::from(bit_k);
             let mask = <T as core::ops::Mul>::mul(bit_k_t, <T as ConstBounded>::max_value());
             let mut i = 0;
@@ -1542,6 +1545,16 @@ c0nst::c0nst! {
 
     /// Branchless per-limb select: returns `if_zero` when `choice == 0`,
     /// `if_one` when `choice == 1`.
+    ///
+    /// The `black_box` on `choice` is load-bearing. Without it, LLVM
+    /// recognizes the algebraic identity `a ^ (mask & (a ^ b))` ==
+    /// `if mask == 0 { a } else { b }` and rewrites the loop into a
+    /// `csel` of the source ADDRESS followed by a load — a secret-
+    /// dependent memory access that the asm-grep gate can't see but
+    /// that the ctgrind taint pass catches. Opacifying the choice
+    /// before it flows into `mask` keeps LLVM from proving the
+    /// equivalence in the first place. This mirrors what `subtle`'s
+    /// `Choice::from(u8)` does internally.
     pub(crate) c0nst fn const_ct_select<
         T: [c0nst] ConstMachineWord + MachineWord,
         const N: usize,
@@ -1551,6 +1564,7 @@ c0nst::c0nst! {
         if_one: FixedUInt<T, N, P>,
         choice: u8,
     ) -> FixedUInt<T, N, P> {
+        let choice = core::hint::black_box(choice);
         let bit_t = <T as core::convert::From<u8>>::from(choice);
         let mask = <T as core::ops::Mul>::mul(bit_t, <T as ConstBounded>::max_value());
         let mut result = if_zero;


### PR DESCRIPTION
LLVM recognizes `a ^ (mask & (a ^ b))` == `if mask == 0 { a } else { b }` and on some targets rewrites the loop into a `csel` of the source ADDRESS followed by a load — branch-free, but a load from a secret-selected address (cache-timing leak).

Opacifying the choice with `core::hint::black_box` at the source of the mask defeats the rewrite. Same protection `subtle`'s `Choice::from(u8)` provides internally; applied directly because `Choice::from` is not `const fn` and would break the `c0nst` macro chain these primitives use for compile-time evaluation.

## Summary by Sourcery

Harden constant-time per-limb selection and shift operations against LLVM optimizations that could introduce secret-dependent memory access by opacifying the selection mask/choice value.

Bug Fixes:
- Prevent LLVM from rewriting constant-time limb selection into a secret-dependent address select and load by opacifying the choice value with black_box in the core constant-time select primitive and its per-limb shift helpers.

Documentation:
- Document the rationale for using black_box in the constant-time select helper, explaining the LLVM optimization it defeats and its relationship to subtle::Choice::from(u8).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened constant-time operations to reduce risk of secret-dependent optimizations.
  * Bumped minimum Rust/toolchain version to 1.86 across build, CI, and related manifests.

* **Documentation**
  * Updated README badge and workflow documentation to reflect the new minimum Rust version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->