### PR TITLE
Apply black_box to remaining Ct mask-select sites

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -234,13 +234,18 @@ impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize> FixedUInt
         let mut e = exp;
         let mut any_overflow: u8 = 0;
         for _ in 0..u32::BITS {
-            let bit = (e & 1) as u8;
+            // `black_box` opacifies the per-iteration bit so LLVM can't
+            // recognize the XOR-select as a cmov-on-secret-flag — see
+            // `const_ct_select` for the load-bearing explanation.
+            let bit = core::hint::black_box((e & 1) as u8);
             let (candidate, mul_ov) = OverflowingMul::overflowing_mul(&result, &base);
             // Multiply overflow matters iff bit_k is set.
             any_overflow |= (mul_ov as u8) & bit;
             // Per-limb CT-select of result vs candidate.
             let bit_t = <T as core::convert::From<u8>>::from(bit);
-            let mask = bit_t * <T as crate::const_numtraits::ConstBounded>::max_value();
+            let mask = core::hint::black_box(
+                bit_t * <T as crate::const_numtraits::ConstBounded>::max_value(),
+            );
             for i in 0..N {
                 let diff = result.array[i] ^ candidate.array[i];
                 result.array[i] ^= mask & diff;
@@ -248,7 +253,7 @@ impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize> FixedUInt
             e >>= 1;
             let (new_base, base_ov) = OverflowingMul::overflowing_mul(&base, &base);
             // Square overflow matters iff there are remaining set bits in e.
-            let any_remaining: u8 = (e != 0) as u8;
+            let any_remaining: u8 = core::hint::black_box((e != 0) as u8);
             any_overflow |= (base_ov as u8) & any_remaining;
             base = new_base;
         }
@@ -984,10 +989,13 @@ c0nst::c0nst! {
             let v = array[index];
             let v_lz = <T as ConstBitPrimInt>::leading_zeros(v);
             // Add this limb's lz contribution iff we haven't decided yet.
-            total += (!decided) & v_lz;
+            // `black_box` defeats the LLVM XOR/AND-select → cmov rewrite —
+            // see `const_ct_select` for the load-bearing explanation.
+            let undecided = core::hint::black_box(!decided);
+            total += undecided & v_lz;
             // Lock the decision the moment we see a non-zero limb.
             let v_nz_bit = (!<T as ConstZero>::is_zero(&v)) as u32;
-            let v_nz_mask = v_nz_bit.wrapping_neg();
+            let v_nz_mask = core::hint::black_box(v_nz_bit.wrapping_neg());
             decided |= v_nz_mask;
         }
         total
@@ -1024,9 +1032,12 @@ c0nst::c0nst! {
         while index < N {
             let v = array[index];
             let v_tz = <T as ConstBitPrimInt>::trailing_zeros(v);
-            total += (!decided) & v_tz;
+            // See `const_leading_zeros_ct` / `const_ct_select` for why
+            // `black_box` is here.
+            let undecided = core::hint::black_box(!decided);
+            total += undecided & v_tz;
             let v_nz_bit = (!<T as ConstZero>::is_zero(&v)) as u32;
-            let v_nz_mask = v_nz_bit.wrapping_neg();
+            let v_nz_mask = core::hint::black_box(v_nz_bit.wrapping_neg());
             decided |= v_nz_mask;
             index += 1;
         }
@@ -1166,10 +1177,11 @@ c0nst::c0nst! {
             let lt = (a[index] < b[index]) as u8;
             // here ∈ {0, 1, 2}: 2 for Greater, 1 for Less, 0 for Equal.
             let here = (gt << 1) | lt;
-            let undecided_mask = !decided;
+            // See `const_ct_select` for why `black_box` is here.
+            let undecided_mask = core::hint::black_box(!decided);
             result |= undecided_mask & here;
             // Lock the decision the moment a non-zero `here` is observed.
-            let here_nz_mask = ((here != 0) as u8).wrapping_neg();
+            let here_nz_mask = core::hint::black_box(((here != 0) as u8).wrapping_neg());
             decided |= here_nz_mask;
         }
         match result {


### PR DESCRIPTION
Same fix mechanism as PR #118 (`black_box` opacification to defeat the LLVM XOR/AND-select → cmov rewrite), applied to four more sites that have the same pattern:

- `const_leading_zeros_ct` — `total += (!decided) & v_lz` plus the `wrapping_neg`-derived decided flag.
- `const_trailing_zeros_ct` — mirror.
- `const_cmp_ct` — `result |= (!decided) & here` plus here-non-zero. Used by ct_gt/ct_lt/Ord::cmp under the Ct personality.
- `ct_checked_pow` inner loop — per-iteration bit-select for the square-and-multiply ladder.

These are defensive fixes for the XOR/AND-select pattern. They prevent latent bugs at sites no fixture currently exposes — most won't trip ctgrind today because the fixtures taint both operands symmetrically, and the rewrite to a secret-flag cmov only fires when one operand is non-tainted.

Of note: this PR is *necessary but not sufficient* to clear the ct-ctgrind x86_64 failures on `leading_zeros` / `trailing_zeros`. The remaining violations are upstream — Rust's `u32::leading_zeros()` on baseline x86_64 (no `lzcnt`) lowers to `test/je/bsr`, with the `je` handling `bsr`-undefined-on-zero. That's a real conditional jump on a tainted flag inside the std intrinsic, not in our code. Will be addressed by setting `-C target-cpu=x86-64-v2` on the ct-ctgrind workflow's x86_64 row in a follow-up.

## Summary by Sourcery

Harden constant-time arithmetic and comparison routines against LLVM’s XOR/AND-select to cmov rewrite by opacifying key selection bits and masks with black_box.

Bug Fixes:
- Ensure ct_checked_pow’s inner loop remains constant-time by opacifying the per-iteration selection bit, limb mask, and remaining-bits flag with black_box.
- Preserve constant-time behavior in const_leading_zeros_ct and const_trailing_zeros_ct by masking undecided flags and non-zero masks through black_box.
- Maintain constant-time semantics in const_cmp_ct by opacifying the undecided mask and here-non-zero mask used in the comparison ladder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal robustness improvements to constant-time mathematical operation implementations to maintain consistent behavior across compiler variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->