### PR TITLE
Add ct-ctgrind: Valgrind taint harness for constant-time primitives

### DIFF
--- a/.github/workflows/ct-ctgrind.yml
+++ b/.github/workflows/ct-ctgrind.yml
@@ -11,12 +11,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # x86_64 needs +lzcnt (BMI1) so that `u32::leading_zeros()`
+          # lowers to `lzcnt` instead of `test/je/bsr`. The `je` handling
+          # `bsr`-undefined-on-zero is a real data-dependent branch in
+          # the baseline-x86_64 std intrinsic lowering, not in our select
+          # code. BMI1 is available on Haswell+ (2013) and equivalent AMD
+          # CPUs — true for every GitHub Actions x86_64 runner.
+          # aarch64 has unconditional CLZ from the base ISA, no flags needed.
           - runner: ubuntu-latest
             arch: x86_64-linux
             target: x86_64-unknown-linux-gnu
+            rustflags: "-C target-feature=+lzcnt,+bmi1"
           - runner: ubuntu-24.04-arm
             arch: aarch64-linux
             target: aarch64-unknown-linux-gnu
+            rustflags: ""
     name: ${{ matrix.arch }} ctgrind
     runs-on: ${{ matrix.runner }}
     steps:
@@ -39,6 +48,8 @@ jobs:
           key: ct-ctgrind-${{ matrix.arch }}
 
       - name: Build ct-ctgrind
+        env:
+          RUSTFLAGS: ${{ matrix.rustflags }}
         run: cargo build --release -p ct-ctgrind
 
       - name: Run under Valgrind

--- a/.github/workflows/ct-ctgrind.yml
+++ b/.github/workflows/ct-ctgrind.yml
@@ -1,0 +1,36 @@
+name: CT Ctgrind
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ctgrind:
+    name: x86_64-linux ctgrind
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.86"
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Install Valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ct-ctgrind
+
+      - name: Build ct-ctgrind
+        run: cargo build --release -p ct-ctgrind
+
+      - name: Run under Valgrind
+        # --error-exitcode=0 hands exit control back to the binary, which
+        # decides pass/fail from per-fixture error-counter deltas. -q hides
+        # Valgrind's own preamble; per-error reports still print.
+        run: valgrind --tool=memcheck --error-exitcode=0 -q target/release/ct-ctgrind

--- a/.github/workflows/ct-ctgrind.yml
+++ b/.github/workflows/ct-ctgrind.yml
@@ -7,16 +7,28 @@ env:
 
 jobs:
   ctgrind:
-    name: x86_64-linux ctgrind
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: x86_64-linux
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            arch: aarch64-linux
+            target: aarch64-unknown-linux-gnu
+    name: ${{ matrix.arch }} ctgrind
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: "1.86"
-          targets: x86_64-unknown-linux-gnu
+          targets: ${{ matrix.target }}
 
       - name: Install Valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
@@ -24,7 +36,7 @@ jobs:
       - name: Cargo cache
         uses: Swatinem/rust-cache@v2
         with:
-          key: ct-ctgrind
+          key: ct-ctgrind-${{ matrix.arch }}
 
       - name: Build ct-ctgrind
         run: cargo build --release -p ct-ctgrind

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
-members = [".", "ct-verify/ct-fixtures", "ct-verify/ct-driver"]
+members = [
+    ".",
+    "ct-verify/ct-fixtures",
+    "ct-verify/ct-driver",
+    "ct-verify/ct-ctgrind",
+]
 resolver = "2"
 
 # Pinned release profile: deterministic codegen so a passing PR locks
@@ -12,6 +17,7 @@ panic = "abort"
 debug = false
 overflow-checks = false
 incremental = false
+
 
 [package]
 name = "fixed-bigint"

--- a/ct-verify/ct-ctgrind/Cargo.toml
+++ b/ct-verify/ct-ctgrind/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "ct-ctgrind"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.85"
+publish = false
+description = "Valgrind taint-based CT verifier for fixed-bigint primitives."
+
+[[bin]]
+name = "ct-ctgrind"
+path = "src/main.rs"
+
+[dependencies]
+# Link the fixtures as a Rust rlib so this binary can call each
+# `extern "C"` symbol directly. `default-features = false` disables
+# ct-fixtures' `#[panic_handler]` so std's panic handler is used.
+ct-fixtures = { path = "../ct-fixtures", default-features = false }
+
+# Distributed-slice collection for the fixture registry.
+inventory = "0.3"
+
+# Identifier concatenation in macros (for `run_<fixture_name>`).
+paste = "1.0"
+
+# Valgrind client-request wrapper, Linux-only (Valgrind itself doesn't
+# support macOS aarch64 or Windows). The driver compiles on every host
+# via stubs in `src/valgrind/stub.rs`, but only Linux can actually run
+# the gate under valgrind.
+[target.'cfg(target_os = "linux")'.dependencies]
+crabgrind = "0.1"

--- a/ct-verify/ct-ctgrind/Cargo.toml
+++ b/ct-verify/ct-ctgrind/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ct-ctgrind"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.86"
 publish = false
 description = "Valgrind taint-based CT verifier for fixed-bigint primitives."
 

--- a/ct-verify/ct-ctgrind/Dockerfile
+++ b/ct-verify/ct-ctgrind/Dockerfile
@@ -1,0 +1,33 @@
+# Dev image for iterating on ct-ctgrind locally.
+#
+# Build once:
+#   docker build -t ct-ctgrind-dev -f ct-verify/ct-ctgrind/Dockerfile .
+#
+# Then run from the repo root:
+#   docker run --rm -v "$PWD:/work" -w /work \
+#       -e CARGO_TARGET_DIR=/work/target/docker \
+#       ct-ctgrind-dev \
+#       bash -c "cargo build --release -p ct-ctgrind && \
+#                valgrind --tool=memcheck --error-exitcode=0 -q \
+#                  target/docker/release/ct-ctgrind"
+#
+# Matches the CI image (ubuntu-latest = 24.04) so Valgrind versions and
+# crabgrind's C header dependencies line up.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update -qq && \
+    apt-get install -y -qq --no-install-recommends \
+        build-essential curl valgrind ca-certificates pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --default-toolchain 1.85 --profile minimal --no-modify-path && \
+    rustup --version && cargo --version
+
+WORKDIR /work

--- a/ct-verify/ct-ctgrind/Dockerfile
+++ b/ct-verify/ct-ctgrind/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-        sh -s -- -y --default-toolchain 1.85 --profile minimal --no-modify-path && \
+        sh -s -- -y --default-toolchain 1.86 --profile minimal --no-modify-path && \
     rustup --version && cargo --version
 
 WORKDIR /work

--- a/ct-verify/ct-ctgrind/README.md
+++ b/ct-verify/ct-ctgrind/README.md
@@ -1,6 +1,6 @@
 # ct-ctgrind
 
-A second layer of CT verification for the same fixtures `ct-driver`
+A second layer of CT verification for the same fixtures that `ct-driver`
 inspects: instead of grepping disassembly for branches, this driver
 runs each fixture under Valgrind with its input buffers tagged
 `MAKE_MEM_UNDEFINED` via crabgrind. Valgrind then flags any

--- a/ct-verify/ct-ctgrind/README.md
+++ b/ct-verify/ct-ctgrind/README.md
@@ -1,0 +1,26 @@
+# ct-ctgrind
+
+A second layer of CT verification for the same fixtures `ct-driver`
+inspects: instead of grepping disassembly for branches, this driver
+runs each fixture under Valgrind with its input buffers tagged
+`MAKE_MEM_UNDEFINED` via crabgrind. Valgrind then flags any
+conditional jump or memory access that depends on those tainted
+bytes — including the secret-derived loads (`table[secret & 0xf]`
+and friends) that asm-grep can't see because they're not branches.
+Between fixtures the driver reads Valgrind's error counter to
+attribute violations to specific symbols, the same way the asm-grep
+driver maps disassembled bodies back to fixture names. The same
+negative-control fixtures from `ct-fixtures` are reused: every
+`nct_fix__neg__*` symbol must trip Valgrind, or the harness itself
+is broken.
+
+To run it locally on a Linux host: `cargo build --release -p
+ct-ctgrind && valgrind --tool=memcheck --error-exitcode=0 -q
+target/release/ct-ctgrind`. Valgrind isn't available on macOS
+aarch64 or Windows, so on those hosts the crate still compiles (via
+no-op stubs in `src/valgrind/stub.rs`) but `cargo run -p ct-ctgrind`
+just prints a "must be run under valgrind" error and exits. CI runs
+the full gate on `x86_64-unknown-linux-gnu`. To extend the fixture
+set, add the corresponding macro invocation in
+`src/fixtures_cat_*.rs` and the matching `ct_fix_*!` entry in
+`ct-fixtures` — the two files mirror each other one-for-one.

--- a/ct-verify/ct-ctgrind/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures_cat_a.rs
@@ -1,0 +1,94 @@
+//! Category A fixture registrations — mirror of ct-fixtures' cat_a.
+
+use crate::{ctgrind_bin, ctgrind_count, ctgrind_pred, ctgrind_shift, ctgrind_un};
+
+// sat_add / sat_sub / sat_mul
+ctgrind_bin!(ct_fix__A__sat_add__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__A__sat_add__u16__N16, u16, 16);
+ctgrind_bin!(ct_fix__A__sat_add__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__A__sat_add__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__A__sat_add__u64__N4, u64, 4);
+
+ctgrind_bin!(ct_fix__A__sat_sub__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__A__sat_sub__u16__N16, u16, 16);
+ctgrind_bin!(ct_fix__A__sat_sub__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__A__sat_sub__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__A__sat_sub__u64__N4, u64, 4);
+
+ctgrind_bin!(ct_fix__A__sat_mul__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__A__sat_mul__u16__N16, u16, 16);
+ctgrind_bin!(ct_fix__A__sat_mul__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__A__sat_mul__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__A__sat_mul__u64__N4, u64, 4);
+
+// shl<usize> / shr<usize>
+ctgrind_shift!(ct_fix__A__shl_usize__u8__N16, u8, 16, usize);
+ctgrind_shift!(ct_fix__A__shl_usize__u16__N16, u16, 16, usize);
+ctgrind_shift!(ct_fix__A__shl_usize__u32__N4, u32, 4, usize);
+ctgrind_shift!(ct_fix__A__shl_usize__u32__N16, u32, 16, usize);
+ctgrind_shift!(ct_fix__A__shl_usize__u64__N4, u64, 4, usize);
+
+ctgrind_shift!(ct_fix__A__shr_usize__u8__N16, u8, 16, usize);
+ctgrind_shift!(ct_fix__A__shr_usize__u16__N16, u16, 16, usize);
+ctgrind_shift!(ct_fix__A__shr_usize__u32__N4, u32, 4, usize);
+ctgrind_shift!(ct_fix__A__shr_usize__u32__N16, u32, 16, usize);
+ctgrind_shift!(ct_fix__A__shr_usize__u64__N4, u64, 4, usize);
+
+// unbounded_shl / unbounded_shr — scalar is u32
+ctgrind_shift!(ct_fix__A__unbounded_shl__u8__N16, u8, 16, u32);
+ctgrind_shift!(ct_fix__A__unbounded_shl__u16__N16, u16, 16, u32);
+ctgrind_shift!(ct_fix__A__unbounded_shl__u32__N4, u32, 4, u32);
+ctgrind_shift!(ct_fix__A__unbounded_shl__u32__N16, u32, 16, u32);
+ctgrind_shift!(ct_fix__A__unbounded_shl__u64__N4, u64, 4, u32);
+
+ctgrind_shift!(ct_fix__A__unbounded_shr__u8__N16, u8, 16, u32);
+ctgrind_shift!(ct_fix__A__unbounded_shr__u16__N16, u16, 16, u32);
+ctgrind_shift!(ct_fix__A__unbounded_shr__u32__N4, u32, 4, u32);
+ctgrind_shift!(ct_fix__A__unbounded_shr__u32__N16, u32, 16, u32);
+ctgrind_shift!(ct_fix__A__unbounded_shr__u64__N4, u64, 4, u32);
+
+// abs_diff
+ctgrind_bin!(ct_fix__A__abs_diff__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__A__abs_diff__u16__N16, u16, 16);
+ctgrind_bin!(ct_fix__A__abs_diff__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__A__abs_diff__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__A__abs_diff__u64__N4, u64, 4);
+
+// is_pow2 / next_pow2
+ctgrind_pred!(ct_fix__A__is_pow2__u8__N16, u8, 16);
+ctgrind_pred!(ct_fix__A__is_pow2__u16__N16, u16, 16);
+ctgrind_pred!(ct_fix__A__is_pow2__u32__N4, u32, 4);
+ctgrind_pred!(ct_fix__A__is_pow2__u32__N16, u32, 16);
+ctgrind_pred!(ct_fix__A__is_pow2__u64__N4, u64, 4);
+
+ctgrind_un!(ct_fix__A__next_pow2__u8__N16, u8, 16);
+ctgrind_un!(ct_fix__A__next_pow2__u16__N16, u16, 16);
+ctgrind_un!(ct_fix__A__next_pow2__u32__N4, u32, 4);
+ctgrind_un!(ct_fix__A__next_pow2__u32__N16, u32, 16);
+ctgrind_un!(ct_fix__A__next_pow2__u64__N4, u64, 4);
+
+// leading_zeros / trailing_zeros
+ctgrind_count!(ct_fix__A__leading_zeros__u8__N16, u8, 16);
+ctgrind_count!(ct_fix__A__leading_zeros__u16__N16, u16, 16);
+ctgrind_count!(ct_fix__A__leading_zeros__u32__N4, u32, 4);
+ctgrind_count!(ct_fix__A__leading_zeros__u32__N16, u32, 16);
+ctgrind_count!(ct_fix__A__leading_zeros__u64__N4, u64, 4);
+
+ctgrind_count!(ct_fix__A__trailing_zeros__u8__N16, u8, 16);
+ctgrind_count!(ct_fix__A__trailing_zeros__u16__N16, u16, 16);
+ctgrind_count!(ct_fix__A__trailing_zeros__u32__N4, u32, 4);
+ctgrind_count!(ct_fix__A__trailing_zeros__u32__N16, u32, 16);
+ctgrind_count!(ct_fix__A__trailing_zeros__u64__N4, u64, 4);
+
+// is_zero / is_one
+ctgrind_pred!(ct_fix__A__is_zero__u8__N16, u8, 16);
+ctgrind_pred!(ct_fix__A__is_zero__u16__N16, u16, 16);
+ctgrind_pred!(ct_fix__A__is_zero__u32__N4, u32, 4);
+ctgrind_pred!(ct_fix__A__is_zero__u32__N16, u32, 16);
+ctgrind_pred!(ct_fix__A__is_zero__u64__N4, u64, 4);
+
+ctgrind_pred!(ct_fix__A__is_one__u8__N16, u8, 16);
+ctgrind_pred!(ct_fix__A__is_one__u16__N16, u16, 16);
+ctgrind_pred!(ct_fix__A__is_one__u32__N4, u32, 4);
+ctgrind_pred!(ct_fix__A__is_one__u32__N16, u32, 16);
+ctgrind_pred!(ct_fix__A__is_one__u64__N4, u64, 4);

--- a/ct-verify/ct-ctgrind/src/fixtures_cat_b.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures_cat_b.rs
@@ -1,0 +1,84 @@
+//! Category B fixture registrations — mirror of ct-fixtures' cat_b.
+
+use crate::{
+    ctgrind_checked_bin, ctgrind_checked_scalar, ctgrind_checked_un, ctgrind_cond_select,
+    ctgrind_pred2, ctgrind_un,
+};
+
+// ct_eq / ct_gt / ct_lt
+ctgrind_pred2!(ct_fix__B__ct_eq__u8__N16, u8, 16);
+ctgrind_pred2!(ct_fix__B__ct_eq__u16__N16, u16, 16);
+ctgrind_pred2!(ct_fix__B__ct_eq__u32__N4, u32, 4);
+ctgrind_pred2!(ct_fix__B__ct_eq__u32__N16, u32, 16);
+ctgrind_pred2!(ct_fix__B__ct_eq__u64__N4, u64, 4);
+
+ctgrind_pred2!(ct_fix__B__ct_gt__u8__N16, u8, 16);
+ctgrind_pred2!(ct_fix__B__ct_gt__u16__N16, u16, 16);
+ctgrind_pred2!(ct_fix__B__ct_gt__u32__N4, u32, 4);
+ctgrind_pred2!(ct_fix__B__ct_gt__u32__N16, u32, 16);
+ctgrind_pred2!(ct_fix__B__ct_gt__u64__N4, u64, 4);
+
+ctgrind_pred2!(ct_fix__B__ct_lt__u8__N16, u8, 16);
+ctgrind_pred2!(ct_fix__B__ct_lt__u16__N16, u16, 16);
+ctgrind_pred2!(ct_fix__B__ct_lt__u32__N4, u32, 4);
+ctgrind_pred2!(ct_fix__B__ct_lt__u32__N16, u32, 16);
+ctgrind_pred2!(ct_fix__B__ct_lt__u64__N4, u64, 4);
+
+// cond_select — (a, b, choice: u8) → out
+ctgrind_cond_select!(ct_fix__B__cond_select__u8__N16, u8, 16);
+ctgrind_cond_select!(ct_fix__B__cond_select__u16__N16, u16, 16);
+ctgrind_cond_select!(ct_fix__B__cond_select__u32__N4, u32, 4);
+ctgrind_cond_select!(ct_fix__B__cond_select__u32__N16, u32, 16);
+ctgrind_cond_select!(ct_fix__B__cond_select__u64__N4, u64, 4);
+
+// ct_checked_add / sub / mul — checked_bin shape
+ctgrind_checked_bin!(ct_fix__B__ct_checked_add__u8__N16, u8, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_add__u16__N16, u16, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_add__u32__N4, u32, 4);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_add__u32__N16, u32, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_add__u64__N4, u64, 4);
+
+ctgrind_checked_bin!(ct_fix__B__ct_checked_sub__u8__N16, u8, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_sub__u16__N16, u16, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_sub__u32__N4, u32, 4);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_sub__u32__N16, u32, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_sub__u64__N4, u64, 4);
+
+ctgrind_checked_bin!(ct_fix__B__ct_checked_mul__u8__N16, u8, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_mul__u16__N16, u16, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_mul__u32__N4, u32, 4);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_mul__u32__N16, u32, 16);
+ctgrind_checked_bin!(ct_fix__B__ct_checked_mul__u64__N4, u64, 4);
+
+// ct_checked_shl / shr / pow — checked_scalar(u32) shape
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shl__u8__N16, u8, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shl__u16__N16, u16, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shl__u32__N4, u32, 4, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shl__u32__N16, u32, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shl__u64__N4, u64, 4, u32);
+
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shr__u8__N16, u8, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shr__u16__N16, u16, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shr__u32__N4, u32, 4, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shr__u32__N16, u32, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_shr__u64__N4, u64, 4, u32);
+
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_pow__u8__N16, u8, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_pow__u16__N16, u16, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_pow__u32__N4, u32, 4, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_pow__u32__N16, u32, 16, u32);
+ctgrind_checked_scalar!(ct_fix__B__ct_checked_pow__u64__N4, u64, 4, u32);
+
+// ct_checked_npot
+ctgrind_checked_un!(ct_fix__B__ct_checked_npot__u8__N16, u8, 16);
+ctgrind_checked_un!(ct_fix__B__ct_checked_npot__u16__N16, u16, 16);
+ctgrind_checked_un!(ct_fix__B__ct_checked_npot__u32__N4, u32, 4);
+ctgrind_checked_un!(ct_fix__B__ct_checked_npot__u32__N16, u32, 16);
+ctgrind_checked_un!(ct_fix__B__ct_checked_npot__u64__N4, u64, 4);
+
+// forget_ct — unary
+ctgrind_un!(ct_fix__B__forget_ct__u8__N16, u8, 16);
+ctgrind_un!(ct_fix__B__forget_ct__u16__N16, u16, 16);
+ctgrind_un!(ct_fix__B__forget_ct__u32__N4, u32, 4);
+ctgrind_un!(ct_fix__B__forget_ct__u32__N16, u32, 16);
+ctgrind_un!(ct_fix__B__forget_ct__u64__N4, u64, 4);

--- a/ct-verify/ct-ctgrind/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures_cat_c.rs
@@ -1,0 +1,64 @@
+//! Category C fixture registrations — mirror of ct-fixtures' cat_c.
+
+use crate::{ctgrind_bin, ctgrind_carrying_add, ctgrind_count, ctgrind_un};
+
+// Bitwise — not is unary, and/or/xor are binary.
+ctgrind_un!(ct_fix__C__not__u8__N16, u8, 16);
+ctgrind_un!(ct_fix__C__not__u32__N4, u32, 4);
+ctgrind_un!(ct_fix__C__not__u32__N16, u32, 16);
+ctgrind_un!(ct_fix__C__not__u64__N4, u64, 4);
+
+ctgrind_bin!(ct_fix__C__bitand__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__C__bitand__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__C__bitand__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__C__bitand__u64__N4, u64, 4);
+
+ctgrind_bin!(ct_fix__C__bitor__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__C__bitor__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__C__bitor__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__C__bitor__u64__N4, u64, 4);
+
+ctgrind_bin!(ct_fix__C__bitxor__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__C__bitxor__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__C__bitxor__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__C__bitxor__u64__N4, u64, 4);
+
+// overflowing_add / wrapping_mul — binary, overflow bool discarded
+ctgrind_bin!(ct_fix__C__overflowing_add__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__C__overflowing_add__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__C__overflowing_add__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__C__overflowing_add__u64__N4, u64, 4);
+
+ctgrind_bin!(ct_fix__C__wrapping_mul__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__C__wrapping_mul__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__C__wrapping_mul__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__C__wrapping_mul__u64__N4, u64, 4);
+
+// carrying_add — (a, b, carry: bool, out) → u8
+ctgrind_carrying_add!(ct_fix__C__carrying_add__u8__N16, u8, 16);
+ctgrind_carrying_add!(ct_fix__C__carrying_add__u32__N4, u32, 4);
+ctgrind_carrying_add!(ct_fix__C__carrying_add__u32__N16, u32, 16);
+ctgrind_carrying_add!(ct_fix__C__carrying_add__u64__N4, u64, 4);
+
+// midpoint — binary
+ctgrind_bin!(ct_fix__C__midpoint__u8__N16, u8, 16);
+ctgrind_bin!(ct_fix__C__midpoint__u32__N4, u32, 4);
+ctgrind_bin!(ct_fix__C__midpoint__u32__N16, u32, 16);
+ctgrind_bin!(ct_fix__C__midpoint__u64__N4, u64, 4);
+
+// count_ones — count shape
+ctgrind_count!(ct_fix__C__count_ones__u8__N16, u8, 16);
+ctgrind_count!(ct_fix__C__count_ones__u32__N4, u32, 4);
+ctgrind_count!(ct_fix__C__count_ones__u32__N16, u32, 16);
+ctgrind_count!(ct_fix__C__count_ones__u64__N4, u64, 4);
+
+// swap_bytes / reverse_bits — unary
+ctgrind_un!(ct_fix__C__swap_bytes__u8__N16, u8, 16);
+ctgrind_un!(ct_fix__C__swap_bytes__u32__N4, u32, 4);
+ctgrind_un!(ct_fix__C__swap_bytes__u32__N16, u32, 16);
+ctgrind_un!(ct_fix__C__swap_bytes__u64__N4, u64, 4);
+
+ctgrind_un!(ct_fix__C__reverse_bits__u8__N16, u8, 16);
+ctgrind_un!(ct_fix__C__reverse_bits__u32__N4, u32, 4);
+ctgrind_un!(ct_fix__C__reverse_bits__u32__N16, u32, 16);
+ctgrind_un!(ct_fix__C__reverse_bits__u64__N4, u64, 4);

--- a/ct-verify/ct-ctgrind/src/fixtures_neg.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures_neg.rs
@@ -1,0 +1,13 @@
+//! Negative-control registrations — mirror of ct-fixtures' fixtures_neg.
+
+use crate::{ctgrind_bin, ctgrind_count};
+
+// nct_div — bin shape
+ctgrind_bin!(nct_fix__neg__nct_div__u32__N4, u32, 4);
+ctgrind_bin!(nct_fix__neg__nct_div__u32__N16, u32, 16);
+
+// nct_ilog10 — count shape (takes (a) returns u32)
+ctgrind_count!(nct_fix__neg__nct_ilog10__u32__N4, u32, 4);
+
+// nct_gcd — bin shape
+ctgrind_bin!(nct_fix__neg__nct_gcd__u32__N4, u32, 4);

--- a/ct-verify/ct-ctgrind/src/macros.rs
+++ b/ct-verify/ct-ctgrind/src/macros.rs
@@ -1,0 +1,369 @@
+//! ctgrind fixture macros — one per ABI shape in ct-fixtures.
+//!
+//! Each macro emits:
+//!   * an `extern "C"` declaration matching the fixture's ABI
+//!   * a `run_<name>()` Rust wrapper that allocates buffers, taints the
+//!     secret inputs with `MAKE_MEM_UNDEFINED`, calls the symbol, then
+//!     marks the output buffer DEFINED so its post-call use (the
+//!     `black_box`) doesn't itself trip Valgrind
+//!   * an `inventory::submit!` registration into `Fixture`
+//!
+//! Mirrors the ABI shapes declared by ct-fixtures' `ct_fix_*` macros.
+
+/// Binary fixture: (T,N) × (T,N) → (T,N).
+#[macro_export]
+macro_rules! ctgrind_bin {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(
+                    a: *const [$T; $N],
+                    b: *const [$T; $N],
+                    out: *mut [$T; $N],
+                );
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let b: [$T; $N] = [0; $N];
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                $crate::macros::taint(&b);
+                unsafe { $name(&a, &b, &mut out); }
+                $crate::macros::untaint(&out);
+                let _ = ::core::hint::black_box(out);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// Unary fixture: (T,N) → (T,N).
+#[macro_export]
+macro_rules! ctgrind_un {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(a: *const [$T; $N], out: *mut [$T; $N]);
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                unsafe { $name(&a, &mut out); }
+                $crate::macros::untaint(&out);
+                let _ = ::core::hint::black_box(out);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// Predicate fixture: (T,N) → u8.
+#[macro_export]
+macro_rules! ctgrind_pred {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(a: *const [$T; $N]) -> u8;
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                let r = unsafe { $name(&a) };
+                $crate::macros::untaint_val(&r);
+                let _ = ::core::hint::black_box(r);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// Binary predicate fixture: (T,N) × (T,N) → u8.
+#[macro_export]
+macro_rules! ctgrind_pred2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(a: *const [$T; $N], b: *const [$T; $N]) -> u8;
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let b: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                $crate::macros::taint(&b);
+                let r = unsafe { $name(&a, &b) };
+                $crate::macros::untaint_val(&r);
+                let _ = ::core::hint::black_box(r);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// Bit-count fixture: (T,N) → u32.
+#[macro_export]
+macro_rules! ctgrind_count {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(a: *const [$T; $N]) -> u32;
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                let r = unsafe { $name(&a) };
+                $crate::macros::untaint_val(&r);
+                let _ = ::core::hint::black_box(r);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// Shift fixture: (T,N) × scalar → (T,N).
+#[macro_export]
+macro_rules! ctgrind_shift {
+    ($name:ident, $T:ty, $N:literal, $NT:ty) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(a: *const [$T; $N], n: $NT, out: *mut [$T; $N]);
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let n: $NT = 0;
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                $crate::macros::taint_val(&n);
+                unsafe { $name(&a, n, &mut out); }
+                $crate::macros::untaint(&out);
+                let _ = ::core::hint::black_box(out);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// Checked-binary fixture: (T,N) × (T,N) → (T,N) + u8.
+#[macro_export]
+macro_rules! ctgrind_checked_bin {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(
+                    a: *const [$T; $N],
+                    b: *const [$T; $N],
+                    out: *mut [$T; $N],
+                ) -> u8;
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let b: [$T; $N] = [0; $N];
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                $crate::macros::taint(&b);
+                let r = unsafe { $name(&a, &b, &mut out) };
+                $crate::macros::untaint(&out);
+                $crate::macros::untaint_val(&r);
+                let _ = ::core::hint::black_box(out);
+                let _ = ::core::hint::black_box(r);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// Checked-unary-with-scalar fixture: (T,N) × scalar → (T,N) + u8.
+#[macro_export]
+macro_rules! ctgrind_checked_scalar {
+    ($name:ident, $T:ty, $N:literal, $ST:ty) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(a: *const [$T; $N], s: $ST, out: *mut [$T; $N]) -> u8;
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let s: $ST = 0;
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                $crate::macros::taint_val(&s);
+                let r = unsafe { $name(&a, s, &mut out) };
+                $crate::macros::untaint(&out);
+                $crate::macros::untaint_val(&r);
+                let _ = ::core::hint::black_box(out);
+                let _ = ::core::hint::black_box(r);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// Checked-unary fixture: (T,N) → (T,N) + u8.
+#[macro_export]
+macro_rules! ctgrind_checked_un {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(a: *const [$T; $N], out: *mut [$T; $N]) -> u8;
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                let r = unsafe { $name(&a, &mut out) };
+                $crate::macros::untaint(&out);
+                $crate::macros::untaint_val(&r);
+                let _ = ::core::hint::black_box(out);
+                let _ = ::core::hint::black_box(r);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// `cond_select` fixture: (T,N) × (T,N) × u8 → (T,N).
+#[macro_export]
+macro_rules! ctgrind_cond_select {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(
+                    a: *const [$T; $N],
+                    b: *const [$T; $N],
+                    choice: u8,
+                    out: *mut [$T; $N],
+                );
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let b: [$T; $N] = [0; $N];
+                let choice: u8 = 0;
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                $crate::macros::taint(&b);
+                $crate::macros::taint_val(&choice);
+                unsafe { $name(&a, &b, choice, &mut out); }
+                $crate::macros::untaint(&out);
+                let _ = ::core::hint::black_box(out);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+/// `carrying_add` fixture: (T,N) × (T,N) × bool → (T,N) + u8.
+#[macro_export]
+macro_rules! ctgrind_carrying_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(
+                    a: *const [$T; $N],
+                    b: *const [$T; $N],
+                    carry: bool,
+                    out: *mut [$T; $N],
+                ) -> u8;
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let a: [$T; $N] = [0; $N];
+                let b: [$T; $N] = [0; $N];
+                let carry: bool = false;
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint(&a);
+                $crate::macros::taint(&b);
+                $crate::macros::taint_val(&carry);
+                let r = unsafe { $name(&a, &b, carry, &mut out) };
+                $crate::macros::untaint(&out);
+                $crate::macros::untaint_val(&r);
+                let _ = ::core::hint::black_box(out);
+                let _ = ::core::hint::black_box(r);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+// ============================================================================
+// Taint helpers — thin wrappers around crabgrind's memcheck client requests.
+// ============================================================================
+
+pub fn taint<T>(buf: &[T]) {
+    crate::valgrind::mark_undefined(buf.as_ptr() as *const u8, ::core::mem::size_of_val(buf));
+}
+
+pub fn taint_val<T>(v: &T) {
+    crate::valgrind::mark_undefined(v as *const T as *const u8, ::core::mem::size_of::<T>());
+}
+
+pub fn untaint<T>(buf: &[T]) {
+    crate::valgrind::mark_defined(buf.as_ptr() as *const u8, ::core::mem::size_of_val(buf));
+}
+
+pub fn untaint_val<T>(v: &T) {
+    crate::valgrind::mark_defined(v as *const T as *const u8, ::core::mem::size_of::<T>());
+}

--- a/ct-verify/ct-ctgrind/src/macros.rs
+++ b/ct-verify/ct-ctgrind/src/macros.rs
@@ -161,7 +161,11 @@ macro_rules! ctgrind_shift {
             #[allow(non_snake_case)]
             fn [<run_ $name>]() {
                 let a: [$T; $N] = [0; $N];
-                let n: $NT = 0;
+                // `black_box(0)` opacifies the literal — without it, release-
+                // LTO constant-propagates the 0 past `taint_val(&n)` (which
+                // only sets Valgrind metadata, not memory contents) and the
+                // taint never reaches the called primitive.
+                let n: $NT = ::core::hint::black_box(0);
                 let mut out: [$T; $N] = [0; $N];
                 $crate::macros::taint(&a);
                 $crate::macros::taint_val(&n);
@@ -225,7 +229,8 @@ macro_rules! ctgrind_checked_scalar {
             #[allow(non_snake_case)]
             fn [<run_ $name>]() {
                 let a: [$T; $N] = [0; $N];
-                let s: $ST = 0;
+                // See `ctgrind_shift` for the `black_box(0)` rationale.
+                let s: $ST = ::core::hint::black_box(0);
                 let mut out: [$T; $N] = [0; $N];
                 $crate::macros::taint(&a);
                 $crate::macros::taint_val(&s);
@@ -291,7 +296,8 @@ macro_rules! ctgrind_cond_select {
             fn [<run_ $name>]() {
                 let a: [$T; $N] = [0; $N];
                 let b: [$T; $N] = [0; $N];
-                let choice: u8 = 0;
+                // See `ctgrind_shift` for the `black_box(0)` rationale.
+                let choice: u8 = ::core::hint::black_box(0);
                 let mut out: [$T; $N] = [0; $N];
                 $crate::macros::taint(&a);
                 $crate::macros::taint(&b);
@@ -327,7 +333,8 @@ macro_rules! ctgrind_carrying_add {
             fn [<run_ $name>]() {
                 let a: [$T; $N] = [0; $N];
                 let b: [$T; $N] = [0; $N];
-                let carry: bool = false;
+                // See `ctgrind_shift` for the `black_box(false)` rationale.
+                let carry: bool = ::core::hint::black_box(false);
                 let mut out: [$T; $N] = [0; $N];
                 $crate::macros::taint(&a);
                 $crate::macros::taint(&b);

--- a/ct-verify/ct-ctgrind/src/main.rs
+++ b/ct-verify/ct-ctgrind/src/main.rs
@@ -53,6 +53,7 @@ fn main() -> ExitCode {
     let mut pos_fail: Vec<&'static str> = Vec::new();
     let mut neg_seen: usize = 0;
     let mut neg_no_trip: Vec<&'static str> = Vec::new();
+    let mut unclassified: Vec<&'static str> = Vec::new();
 
     for fixture in inventory::iter::<Fixture>() {
         let before = valgrind::count_errors();
@@ -71,6 +72,11 @@ fn main() -> ExitCode {
             if !tripped {
                 neg_no_trip.push(fixture.name);
             }
+        } else {
+            // Fail closed — a fixture whose name matches neither prefix is
+            // almost certainly a rename/typo that would otherwise vanish
+            // from coverage silently.
+            unclassified.push(fixture.name);
         }
     }
 
@@ -91,6 +97,9 @@ fn main() -> ExitCode {
     for f in &neg_no_trip {
         println!("    FAIL (negative didn't trip): {}", f);
     }
+    for f in &unclassified {
+        println!("    FAIL (unclassified fixture name): {}", f);
+    }
 
     if pos_pass + pos_fail.len() == 0 {
         eprintln!("error: no positive fixtures registered — registry empty?");
@@ -100,7 +109,7 @@ fn main() -> ExitCode {
         eprintln!("error: no negative controls registered — registry empty?");
         return ExitCode::FAILURE;
     }
-    if !pos_fail.is_empty() || !neg_no_trip.is_empty() {
+    if !pos_fail.is_empty() || !neg_no_trip.is_empty() || !unclassified.is_empty() {
         return ExitCode::FAILURE;
     }
     ExitCode::SUCCESS

--- a/ct-verify/ct-ctgrind/src/main.rs
+++ b/ct-verify/ct-ctgrind/src/main.rs
@@ -1,0 +1,107 @@
+//! ct-ctgrind — Valgrind-based taint verifier for fixed-bigint Ct primitives.
+//!
+//! Each fixture from `ct-fixtures` is called with its input buffers tagged
+//! `MAKE_MEM_UNDEFINED` via crabgrind. Valgrind then flags any conditional
+//! jump or memory access that depends on those tainted bytes. The driver
+//! reads Valgrind's error counter between fixtures to attribute violations.
+//!
+//! Run as: `valgrind --tool=memcheck --error-exitcode=0 ct-ctgrind`.
+//! `--error-exitcode=0` is important — we want Valgrind to NOT set the
+//! process exit code, because we decide pass/fail ourselves based on
+//! which fixtures (positive or negative) tripped.
+
+use std::process::ExitCode;
+
+mod macros;
+mod valgrind;
+
+mod fixtures_cat_a;
+mod fixtures_cat_b;
+mod fixtures_cat_c;
+mod fixtures_neg;
+
+pub struct Fixture {
+    pub name: &'static str,
+    pub run: fn(),
+}
+
+inventory::collect!(Fixture);
+
+fn is_positive(name: &str) -> bool {
+    name.starts_with("ct_fix__")
+}
+
+fn is_negative(name: &str) -> bool {
+    name.starts_with("nct_fix__neg__")
+}
+
+fn main() -> ExitCode {
+    // Force ct-fixtures' rlib to be linked. Without a Rust-level
+    // reference rustc drops it from the link line, and the
+    // extern "C" fixture symbols come back undefined.
+    ct_fixtures::link_anchor();
+
+    if !valgrind::is_under_valgrind() {
+        eprintln!(
+            "error: ct-ctgrind must be run under valgrind \
+             (e.g. `valgrind --tool=memcheck --error-exitcode=0 ct-ctgrind`)"
+        );
+        return ExitCode::from(2);
+    }
+
+    let mut pos_pass: usize = 0;
+    let mut pos_fail: Vec<&'static str> = Vec::new();
+    let mut neg_seen: usize = 0;
+    let mut neg_no_trip: Vec<&'static str> = Vec::new();
+
+    for fixture in inventory::iter::<Fixture>() {
+        let before = valgrind::count_errors();
+        (fixture.run)();
+        let after = valgrind::count_errors();
+        let tripped = after > before;
+
+        if is_positive(fixture.name) {
+            if tripped {
+                pos_fail.push(fixture.name);
+            } else {
+                pos_pass += 1;
+            }
+        } else if is_negative(fixture.name) {
+            neg_seen += 1;
+            if !tripped {
+                neg_no_trip.push(fixture.name);
+            }
+        }
+    }
+
+    println!("==== CT-ctgrind report ====");
+    println!(
+        "  ct_fix__*       passed: {}  failed: {}",
+        pos_pass,
+        pos_fail.len()
+    );
+    println!(
+        "  nct_fix__neg__* tripped: {}/{}",
+        neg_seen - neg_no_trip.len(),
+        neg_seen
+    );
+    for f in &pos_fail {
+        println!("    FAIL (positive tripped Valgrind): {}", f);
+    }
+    for f in &neg_no_trip {
+        println!("    FAIL (negative didn't trip): {}", f);
+    }
+
+    if pos_pass + pos_fail.len() == 0 {
+        eprintln!("error: no positive fixtures registered — registry empty?");
+        return ExitCode::FAILURE;
+    }
+    if neg_seen == 0 {
+        eprintln!("error: no negative controls registered — registry empty?");
+        return ExitCode::FAILURE;
+    }
+    if !pos_fail.is_empty() || !neg_no_trip.is_empty() {
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
+}

--- a/ct-verify/ct-ctgrind/src/valgrind.rs
+++ b/ct-verify/ct-ctgrind/src/valgrind.rs
@@ -1,0 +1,18 @@
+//! Thin abstraction over crabgrind's Valgrind client requests.
+//!
+//! crabgrind links against Valgrind's C headers, which aren't available
+//! outside Linux (Valgrind itself doesn't support macOS aarch64 or Windows).
+//! On non-Linux hosts this module compiles as no-op stubs so the workspace
+//! still builds, but actually exercising the gate requires Linux.
+
+#[cfg(target_os = "linux")]
+mod real;
+
+#[cfg(target_os = "linux")]
+pub use real::*;
+
+#[cfg(not(target_os = "linux"))]
+mod stub;
+
+#[cfg(not(target_os = "linux"))]
+pub use stub::*;

--- a/ct-verify/ct-ctgrind/src/valgrind/real.rs
+++ b/ct-verify/ct-ctgrind/src/valgrind/real.rs
@@ -1,0 +1,27 @@
+//! Linux implementation — real crabgrind calls.
+
+use std::ffi::c_void;
+
+pub fn is_under_valgrind() -> bool {
+    !matches!(crabgrind::run_mode(), crabgrind::RunMode::Native)
+}
+
+pub fn count_errors() -> usize {
+    crabgrind::count_errors()
+}
+
+pub fn mark_undefined(addr: *const u8, len: usize) {
+    let _ = crabgrind::memcheck::mark_mem(
+        addr as *mut c_void,
+        len,
+        crabgrind::memcheck::MemState::Undefined,
+    );
+}
+
+pub fn mark_defined(addr: *const u8, len: usize) {
+    let _ = crabgrind::memcheck::mark_mem(
+        addr as *mut c_void,
+        len,
+        crabgrind::memcheck::MemState::Defined,
+    );
+}

--- a/ct-verify/ct-ctgrind/src/valgrind/stub.rs
+++ b/ct-verify/ct-ctgrind/src/valgrind/stub.rs
@@ -1,0 +1,14 @@
+//! Non-Linux stubs. Lets cargo build succeed; actual verification is
+//! Linux-only because Valgrind doesn't run elsewhere.
+
+pub fn is_under_valgrind() -> bool {
+    false
+}
+
+pub fn count_errors() -> usize {
+    0
+}
+
+pub fn mark_undefined(_addr: *const u8, _len: usize) {}
+
+pub fn mark_defined(_addr: *const u8, _len: usize) {}

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -13,6 +13,13 @@ description = "Inspection fixtures for the fixed-bigint CT-verify harness."
 # Rust dependency.
 crate-type = ["staticlib", "rlib"]
 
+[features]
+default = ["panic-handler"]
+# Define a `#[panic_handler]` in this crate. Required for no_std staticlib
+# builds (every asm-grep target). Disabled by host-side consumers (ct-ctgrind)
+# that link ct-fixtures as rlib alongside std, which supplies its own.
+panic-handler = []
+
 [dependencies]
 fixed-bigint = { path = "../.." }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -16,11 +16,11 @@
 //! the gate; they use the `nct_fix__neg__*` prefix so the driver can
 //! distinguish them and assert each one produces ≥ 1 violation.
 
-#![no_std]
+// `no_std` is gated on the `panic-handler` feature so host-side consumers
+// (ct-ctgrind) can link this crate as an rlib alongside std, which supplies
+// the panic handler and eh personality that bare-metal builds lack.
+#![cfg_attr(feature = "panic-handler", no_std)]
 #![allow(non_snake_case)]
-// Tier-2 / no_std targets ship without panic-strategy unwind libs; we
-// hardcode `panic = "abort"` in the release profile, so the lang-item is
-// satisfied at codegen time. The `#[panic_handler]` below covers debug.
 #![cfg_attr(not(test), allow(unused_imports))]
 
 mod fixtures_cat_a;
@@ -28,6 +28,17 @@ mod fixtures_cat_b;
 mod fixtures_cat_c;
 mod fixtures_neg;
 
+/// No-op Rust-visible anchor. Host-side consumers (ct-ctgrind) call this
+/// once so rustc actually links the rlib at all — without a Rust-side
+/// reference it would be dropped from the link line and the
+/// `#[no_mangle] extern "C"` fixture symbols would resolve as undefined.
+pub fn link_anchor() {}
+
+// Only define a panic_handler under the `panic-handler` feature (default on).
+// When this crate is linked as an rlib into a host binary (ct-ctgrind etc.),
+// std supplies its own and the two would otherwise collide; that consumer
+// disables the default features.
+#[cfg(feature = "panic-handler")]
 #[panic_handler]
 fn panic(_: &core::panic::PanicInfo) -> ! {
     loop {}


### PR DESCRIPTION
Companion to the existing asm-grep harness. Catches secret-derived memory access patterns (data-dependent loads, cache-timing leaks) that asm-grep can't see because they don't compile to branches.

Mirrors the ct-fixtures fixture set under crabgrind+Valgrind taint with a host-only driver that attributes per-fixture violations via the memcheck error counter delta. Adds:

- ct-verify/ct-ctgrind/ workspace member: host-only binary via a Linux-conditional crabgrind dep. Non-Linux hosts get no-op stubs so the workspace still builds; running natively prints a clear "must be run under valgrind" error and exits.
- panic-handler feature gate on ct-fixtures so the same crate can link as rlib into a host std binary. The cross-target asm-grep builds keep the default feature enabled.
- .github/workflows/ct-ctgrind.yml CI job (ubuntu, apt valgrind).
- ct-verify/ct-ctgrind/Dockerfile for local iteration on macOS or Windows hosts where valgrind isn't available natively.

## Summary by Sourcery

Introduce a Valgrind-based constant-time verification harness alongside existing fixtures and integrate it into the workspace and CI.

New Features:
- Add ct-ctgrind binary that runs ct-fixtures under Valgrind taint to detect secret-dependent control flow and memory access.
- Provide fixture macros and Valgrind abstraction layer to register and execute all ct-fixtures under the ct-ctgrind driver.
- Add a Dockerfile for a Linux-based development image to run ct-ctgrind with Valgrind on non-Linux hosts.

Enhancements:
- Make ct-fixtures usable as an rlib in host binaries by gating no_std and the panic handler behind a feature and adding a link anchor function.

Build:
- Register ct-ctgrind as a workspace member and configure its Cargo package and Linux-only crabgrind dependency.

CI:
- Add a GitHub Actions workflow to build ct-ctgrind on Ubuntu and run it under Valgrind as part of CI.

Documentation:
- Document ct-ctgrind usage, scope, and extension points in a new README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Valgrind-based verification runner and a broad suite of constant-time test fixtures for integer operations and predicates.

* **Documentation**
  * Added usage and CI/local run instructions for the Valgrind verification flow and guidance to extend the fixture set.
  * Added a reproducible container image for local verification.

* **Chores**
  * CI workflow to run Valgrind checks on push/PR (x86_64 and aarch64).
  * Workspace expanded and improved non-Linux build compatibility; added a feature to gate no_std/panic-handler behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->