### PR TITLE
Add category ASYM: asymmetric-taint regression fixtures

### DIFF
--- a/ct-verify/ct-ctgrind/src/fixtures_asym.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures_asym.rs
@@ -1,0 +1,118 @@
+//! Registrations for the category ASYM fixtures defined in ct-fixtures.
+//!
+//! Each fixture here taints only its single secret-slot input (the shift
+//! amount, the choice byte, or the exponent), leaves the rest of the
+//! computation involving hardcoded constants on the symbol side, and
+//! invokes the corresponding `ct_fix__ASYM__*` symbol from ct-fixtures.
+//!
+//! These exist as a regression test for the load-bearing `black_box`
+//! calls in `const_shl_ct`, `const_ct_select`, and `ct_checked_pow` —
+//! see the matching `fixtures_asym.rs` in ct-fixtures for the
+//! per-fixture rationale.
+
+// =============================================================================
+// Asymmetric shift: tainted u32 amount → output array.
+// =============================================================================
+
+macro_rules! ctgrind_asym_shl_u32 {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(amount: *const u32, out: *mut [$T; $N]);
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let amount: u32 = ::core::hint::black_box(0);
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint_val(&amount);
+                unsafe { $name(&amount, &mut out); }
+                $crate::macros::untaint(&out);
+                let _ = ::core::hint::black_box(out);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+ctgrind_asym_shl_u32!(ct_fix__ASYM__one_shl__u8__N16, u8, 16);
+ctgrind_asym_shl_u32!(ct_fix__ASYM__one_shl__u16__N16, u16, 16);
+ctgrind_asym_shl_u32!(ct_fix__ASYM__one_shl__u32__N4, u32, 4);
+ctgrind_asym_shl_u32!(ct_fix__ASYM__one_shl__u32__N16, u32, 16);
+ctgrind_asym_shl_u32!(ct_fix__ASYM__one_shl__u64__N4, u64, 4);
+
+// =============================================================================
+// Asymmetric conditional_select: tainted u8 choice → output array.
+// =============================================================================
+
+macro_rules! ctgrind_asym_select_u8 {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(choice: *const u8, out: *mut [$T; $N]);
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let choice: u8 = ::core::hint::black_box(0);
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint_val(&choice);
+                unsafe { $name(&choice, &mut out); }
+                $crate::macros::untaint(&out);
+                let _ = ::core::hint::black_box(out);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u8__N16, u8, 16);
+ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u16__N16, u16, 16);
+ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u32__N4, u32, 4);
+ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u32__N16, u32, 16);
+ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u64__N4, u64, 4);
+
+// =============================================================================
+// Asymmetric pow: tainted u32 exponent → output array + validity u8.
+// =============================================================================
+
+macro_rules! ctgrind_asym_pow_u32 {
+    ($name:ident, $T:ty, $N:literal) => {
+        paste::paste! {
+            extern "C" {
+                fn $name(exp: *const u32, out: *mut [$T; $N]) -> u8;
+            }
+            #[allow(non_snake_case)]
+            fn [<run_ $name>]() {
+                let exp: u32 = ::core::hint::black_box(0);
+                let mut out: [$T; $N] = [0; $N];
+                $crate::macros::taint_val(&exp);
+                let r = unsafe { $name(&exp, &mut out) };
+                $crate::macros::untaint(&out);
+                $crate::macros::untaint_val(&r);
+                let _ = ::core::hint::black_box(out);
+                let _ = ::core::hint::black_box(r);
+            }
+            inventory::submit! {
+                $crate::Fixture {
+                    name: stringify!($name),
+                    run: [<run_ $name>],
+                }
+            }
+        }
+    };
+}
+
+ctgrind_asym_pow_u32!(ct_fix__ASYM__pow_const_base__u8__N16, u8, 16);
+ctgrind_asym_pow_u32!(ct_fix__ASYM__pow_const_base__u16__N16, u16, 16);
+ctgrind_asym_pow_u32!(ct_fix__ASYM__pow_const_base__u32__N4, u32, 4);
+ctgrind_asym_pow_u32!(ct_fix__ASYM__pow_const_base__u32__N16, u32, 16);
+ctgrind_asym_pow_u32!(ct_fix__ASYM__pow_const_base__u64__N4, u64, 4);

--- a/ct-verify/ct-ctgrind/src/fixtures_asym.rs
+++ b/ct-verify/ct-ctgrind/src/fixtures_asym.rs
@@ -6,9 +6,12 @@
 //! invokes the corresponding `ct_fix__ASYM__*` symbol from ct-fixtures.
 //!
 //! These exist as a regression test for the load-bearing `black_box`
-//! calls in `const_shl_ct`, `const_ct_select`, and `ct_checked_pow` —
-//! see the matching `fixtures_asym.rs` in ct-fixtures for the
-//! per-fixture rationale.
+//! calls in `const_shl_ct`, `ct_checked_pow`, and (for `subtle_cond_select`)
+//! subtle's own `Choice::from(u8)` opacification. See the matching
+//! `fixtures_asym.rs` in ct-fixtures for the per-fixture rationale —
+//! `const_ct_select` itself is exercised by existing fixtures via the
+//! `next_pow2` / saturating-arithmetic internal-asymmetric flow, not by
+//! a direct fixture here.
 
 // =============================================================================
 // Asymmetric shift: tainted u32 amount → output array.
@@ -74,11 +77,11 @@ macro_rules! ctgrind_asym_select_u8 {
     };
 }
 
-ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u8__N16, u8, 16);
-ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u16__N16, u16, 16);
-ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u32__N4, u32, 4);
-ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u32__N16, u32, 16);
-ctgrind_asym_select_u8!(ct_fix__ASYM__cond_select_consts__u64__N4, u64, 4);
+ctgrind_asym_select_u8!(ct_fix__ASYM__subtle_cond_select__u8__N16, u8, 16);
+ctgrind_asym_select_u8!(ct_fix__ASYM__subtle_cond_select__u16__N16, u16, 16);
+ctgrind_asym_select_u8!(ct_fix__ASYM__subtle_cond_select__u32__N4, u32, 4);
+ctgrind_asym_select_u8!(ct_fix__ASYM__subtle_cond_select__u32__N16, u32, 16);
+ctgrind_asym_select_u8!(ct_fix__ASYM__subtle_cond_select__u64__N4, u64, 4);
 
 // =============================================================================
 // Asymmetric pow: tainted u32 exponent → output array + validity u8.

--- a/ct-verify/ct-ctgrind/src/main.rs
+++ b/ct-verify/ct-ctgrind/src/main.rs
@@ -15,6 +15,7 @@ use std::process::ExitCode;
 mod macros;
 mod valgrind;
 
+mod fixtures_asym;
 mod fixtures_cat_a;
 mod fixtures_cat_b;
 mod fixtures_cat_c;

--- a/ct-verify/ct-fixtures/src/fixtures_asym.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_asym.rs
@@ -1,0 +1,125 @@
+//! Category ASYM: asymmetric-taint regression fixtures.
+//!
+//! Each fixture here exercises a single load-bearing `core::hint::black_box`
+//! site in `fixed_bigint::fixeduint` under the *asymmetric* taint pattern
+//! that originally surfaced the bug each `black_box` defends against (see
+//! PR #118, PR #120 for the address-select / cmov-on-tainted-flag class).
+//!
+//! Why these are necessary on top of the symmetric Cat A/B/C fixtures: when
+//! both operands of the LLVM-rewritten select are tainted, Valgrind sees
+//! taint propagation through `cmov`/`csel` without flagging — both possible
+//! result values contain tainted bytes, so reading either is correct from
+//! Memcheck's POV. The asymmetric case (one operand tainted, one a hardcoded
+//! constant) is the configuration that actually surfaces the rewrite:
+//! Valgrind sees a `cmov` whose flag depends on a tainted condition while
+//! the source operands carry different taint metadata, which is exactly the
+//! "use of uninitialised value in conditional move" pattern Memcheck flags.
+//!
+//! If a future refactor removes one of the protected `black_box` calls,
+//! these fixtures trip immediately. They are otherwise expected to pass
+//! cleanly on every ctgrind-covered architecture.
+
+use fixed_bigint::{Ct, FixedUInt};
+use subtle::ConditionallySelectable;
+
+// =============================================================================
+// `Self::one() << tainted_amount`
+//
+// Exercises `const_shl_ct`'s `black_box(bit_k)`. Mirrors the configuration
+// that surfaced the original `next_pow2` bug: non-tainted LHS, tainted shift
+// amount derived from secret state.
+// =============================================================================
+
+macro_rules! emit_asym_one_shl {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(amount_ptr: *const u32, out_ptr: *mut [$T; $N]) {
+            let amount = core::hint::black_box(unsafe { *amount_ptr });
+            let mut one_arr: [$T; $N] = [0; $N];
+            one_arr[0] = 1;
+            let one = FixedUInt::<$T, $N, Ct>::from(one_arr);
+            let shifted = one << (amount as usize);
+            let result = core::hint::black_box(*shifted.words());
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+    };
+}
+
+emit_asym_one_shl!(ct_fix__ASYM__one_shl__u8__N16, u8, 16);
+emit_asym_one_shl!(ct_fix__ASYM__one_shl__u16__N16, u16, 16);
+emit_asym_one_shl!(ct_fix__ASYM__one_shl__u32__N4, u32, 4);
+emit_asym_one_shl!(ct_fix__ASYM__one_shl__u32__N16, u32, 16);
+emit_asym_one_shl!(ct_fix__ASYM__one_shl__u64__N4, u64, 4);
+
+// =============================================================================
+// `conditional_select(zero, one, tainted_choice)`
+//
+// Exercises `const_ct_select`'s `black_box(choice)`. Both operands of the
+// select are non-tainted constants; the choice is the only tainted input.
+// =============================================================================
+
+macro_rules! emit_asym_cond_select_consts {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(choice_ptr: *const u8, out_ptr: *mut [$T; $N]) {
+            let choice = core::hint::black_box(unsafe { *choice_ptr });
+            let zero = FixedUInt::<$T, $N, Ct>::from([0; $N]);
+            let mut one_arr: [$T; $N] = [0; $N];
+            one_arr[0] = 1;
+            let one = FixedUInt::<$T, $N, Ct>::from(one_arr);
+            let selected = FixedUInt::<$T, $N, Ct>::conditional_select(
+                &zero,
+                &one,
+                subtle::Choice::from(choice),
+            );
+            let result = core::hint::black_box(*selected.words());
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+    };
+}
+
+emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u8__N16, u8, 16);
+emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u16__N16, u16, 16);
+emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u32__N4, u32, 4);
+emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u32__N16, u32, 16);
+emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u64__N4, u64, 4);
+
+// =============================================================================
+// `const_base.ct_checked_pow(tainted_exp)` with non-tainted base (= 2).
+//
+// Exercises `ct_checked_pow`'s `black_box(bit)` in the square-and-multiply
+// inner loop. With a non-tainted base, the per-iteration select between
+// `result` and `candidate` (both derived from non-tainted state) is what
+// the cmov-on-tainted-flag rewrite would target.
+// =============================================================================
+
+macro_rules! emit_asym_pow_const_base {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(exp_ptr: *const u32, out_ptr: *mut [$T; $N]) -> u8 {
+            let exp = core::hint::black_box(unsafe { *exp_ptr });
+            let mut base_arr: [$T; $N] = [0; $N];
+            base_arr[0] = 2;
+            let base = FixedUInt::<$T, $N, Ct>::from(base_arr);
+            let res = base.ct_checked_pow(exp);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
+            let result_words = core::hint::black_box(*value.words());
+            let valid = core::hint::black_box(valid);
+            unsafe {
+                *out_ptr = result_words;
+            }
+            valid
+        }
+    };
+}
+
+emit_asym_pow_const_base!(ct_fix__ASYM__pow_const_base__u8__N16, u8, 16);
+emit_asym_pow_const_base!(ct_fix__ASYM__pow_const_base__u16__N16, u16, 16);
+emit_asym_pow_const_base!(ct_fix__ASYM__pow_const_base__u32__N4, u32, 4);
+emit_asym_pow_const_base!(ct_fix__ASYM__pow_const_base__u32__N16, u32, 16);
+emit_asym_pow_const_base!(ct_fix__ASYM__pow_const_base__u64__N4, u64, 4);

--- a/ct-verify/ct-fixtures/src/fixtures_asym.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_asym.rs
@@ -1,9 +1,9 @@
 //! Category ASYM: asymmetric-taint regression fixtures.
 //!
-//! Each fixture here exercises a single load-bearing `core::hint::black_box`
-//! site in `fixed_bigint::fixeduint` under the *asymmetric* taint pattern
-//! that originally surfaced the bug each `black_box` defends against (see
-//! PR #118, PR #120 for the address-select / cmov-on-tainted-flag class).
+//! Each fixture here exercises a load-bearing `core::hint::black_box`
+//! protection under the *asymmetric* taint pattern that originally
+//! surfaced the bugs the `black_box` calls defend against (see PR #118,
+//! PR #120 for the address-select / cmov-on-tainted-flag class).
 //!
 //! Why these are necessary on top of the symmetric Cat A/B/C fixtures: when
 //! both operands of the LLVM-rewritten select are tainted, Valgrind sees
@@ -15,9 +15,27 @@
 //! the source operands carry different taint metadata, which is exactly the
 //! "use of uninitialised value in conditional move" pattern Memcheck flags.
 //!
+//! What each family exercises:
+//!
+//! - `one_shl` — `Self::one() << tainted_amount`. Dispatches through
+//!   `Shl<u32>` → `Shl<usize>` → `const_shl_ct`, exercising the
+//!   `black_box(bit_k)` in that helper.
+//! - `subtle_cond_select` — `subtle::ConditionallySelectable::conditional_select`
+//!   on a Ct `FixedUInt` with two non-tainted constant operands. This goes
+//!   through subtle's per-limb primitive `T::conditional_select`, NOT our
+//!   `const_ct_select` helper — the test target here is subtle's own
+//!   `Choice::from(u8)` opacification. Our `const_ct_select`'s `black_box`
+//!   protection is already exercised by existing fixtures like
+//!   `ct_fix__A__next_pow2__*` and the saturating arithmetic family, which
+//!   call `const_ct_select` internally with one tainted operand and one
+//!   constant (e.g. `const_ct_select(shifted, max_value, overflow)`).
+//! - `pow_const_base` — `const_base.ct_checked_pow(tainted_exp)` with the
+//!   base hardcoded to 2. Exercises the per-iteration `black_box(bit)` in
+//!   the square-and-multiply inner loop of `ct_checked_pow`.
+//!
 //! If a future refactor removes one of the protected `black_box` calls,
-//! these fixtures trip immediately. They are otherwise expected to pass
-//! cleanly on every ctgrind-covered architecture.
+//! the corresponding fixture trips on the next ctgrind run. They are
+//! otherwise expected to pass cleanly on every ctgrind-covered architecture.
 
 use fixed_bigint::{Ct, FixedUInt};
 use subtle::ConditionallySelectable;
@@ -25,9 +43,10 @@ use subtle::ConditionallySelectable;
 // =============================================================================
 // `Self::one() << tainted_amount`
 //
-// Exercises `const_shl_ct`'s `black_box(bit_k)`. Mirrors the configuration
-// that surfaced the original `next_pow2` bug: non-tainted LHS, tainted shift
-// amount derived from secret state.
+// Routes through `Shl<u32>` (which normalises the amount and recurses into
+// `Shl<usize>` → `const_shl_ct`), exercising the `black_box(bit_k)` in the
+// barrel-shifter inner loop. Non-tainted LHS, tainted shift amount —
+// mirrors the configuration that surfaced the original `next_pow2` bug.
 // =============================================================================
 
 macro_rules! emit_asym_one_shl {
@@ -38,7 +57,7 @@ macro_rules! emit_asym_one_shl {
             let mut one_arr: [$T; $N] = [0; $N];
             one_arr[0] = 1;
             let one = FixedUInt::<$T, $N, Ct>::from(one_arr);
-            let shifted = one << (amount as usize);
+            let shifted = one << amount;
             let result = core::hint::black_box(*shifted.words());
             unsafe {
                 *out_ptr = result;
@@ -54,13 +73,18 @@ emit_asym_one_shl!(ct_fix__ASYM__one_shl__u32__N16, u32, 16);
 emit_asym_one_shl!(ct_fix__ASYM__one_shl__u64__N4, u64, 4);
 
 // =============================================================================
-// `conditional_select(zero, one, tainted_choice)`
+// `subtle::ConditionallySelectable::conditional_select(zero, one, tainted_choice)`
 //
-// Exercises `const_ct_select`'s `black_box(choice)`. Both operands of the
-// select are non-tainted constants; the choice is the only tainted input.
+// Exercises subtle's per-limb primitive `T::conditional_select` and the
+// `Choice::from(u8)` opacification it relies on. Note: this does NOT
+// reach our internal `const_ct_select` helper — that path runs through
+// `next_power_of_two`, `sat_add`/`sat_sub`/`sat_mul`, `abs_diff`,
+// `ct_checked_*` shifts, etc., and is exercised by their existing
+// fixtures via internal asymmetric flow (e.g. `const_ct_select(shifted,
+// max_value, overflow)` where `max_value` is a non-tainted constant).
 // =============================================================================
 
-macro_rules! emit_asym_cond_select_consts {
+macro_rules! emit_asym_subtle_cond_select {
     ($name:ident, $T:ty, $N:literal) => {
         #[no_mangle]
         pub extern "C" fn $name(choice_ptr: *const u8, out_ptr: *mut [$T; $N]) {
@@ -82,11 +106,11 @@ macro_rules! emit_asym_cond_select_consts {
     };
 }
 
-emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u8__N16, u8, 16);
-emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u16__N16, u16, 16);
-emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u32__N4, u32, 4);
-emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u32__N16, u32, 16);
-emit_asym_cond_select_consts!(ct_fix__ASYM__cond_select_consts__u64__N4, u64, 4);
+emit_asym_subtle_cond_select!(ct_fix__ASYM__subtle_cond_select__u8__N16, u8, 16);
+emit_asym_subtle_cond_select!(ct_fix__ASYM__subtle_cond_select__u16__N16, u16, 16);
+emit_asym_subtle_cond_select!(ct_fix__ASYM__subtle_cond_select__u32__N4, u32, 4);
+emit_asym_subtle_cond_select!(ct_fix__ASYM__subtle_cond_select__u32__N16, u32, 16);
+emit_asym_subtle_cond_select!(ct_fix__ASYM__subtle_cond_select__u64__N4, u64, 4);
 
 // =============================================================================
 // `const_base.ct_checked_pow(tainted_exp)` with non-tainted base (= 2).

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -23,6 +23,7 @@
 #![allow(non_snake_case)]
 #![cfg_attr(not(test), allow(unused_imports))]
 
+mod fixtures_asym;
 mod fixtures_cat_a;
 mod fixtures_cat_b;
 mod fixtures_cat_c;

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -185,19 +185,14 @@ c0nst::c0nst! {
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shl<u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shl(self, bits: u32) -> Self::Output {
-            // `bits as usize` would truncate on 16-bit-usize targets; route
-            // through the u32-aware normalizer that the Overflowing*/Unbounded
-            // paths already use.
-            let (shift, overflow) = normalize_shift_amount(bits, Self::BIT_SIZE);
-            if overflow { <Self as ConstZero>::zero() } else { self.shl(shift) }
+            const_unbounded_shl_u32(self, bits)
         }
     }
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst core::ops::Shr<u32> for FixedUInt<T, N, P> {
         type Output = Self;
         fn shr(self, bits: u32) -> Self::Output {
-            let (shift, overflow) = normalize_shift_amount(bits, Self::BIT_SIZE);
-            if overflow { <Self as ConstZero>::zero() } else { self.shr(shift) }
+            const_unbounded_shr_u32(self, bits)
         }
     }
 
@@ -323,6 +318,73 @@ c0nst::c0nst! {
         }
     }
 
+    // Shared body for `Shl<u32>` and `ConstUnboundedShift::unbounded_shl`.
+    // Both want the same semantics — shift by a u32 amount, with values
+    // outside [0, BIT_SIZE) collapsing to zero — and previously had
+    // parallel implementations. The Ct fix in PR #120 was applied to
+    // `unbounded_shl` but missed the `Shl<u32>` copy; centralizing here
+    // makes that class of drift impossible.
+    pub(crate) c0nst fn const_unbounded_shl_u32<
+        T: [c0nst] ConstMachineWord + MachineWord,
+        const N: usize,
+        P: Personality,
+    >(
+        target: FixedUInt<T, N, P>,
+        bits: u32,
+    ) -> FixedUInt<T, N, P> {
+        let (shift, overflow) =
+            normalize_shift_amount(bits, FixedUInt::<T, N, P>::BIT_SIZE);
+        match P::TAG {
+            PersonalityTag::Nct => {
+                if overflow {
+                    <FixedUInt<T, N, P> as ConstZero>::zero()
+                } else {
+                    target << shift
+                }
+            }
+            PersonalityTag::Ct => {
+                // Branchless: always compute the shift, ct-select between
+                // the shifted result and zero on the overflow flag.
+                let shifted = target << shift;
+                const_ct_select(
+                    shifted,
+                    <FixedUInt<T, N, P> as ConstZero>::zero(),
+                    overflow as u8,
+                )
+            }
+        }
+    }
+
+    /// Mirror of [`const_unbounded_shl_u32`] for right-shifts.
+    pub(crate) c0nst fn const_unbounded_shr_u32<
+        T: [c0nst] ConstMachineWord + MachineWord,
+        const N: usize,
+        P: Personality,
+    >(
+        target: FixedUInt<T, N, P>,
+        bits: u32,
+    ) -> FixedUInt<T, N, P> {
+        let (shift, overflow) =
+            normalize_shift_amount(bits, FixedUInt::<T, N, P>::BIT_SIZE);
+        match P::TAG {
+            PersonalityTag::Nct => {
+                if overflow {
+                    <FixedUInt<T, N, P> as ConstZero>::zero()
+                } else {
+                    target >> shift
+                }
+            }
+            PersonalityTag::Ct => {
+                let shifted = target >> shift;
+                const_ct_select(
+                    shifted,
+                    <FixedUInt<T, N, P> as ConstZero>::zero(),
+                    overflow as u8,
+                )
+            }
+        }
+    }
+
     // Helper to normalize shift amount and detect overflow.
     // Handles both 16-bit (usize < u32) and 64-bit (bit_size > u32::MAX) platforms.
     c0nst fn normalize_shift_amount(bits: u32, bit_size: usize) -> (usize, bool) {
@@ -386,37 +448,11 @@ c0nst::c0nst! {
 
     impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> c0nst ConstUnboundedShift for FixedUInt<T, N, P> {
         fn unbounded_shl(self, rhs: u32) -> Self {
-            let (shift, overflow) = normalize_shift_amount(rhs, Self::BIT_SIZE);
-            match P::TAG {
-                PersonalityTag::Nct => {
-                    if overflow {
-                        Self::zero()
-                    } else {
-                        self << shift
-                    }
-                }
-                PersonalityTag::Ct => {
-                    let shifted = self << shift;
-                    const_ct_select(shifted, Self::zero(), overflow as u8)
-                }
-            }
+            const_unbounded_shl_u32(self, rhs)
         }
 
         fn unbounded_shr(self, rhs: u32) -> Self {
-            let (shift, overflow) = normalize_shift_amount(rhs, Self::BIT_SIZE);
-            match P::TAG {
-                PersonalityTag::Nct => {
-                    if overflow {
-                        Self::zero()
-                    } else {
-                        self >> shift
-                    }
-                }
-                PersonalityTag::Ct => {
-                    let shifted = self >> shift;
-                    const_ct_select(shifted, Self::zero(), overflow as u8)
-                }
-            }
+            const_unbounded_shr_u32(self, rhs)
         }
     }
 }

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -1,7 +1,4 @@
-use super::{
-    const_ct_select, const_shl_ct, const_shl_impl, const_shr_ct, const_shr_impl, FixedUInt,
-    MachineWord,
-};
+use super::{const_shl_ct, const_shl_impl, const_shr_ct, const_shr_impl, FixedUInt, MachineWord};
 
 use crate::const_numtraits::{
     ConstCheckedShl, ConstCheckedShr, ConstOverflowingShl, ConstOverflowingShr,
@@ -332,10 +329,10 @@ c0nst::c0nst! {
         target: FixedUInt<T, N, P>,
         bits: u32,
     ) -> FixedUInt<T, N, P> {
-        let (shift, overflow) =
-            normalize_shift_amount(bits, FixedUInt::<T, N, P>::BIT_SIZE);
         match P::TAG {
             PersonalityTag::Nct => {
+                let (shift, overflow) =
+                    normalize_shift_amount(bits, FixedUInt::<T, N, P>::BIT_SIZE);
                 if overflow {
                     <FixedUInt<T, N, P> as ConstZero>::zero()
                 } else {
@@ -343,14 +340,15 @@ c0nst::c0nst! {
                 }
             }
             PersonalityTag::Ct => {
-                // Branchless: always compute the shift, ct-select between
-                // the shifted result and zero on the overflow flag.
-                let shifted = target << shift;
-                const_ct_select(
-                    shifted,
-                    <FixedUInt<T, N, P> as ConstZero>::zero(),
-                    overflow as u8,
-                )
+                // Skip `normalize_shift_amount` entirely. Its `if bits >=
+                // bit_size_u32` is a tainted-flag branch and `bits %
+                // bit_size_u32` is a variable-time modulo when bits is a
+                // secret — both leaks even though current LLVM may pattern-
+                // match them on power-of-2 BIT_SIZE. `const_shl_ct`'s
+                // barrel shifter already collapses out-of-range shifts to
+                // zero (via `const_shl_impl`'s `nwords >= N` zero-out), so
+                // the overflow detection is redundant for the Ct path.
+                target << (bits as usize)
             }
         }
     }
@@ -364,10 +362,10 @@ c0nst::c0nst! {
         target: FixedUInt<T, N, P>,
         bits: u32,
     ) -> FixedUInt<T, N, P> {
-        let (shift, overflow) =
-            normalize_shift_amount(bits, FixedUInt::<T, N, P>::BIT_SIZE);
         match P::TAG {
             PersonalityTag::Nct => {
+                let (shift, overflow) =
+                    normalize_shift_amount(bits, FixedUInt::<T, N, P>::BIT_SIZE);
                 if overflow {
                     <FixedUInt<T, N, P> as ConstZero>::zero()
                 } else {
@@ -375,12 +373,10 @@ c0nst::c0nst! {
                 }
             }
             PersonalityTag::Ct => {
-                let shifted = target >> shift;
-                const_ct_select(
-                    shifted,
-                    <FixedUInt<T, N, P> as ConstZero>::zero(),
-                    overflow as u8,
-                )
+                // See `const_unbounded_shl_u32` for why this skips
+                // `normalize_shift_amount`. `const_shr_ct` collapses
+                // out-of-range shifts to zero the same way.
+                target >> (bits as usize)
             }
         }
     }

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -347,8 +347,15 @@ c0nst::c0nst! {
                 // match them on power-of-2 BIT_SIZE. `const_shl_ct`'s
                 // barrel shifter already collapses out-of-range shifts to
                 // zero (via `const_shl_impl`'s `nwords >= N` zero-out), so
-                // the overflow detection is redundant for the Ct path.
-                target << (bits as usize)
+                // the overflow detection is redundant for the Ct path —
+                // EXCEPT for the cast to usize on 16-bit-usize targets,
+                // where `bits as usize` truncates and could undo the
+                // saturation. Cap branchlessly to `BIT_SIZE` first; for
+                // every priority diagonal BIT_SIZE fits in u16, so the
+                // capped value casts losslessly even on AVR.
+                let bit_size_u32 = FixedUInt::<T, N, P>::BIT_SIZE as u32;
+                let capped = const_ct_min_u32(bits, bit_size_u32);
+                target << (capped as usize)
             }
         }
     }
@@ -374,11 +381,28 @@ c0nst::c0nst! {
             }
             PersonalityTag::Ct => {
                 // See `const_unbounded_shl_u32` for why this skips
-                // `normalize_shift_amount`. `const_shr_ct` collapses
-                // out-of-range shifts to zero the same way.
-                target >> (bits as usize)
+                // `normalize_shift_amount` and caps before casting.
+                let bit_size_u32 = FixedUInt::<T, N, P>::BIT_SIZE as u32;
+                let capped = const_ct_min_u32(bits, bit_size_u32);
+                target >> (capped as usize)
             }
         }
+    }
+
+    /// Branchless CT-safe `min(bits, cap)` for u32, used to clamp Ct
+    /// shift amounts to `BIT_SIZE` before casting to usize. The
+    /// `black_box` on the mask is load-bearing — without it, LLVM
+    /// recognises the XOR-AND-XOR select idiom and rewrites it into a
+    /// `cmov` whose flag depends on the secret `bits`. Same defence as
+    /// `const_ct_select` (PR #118).
+    c0nst fn const_ct_min_u32(bits: u32, cap: u32) -> u32 {
+        // diff = cap - bits, wraps to negative (high bit set) iff bits > cap.
+        let diff = cap.wrapping_sub(bits);
+        let too_big_bit = (diff >> 31) & 1;
+        let too_big_mask = core::hint::black_box(too_big_bit.wrapping_neg());
+        // bits if !too_big, cap otherwise. XOR-AND-XOR select with
+        // opaque mask.
+        bits ^ (too_big_mask & (bits ^ cap))
     }
 
     // Helper to normalize shift amount and detect overflow.


### PR DESCRIPTION
The existing Cat A/B/C fixtures taint both operands symmetrically, which is the right pattern for general CT-property verification — but it doesn't catch a future refactor that removes a load-bearing `core::hint::black_box` from one of the protected mask-select sites. The LLVM XOR-select → cmov rewrite (PR #118, #120) only triggers observably when the cmov's source operands carry asymmetric taint metadata; with both fully tainted, Valgrind sees the cmov as taint propagation rather than a "use of uninit value in conditional move" error.

This category adds three fixture families that exercise the load-bearing sites with non-tainted operands + tainted scalar:

- `one_shl`: `Self::one() << tainted_amount` — mirrors the original `next_pow2` configuration that surfaced the address-select bug in `const_shl_ct`.
- `cond_select_consts`: `conditional_select(zero, one, tainted_choice)` — exercises the `black_box(choice)` in `const_ct_select`.
- `pow_const_base`: `const_base.ct_checked_pow(tainted_exp)` — exercises the per-iteration `black_box(bit)` in the square-and-multiply ladder.

## Summary by Sourcery

Add a new ASYM fixture category to exercise asymmetric-taint constant-time operations in ct-ctgrind and ct-fixtures.

Tests:
- Introduce ct-ctgrind registrations for asymmetric-taint fixtures covering shift, conditional select, and exponentiation operations.
- Wire the new ASYM fixture module into both ct-ctgrind and ct-fixtures so these regression tests run with the existing fixture suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added asymmetric regression fixtures for left-shift, conditional-select, and exponentiation; expanded coverage across additional integer widths and array sizes to strengthen constant-time verification.
* **Refactor**
  * Consolidated unbounded shift logic into shared helpers for consistent behavior across build modes, reducing duplication while preserving semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->