### PR TITLE
Extend asm-grep scope to follow helpers reachable from fixtures

### DIFF
--- a/.github/workflows/ct-verify.yml
+++ b/.github/workflows/ct-verify.yml
@@ -27,9 +27,14 @@ jobs:
           # Priority 5: aarch64
           - triple: aarch64-unknown-linux-gnu
             toolchain: "1.86"
-          # Priority 6: x86_64
+          # Priority 6: x86_64. +lzcnt,+bmi1 mirrors ct-ctgrind.yml:
+          # baseline-x86_64 lowers `u32::leading_zeros()` to
+          # `test/je/bsr` (bsr undefined on zero, hence the `je`), a
+          # real data-dependent branch in the std intrinsic. BMI1 is
+          # on Haswell+ (2013) and every GitHub Actions x86_64 runner.
           - triple: x86_64-unknown-linux-gnu
             toolchain: "1.86"
+            extra_rustflags: "-C target-feature=+lzcnt,+bmi1"
           # Priority 4: AVR (nightly-only, needs build-std + target-cpu).
           # Bare `nightly` because rust-std for avr-none isn't published
           # on every nightly date — a pinned date risks the AVR job
@@ -64,11 +69,18 @@ jobs:
         with:
           key: ct-verify-${{ matrix.triple }}
 
+      - name: Scope per-target RUSTFLAGS to the cross-build
+        # Cargo recognises CARGO_TARGET_<TRIPLE>_RUSTFLAGS (triple
+        # uppercased with `-` → `_`) and applies it only when building
+        # for that target. We compute the var name here so each matrix
+        # row's `extra_rustflags` lands in the right place without
+        # leaking into the host ct-driver compile.
+        if: matrix.extra_rustflags != ''
+        run: |
+          name="CARGO_TARGET_$(echo '${{ matrix.triple }}' | tr 'a-z-' 'A-Z_')_RUSTFLAGS"
+          echo "$name=${{ matrix.extra_rustflags }}" >> "$GITHUB_ENV"
+
       - name: Run ct-driver
-        env:
-          # Scope target-specific rustflags to the cross-target build
-          # only — leaks into the host ct-driver compile otherwise.
-          CARGO_TARGET_AVR_NONE_RUSTFLAGS: ${{ matrix.extra_rustflags }}
         run: cargo run --release -p ct-driver -- --target ${{ matrix.triple }} --json-out target/ct-report/${{ matrix.triple }}.json
 
       - name: Upload report

--- a/ct-verify/ct-driver/src/main.rs
+++ b/ct-verify/ct-driver/src/main.rs
@@ -146,31 +146,48 @@ fn main() -> ExitCode {
     // 4. Parse + scan.
     let blocks = parse::split_blocks(&objdump_text);
     let pat = Patterns::build(spec);
+    // Reachability: fixtures plus every helper transitively reachable
+    // through call edges. Helpers that aren't reached from any fixture
+    // are out of scope (probably dead code in the staticlib).
+    let reachable = parse::compute_reachable_symbols(&blocks, &pat.call);
 
     let mut ct_fixture_count: usize = 0;
     let mut ct_violations: Vec<Violation> = Vec::new();
     let mut neg_tripped: BTreeSet<String> = BTreeSet::new();
     let mut neg_seen: BTreeSet<String> = BTreeSet::new();
+    let mut helper_violations: Vec<Violation> = Vec::new();
+    let mut helpers_scanned: usize = 0;
+    let mut helpers_allowlisted: usize = 0;
 
     for block in &blocks {
-        if !parse::is_in_scope_symbol(&block.symbol) {
-            continue;
-        }
-        let violations = parse::scan_block(block, spec, &pat);
-
+        // Fixtures: scan all (positive + negative). Negative-control
+        // bodies are expected to contain forbidden mnemonics.
         if parse::is_positive_fixture(&block.symbol) {
             ct_fixture_count += 1;
-            ct_violations.extend(violations);
-        } else if parse::is_negative_control(&block.symbol) {
-            // For negative controls, count unique top-level fixture names
-            // (one fixture per "nct_fix__neg__<op>__<T>__N<n>" prefix).
-            // Strip any leading underscore.
+            ct_violations.extend(parse::scan_block(block, spec, &pat));
+            continue;
+        }
+        if parse::is_negative_control(&block.symbol) {
             let canonical = block.symbol.trim_start_matches('_').to_string();
             neg_seen.insert(canonical.clone());
-            if !violations.is_empty() {
+            if !parse::scan_block(block, spec, &pat).is_empty() {
                 neg_tripped.insert(canonical);
             }
+            continue;
         }
+
+        // Helper reached transitively from a Ct fixture. Skip if it
+        // matches the per-target allowlist (public-parameter loop
+        // class).
+        if !reachable.contains(&block.symbol) {
+            continue;
+        }
+        if parse::is_allowed_helper(&block.symbol, &pat.allowed_helpers) {
+            helpers_allowlisted += 1;
+            continue;
+        }
+        helpers_scanned += 1;
+        helper_violations.extend(parse::scan_block(block, spec, &pat));
     }
     let neg_fixture_count = neg_seen.len();
     let neg_failed: Vec<String> = neg_seen.difference(&neg_tripped).cloned().collect();
@@ -180,7 +197,13 @@ fn main() -> ExitCode {
         target: triple.clone(),
         fixtures_checked: ct_fixture_count,
         negative_controls_checked: neg_fixture_count,
+        helpers_scanned,
+        helpers_allowlisted,
         ct_violations: ct_violations.into_iter().map(ViolationOut::from).collect(),
+        helper_violations: helper_violations
+            .into_iter()
+            .map(ViolationOut::from)
+            .collect(),
         negative_controls_failed_to_trip: neg_failed,
     };
     report.print_human();
@@ -334,7 +357,13 @@ fn run_objdump(spec: &TargetSpec, archive: &Path) -> Result<String, String> {
     let mut cmd = Command::new(&tool);
     cmd.arg("--disassemble")
         .arg("--no-show-raw-insn")
-        .arg("--no-leading-addr");
+        .arg("--no-leading-addr")
+        // `-r` interleaves relocation entries with the disassembly. The
+        // reachability walker reads these to resolve `bl` / `call` /
+        // `jal` targets — in a static archive they're unresolved at
+        // disassembly time and otherwise print as self-relative
+        // placeholders like `bl 0x6c70 <self+0x10>`.
+        .arg("--reloc");
     if let Some(arch) = arch_flag {
         cmd.arg(format!("--triple={}", arch));
     }

--- a/ct-verify/ct-driver/src/mnemonics.rs
+++ b/ct-verify/ct-driver/src/mnemonics.rs
@@ -94,3 +94,18 @@ pub const X86_64_FORBIDDEN: &[&str] =
     &[r"^j(e|ne|z|nz|a|ae|b|be|c|nc|g|ge|l|le|o|no|s|ns|p|np|pe|po|cxz|ecxz|rcxz)$"];
 
 pub const X86_64_ALLOWED: &[&str] = &[r"^cmov[a-z]+$", r"^set[a-z]+$", r"^sbb[bwlq]?$"];
+
+// =============================================================================
+// Call instructions (per arch)
+// =============================================================================
+//
+// Used by the reachability walker: from each fixture symbol, scan its
+// disassembly for any of these mnemonics and follow the call target to
+// expand the inspection scope to reachable helpers. The walker doesn't
+// flag these mnemonics — it just uses them as graph edges.
+
+pub const THUMB_CALL: &[&str] = &[r"^blx?$"];
+pub const AARCH64_CALL: &[&str] = &[r"^bl$", r"^blr$"];
+pub const RISCV_CALL: &[&str] = &[r"^jal$", r"^jalr$", r"^c\.jal$", r"^c\.jalr$"];
+pub const AVR_CALL: &[&str] = &[r"^r?call$", r"^icall$", r"^eicall$"];
+pub const X86_64_CALL: &[&str] = &[r"^callq?$"];

--- a/ct-verify/ct-driver/src/parse.rs
+++ b/ct-verify/ct-driver/src/parse.rs
@@ -6,7 +6,7 @@
 //! check + the thumb IT-state machine + the unconditional-branch
 //! direction classifier.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::LazyLock;
 
 use regex::Regex;
@@ -26,6 +26,19 @@ static HEADER_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<([^>]+)>:\s*$
 static INSN_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*(?:([0-9a-fA-F]+):)?\s+(\S+)(?:\s+(.*))?$").unwrap());
 
+// Relocation line emitted by `objdump -r`, interleaved with disassembly.
+// Format varies by file format:
+//   Mach-O: `\t\t<addr>:  ARM64_RELOC_BRANCH26\t<symbol>`
+//   ELF:    `\t\t<addr>: R_AARCH64_CALL26\t<symbol>` (and other R_*)
+// Common shape: indented line, optional `addr:`, a relocation type
+// (token containing `RELOC` or starting with `R_`), then a symbol.
+static RELOC_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^\s+(?:[0-9a-fA-F]+:)?\s*(?:[A-Z][A-Z0-9_]*_RELOC_[A-Z0-9_]+|R_[A-Z0-9_]+)\s+(\S+)\s*$",
+    )
+    .unwrap()
+});
+
 /// One disassembled function block.
 #[derive(Debug)]
 pub struct FunctionBlock {
@@ -39,6 +52,11 @@ pub struct Insn {
     pub offset: u64,
     pub mnemonic: String,
     pub full_line: String,
+    /// When the instruction has a relocation entry resolving its
+    /// operand (a `bl`/`call`/`jal` target, typically), the relocation
+    /// symbol name. `None` for non-call instructions and for indirect
+    /// or fully-resolved operands.
+    pub call_target: Option<String>,
 }
 
 /// Parse the entire objdump output into function blocks.
@@ -75,6 +93,18 @@ pub fn split_blocks(objdump_out: &str) -> Vec<FunctionBlock> {
             continue;
         };
 
+        // Relocation lines look superficially like instruction lines
+        // (they have an `address:` prefix), so match them first and
+        // attach the symbol to the previous instruction.
+        if let Some(caps) = RELOC_RE.captures(line) {
+            if let Some(last) = block.insns.last_mut() {
+                if last.call_target.is_none() {
+                    last.call_target = caps.get(1).map(|m| m.as_str().to_string());
+                }
+            }
+            continue;
+        }
+
         if let Some(caps) = INSN_RE.captures(line) {
             let offset = if let Some(parsed) = caps
                 .get(1)
@@ -102,6 +132,7 @@ pub fn split_blocks(objdump_out: &str) -> Vec<FunctionBlock> {
                 offset,
                 mnemonic,
                 full_line: line.trim_end().to_string(),
+                call_target: None,
             });
         }
     }
@@ -128,6 +159,8 @@ pub struct Violation {
 pub struct Patterns {
     pub forbidden: Vec<Regex>,
     pub allowed: Vec<Regex>,
+    pub call: Vec<Regex>,
+    pub allowed_helpers: Vec<Regex>,
 }
 
 impl Patterns {
@@ -142,6 +175,16 @@ impl Patterns {
                 .allowed_cmov
                 .iter()
                 .map(|p| Regex::new(p).expect("bad allowed regex"))
+                .collect(),
+            call: spec
+                .call_mnemonics
+                .iter()
+                .map(|p| Regex::new(p).expect("bad call regex"))
+                .collect(),
+            allowed_helpers: spec
+                .allowed_helpers
+                .iter()
+                .map(|p| Regex::new(p).expect("bad allowed_helpers regex"))
                 .collect(),
         }
     }
@@ -225,35 +268,77 @@ pub fn scan_block(block: &FunctionBlock, spec: &TargetSpec, pat: &Patterns) -> V
     violations
 }
 
-/// Decide which symbols the driver inspects.
+/// Compute the transitive call-reachability closure starting from each
+/// Ct fixture symbol (`ct_fix__*`). Negative-control fixtures are
+/// deliberately excluded — their bodies invoke Nct helpers that have
+/// branchful behaviour by design, and we don't want those helpers
+/// flagged. The returned set is `{ct_fixtures} ∪ {helpers reached from
+/// any ct_fixture via call edges}`.
 ///
-/// **v1 scope**: only the fixture wrappers themselves
-/// (`ct_fix__*` and `nct_fix__*`). Helper symbols compiled into the
-/// staticlib are NOT inspected here, for two reasons:
-///
-/// 1. **No call-graph reachability**: a helper like
-///    `<FixedUInt as Integer>::gcd` exists in the archive because the
-///    crate compiled it, not because any Ct fixture calls it. We can't
-///    tell, from one symbol's mangled name, whether it's actually on a
-///    Ct call path.
-/// 2. **Public-parameter loop bounds**: helpers like
-///    `<FixedUInt as ConditionallySelectable>::conditional_select`
-///    contain a `for i in 0..N` loop that compiles to
-///    `cmp i, #N; b.lt`. That's a forbidden mnemonic by raw regex but
-///    perfectly CT-safe in context (N is a compile-time constant). A
-///    static-pattern check can't distinguish that from a real
-///    data-dependent branch without taint analysis.
-///
-/// The trade-off: we don't catch branch-injection regressions in a
-/// helper that's never called from a fixture.
-pub fn is_in_scope_symbol(sym: &str) -> bool {
-    if sym.starts_with("ct_fix__") || sym.starts_with("_ct_fix__") {
-        return true;
+/// External targets (symbols not present as `FunctionBlock`s in
+/// `blocks`) and indirect calls (no resolved relocation or `<sym>`
+/// operand) are silently dropped — those are outside our scope.
+pub fn compute_reachable_symbols(
+    blocks: &[FunctionBlock],
+    call_patterns: &[Regex],
+) -> HashSet<String> {
+    let blocks_by_sym: HashMap<&str, &FunctionBlock> =
+        blocks.iter().map(|b| (b.symbol.as_str(), b)).collect();
+
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut queue: VecDeque<String> = blocks
+        .iter()
+        .filter(|b| is_positive_fixture(&b.symbol))
+        .map(|b| b.symbol.clone())
+        .collect();
+
+    while let Some(sym) = queue.pop_front() {
+        if !visited.insert(sym.clone()) {
+            continue;
+        }
+        let Some(block) = blocks_by_sym.get(sym.as_str()) else {
+            // External symbol or stripped target — outside our scope.
+            continue;
+        };
+        for insn in &block.insns {
+            if !call_patterns.iter().any(|re| re.is_match(&insn.mnemonic)) {
+                continue;
+            }
+            // Prefer the relocation-resolved target (covers unresolved
+            // calls in the staticlib); fall back to the inline
+            // `<symbol>` annotation for already-linked binaries.
+            let target = insn
+                .call_target
+                .clone()
+                .or_else(|| extract_call_target(&insn.full_line));
+            if let Some(target) = target {
+                if !visited.contains(&target) {
+                    queue.push_back(target);
+                }
+            }
+        }
     }
-    if sym.starts_with("nct_fix__") || sym.starts_with("_nct_fix__") {
-        return true;
-    }
-    false
+    visited
+}
+
+/// Pull a resolved call target out of an objdump line. Objdump prints
+/// the resolved symbol as `<symbol_name>` after the instruction operands
+/// when the call has a known target in the same disassembly unit;
+/// indirect calls (e.g. `blr x0`) and unresolved targets don't get a
+/// `<...>` suffix and return `None`.
+fn extract_call_target(full_line: &str) -> Option<String> {
+    static TARGET_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<([^>]+)>\s*$").unwrap());
+    TARGET_RE
+        .captures(full_line.trim_end())
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+/// Check whether a symbol matches any of the per-target helper
+/// allowlist patterns (public-parameter loops we've classified as
+/// CT-safe by inspection).
+pub fn is_allowed_helper(sym: &str, allowed_helpers: &[Regex]) -> bool {
+    allowed_helpers.iter().any(|re| re.is_match(sym))
 }
 
 /// True if a `nct_fix__neg__*` symbol — the negative controls.

--- a/ct-verify/ct-driver/src/parse.rs
+++ b/ct-verify/ct-driver/src/parse.rs
@@ -184,6 +184,7 @@ impl Patterns {
             allowed_helpers: spec
                 .allowed_helpers
                 .iter()
+                .chain(spec.extra_allowed_helpers.iter())
                 .map(|p| Regex::new(p).expect("bad allowed_helpers regex"))
                 .collect(),
         }

--- a/ct-verify/ct-driver/src/parse.rs
+++ b/ct-verify/ct-driver/src/parse.rs
@@ -99,7 +99,7 @@ pub fn split_blocks(objdump_out: &str) -> Vec<FunctionBlock> {
         if let Some(caps) = RELOC_RE.captures(line) {
             if let Some(last) = block.insns.last_mut() {
                 if last.call_target.is_none() {
-                    last.call_target = caps.get(1).map(|m| m.as_str().to_string());
+                    last.call_target = caps.get(1).map(|m| normalize_call_target(m.as_str()));
                 }
             }
             continue;
@@ -327,11 +327,32 @@ pub fn compute_reachable_symbols(
 /// indirect calls (e.g. `blr x0`) and unresolved targets don't get a
 /// `<...>` suffix and return `None`.
 fn extract_call_target(full_line: &str) -> Option<String> {
-    static TARGET_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"<([^>]+)>\s*$").unwrap());
+    // Match `<symbol>` near the end of the line, tolerating a trailing
+    // `@ imm = #0x…` annotation that thumb objdump appends.
+    static TARGET_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"<([^>]+)>(?:\s+@\s+imm[^<]*)?\s*$").unwrap());
     TARGET_RE
         .captures(full_line.trim_end())
         .and_then(|c| c.get(1))
-        .map(|m| m.as_str().to_string())
+        .map(|m| normalize_call_target(m.as_str()))
+}
+
+/// Strip addend / PLT / GOT decorations that objdump appends to call
+/// targets, so the result matches the bare-name keys in
+/// `blocks_by_sym`. Examples that need normalising:
+///
+/// - `_ZN…count_ones…E-0x4`       (ELF `R_X86_64_GOTPCREL` addend)
+/// - `<some_helper+0x10>`         (inline `<>` tag with non-zero offset)
+/// - `memcpy@plt`                 (PLT decoration)
+/// - `__some_sym@GOTPCREL`        (GOT / reloc-type decoration)
+///
+/// Truncate at the first `+`, `-`, `@`, or whitespace and return the
+/// prefix.
+fn normalize_call_target(raw: &str) -> String {
+    let cutoff = raw
+        .find(|c: char| c == '+' || c == '-' || c == '@' || c.is_whitespace())
+        .unwrap_or(raw.len());
+    raw[..cutoff].to_string()
 }
 
 /// Check whether a symbol matches any of the per-target helper

--- a/ct-verify/ct-driver/src/report.rs
+++ b/ct-verify/ct-driver/src/report.rs
@@ -11,7 +11,14 @@ pub struct Report {
     pub target: String,
     pub fixtures_checked: usize,
     pub negative_controls_checked: usize,
+    pub helpers_scanned: usize,
+    pub helpers_allowlisted: usize,
     pub ct_violations: Vec<ViolationOut>,
+    /// Violations found in helpers (functions called transitively from
+    /// fixtures, not the fixture wrappers themselves). Kept separate so
+    /// reviewers can see at a glance whether a regression is in a Ct
+    /// primitive's own body or in a helper it pulls in.
+    pub helper_violations: Vec<ViolationOut>,
     pub negative_controls_failed_to_trip: Vec<String>,
 }
 
@@ -36,7 +43,10 @@ impl From<Violation> for ViolationOut {
 
 impl Report {
     pub fn exit_code(&self) -> i32 {
-        if !self.ct_violations.is_empty() || !self.negative_controls_failed_to_trip.is_empty() {
+        if !self.ct_violations.is_empty()
+            || !self.helper_violations.is_empty()
+            || !self.negative_controls_failed_to_trip.is_empty()
+        {
             1
         } else {
             0
@@ -53,14 +63,32 @@ impl Report {
             "  nct_fix__neg__* controls checked: {}",
             self.negative_controls_checked
         );
+        println!(
+            "  helpers scanned (reachable):      {} ({} allowlisted)",
+            self.helpers_scanned, self.helpers_allowlisted
+        );
         if self.ct_violations.is_empty() {
-            println!("  Ct violations:                    0  ✓");
+            println!("  Ct violations (fixture):          0  ✓");
         } else {
             println!(
-                "  Ct violations:                    {}  ✗",
+                "  Ct violations (fixture):          {}  ✗",
                 self.ct_violations.len()
             );
             for v in &self.ct_violations {
+                println!("    [{}] {} {}", v.offset, v.symbol, v.insn);
+                for ctx in &v.context {
+                    println!("        | {}", ctx.trim());
+                }
+            }
+        }
+        if self.helper_violations.is_empty() {
+            println!("  Ct violations (helper):           0  ✓");
+        } else {
+            println!(
+                "  Ct violations (helper):           {}  ✗",
+                self.helper_violations.len()
+            );
+            for v in &self.helper_violations {
                 println!("    [{}] {} {}", v.offset, v.symbol, v.insn);
                 for ctx in &v.context {
                     println!("        | {}", ctx.trim());

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -246,6 +246,18 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // Bare libc-style names (Linux/Mach-O) and their `__` variants
     // emitted by compiler-builtins:
     r"^_?_?(?:mem(?:cpy|set|clr|move|cmp)|bcmp)$",
+    // The Rust `compiler_builtins::mem::{memcpy,memset,memmove,memcmp}`
+    // implementations (mangled `_ZN17compiler_builtins3mem…E`). On
+    // bare-metal targets without a libc, the bare-name symbols above
+    // resolve to these. Branchful on length only.
+    r"compiler_builtins3mem(?:6memcpy|6memset|7memmove|6memcmp)",
+    // compiler-rt 128-bit shift helpers (`__ashlti3`, `__ashrti3`,
+    // `__lshrti3`) and their 64-bit twins on 32-bit targets
+    // (`__ashldi3`, etc.). Reached from any FixedUInt shift whose
+    // backing limb pair spans a register width. The internal branches
+    // are on the shift count, which our Ct shift helpers always pass
+    // as a public-bounded `1 << k` from a public iteration counter.
+    r"^__(?:ashl|ashr|lshr)[dt]i3$",
 ];
 
 /// Thumbv6m-specific extras layered onto `HELPER_ALLOWLIST`.

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -36,6 +36,13 @@ pub struct TargetSpec {
     /// pattern matching can't distinguish those from secret-dependent
     /// branches, so this list is a small per-target escape hatch.
     pub allowed_helpers: &'static [&'static str],
+    /// Per-target extras layered on top of `allowed_helpers`. Reserved
+    /// for branches whose root cause is architecture-specific (e.g.,
+    /// armv6m lacks the `clz` instruction, so `u32::leading_zeros()`
+    /// lowers to a branchful software polynomial in `core` itself).
+    /// These don't belong in the shared list because every other arch
+    /// should keep grepping for them.
+    pub extra_allowed_helpers: &'static [&'static str],
     /// Extra cargo args needed for this target (e.g., `-Z build-std=core`
     /// for AVR).
     pub extra_cargo_args: &'static [&'static str],
@@ -53,6 +60,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: true,
         call_mnemonics: mnemonics::THUMB_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
     TargetSpec {
@@ -64,6 +72,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: true,
         call_mnemonics: mnemonics::THUMB_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
     // Priority 2: Cortex-M0
@@ -76,6 +85,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false, // armv6m has no IT; no allowlist needed
         call_mnemonics: mnemonics::THUMB_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: THUMBV6M_EXTRA_HELPERS,
         extra_cargo_args: &[],
     },
     // Priority 3: 32-bit RISC-V
@@ -88,6 +98,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false,
         call_mnemonics: mnemonics::RISCV_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
     TargetSpec {
@@ -99,6 +110,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false,
         call_mnemonics: mnemonics::RISCV_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
     // Priority 4: 8-bit AVR (nightly-only, needs build-std + target-cpu).
@@ -114,6 +126,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false,
         call_mnemonics: mnemonics::AVR_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &["-Z", "build-std=core"],
     },
     // Priority 5: aarch64
@@ -126,6 +139,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false,
         call_mnemonics: mnemonics::AARCH64_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
     // Priority 6: x86_64
@@ -138,6 +152,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false,
         call_mnemonics: mnemonics::X86_64_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
     // Host fallback: aarch64-apple-darwin. Same mnemonic tables as
@@ -152,6 +167,7 @@ pub const TARGETS: &[TargetSpec] = &[
         thumb_it_blocks: false,
         call_mnemonics: mnemonics::AARCH64_CALL,
         allowed_helpers: HELPER_ALLOWLIST,
+        extra_allowed_helpers: &[],
         extra_cargo_args: &[],
     },
 ];
@@ -216,6 +232,10 @@ const HELPER_ALLOWLIST: &[&str] = &[
     r"fixed_bigint\.\.fixeduint\.\.FixedUInt.*subtle\.\.ConstantTimeGreater",
     // subtle's primitive u32 ct_gt: loop bound is u32::BITS = 32.
     r"\$LT\$u32\$u20\$as\$u20\$subtle\.\.ConstantTimeGreater\$GT\$5ct_gt",
+    // subtle's slice `<[T] as ConstantTimeEq>::ct_eq`: iterates the
+    // slice element-by-element, length is the slice length (public).
+    // Same shape as our per-limb N-bounded loops.
+    r"\$LT\$\$u5b\$T\$u5d\$.*subtle\.\.ConstantTimeEq.*5ct_eq",
     // Compiler-builtin and libc-class byte-copy / byte-zero helpers
     // reached transitively from array initialisation. All branchful
     // on size (public parameter), not on data — same shape as our own
@@ -226,6 +246,44 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // Bare libc-style names (Linux/Mach-O) and their `__` variants
     // emitted by compiler-builtins:
     r"^_?_?(?:mem(?:cpy|set|clr|move|cmp)|bcmp)$",
+];
+
+/// Thumbv6m-specific extras layered onto `HELPER_ALLOWLIST`.
+///
+/// Cortex-M0 (armv6m) is the only target in our matrix without a CLZ
+/// instruction, so std's `u{8,16,32,64}::leading_zeros` /
+/// `trailing_zeros` intrinsics lower to a branchful software
+/// polynomial inside `core` itself. Any function that inlines one of
+/// them inherits those branches — and on armv6m without IT-block
+/// predication, conditional sub-with-borrow on primitives and subtle's
+/// own primitive `ct_eq` also expand to short `b<cc>` sequences rather
+/// than the conditional moves used on armv7m+/aarch64/x86_64.
+///
+/// These are upstream concerns the asm-grep gate can't fix here. The
+/// taint-based ctgrind harness still catches them on its supported
+/// targets. Removing entries from this list is a tracked follow-up:
+/// once `fixed-bigint` ships branchless replacements for the affected
+/// intrinsics, the corresponding row drops out.
+const THUMBV6M_EXTRA_HELPERS: &[&str] = &[
+    // `<u8/u16/u32/u64 as ConstBitPrimInt>::leading_zeros` /
+    // `trailing_zeros`: forward to `core`'s intrinsic. Branchful on
+    // armv6m (no CLZ).
+    r"\$LT\$u(?:8|16|32|64)\$.*fixed_bigint\.\.const_numtraits\.\.ConstBitPrimInt.*(?:leading|trailing)_zeros",
+    // `<u8/u16/u32/u64 as ConstBorrowingSub>::borrowing_sub`: the
+    // `||` over two overflow flags compiles to a short conditional
+    // branch on armv6m. CT-safe everywhere with IT or cmov.
+    r"\$LT\$u(?:8|16|32|64)\$.*fixed_bigint\.\.const_numtraits\.\.ConstBorrowingSub.*13borrowing_sub",
+    // subtle's primitive `<u{8,16,32,64} as ConstantTimeEq>::ct_eq` —
+    // upstream impl, branchful on armv6m for the same IT/cmov reason.
+    r"\$LT\$u(?:8|16|32|64)\$.*subtle\.\.ConstantTimeEq.*5ct_eq",
+    // ConstPowerOfTwo for FixedUInt: `next_power_of_two` and
+    // `ct_checked_next_power_of_two` inline the primitive
+    // `leading_zeros` above and inherit its branches on armv6m.
+    r"fixed_bigint9fixeduint17power_of_two_impl.*next_power_of_two",
+    r"fixed_bigint9fixeduint.*FixedUInt.*ct_checked_next_power_of_two",
+    // compiler_builtins' software division — pulled in transitively
+    // by the armv6m `leading_zeros` polynomial. Branchful on size.
+    r"compiler_builtins3int.*specialized_div_rem",
 ];
 
 pub fn lookup(triple: &str) -> Option<&'static TargetSpec> {

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -296,6 +296,16 @@ const THUMBV6M_EXTRA_HELPERS: &[&str] = &[
     // compiler_builtins' software division — pulled in transitively
     // by the armv6m `leading_zeros` polynomial. Branchful on size.
     r"compiler_builtins3int.*specialized_div_rem",
+    // compiler-rt runtime helpers only emitted on armv6m because the
+    // ISA lacks the underlying instruction:
+    //   __clzsi2 / __clzdi2  — software CLZ (no `clz` on armv6m)
+    //   __udivmodsi4         — software u32 division (no `udiv`)
+    //   __aeabi_llsl / llsr  — i64 shifts (no native 64-bit shifts)
+    // Each is branchful on its count or magnitude operand, which is a
+    // public parameter at every callsite we reach them through.
+    r"^__clz[sd]i2$",
+    r"^__udivmodsi4$",
+    r"^__aeabi_l?ls[lr]$",
 ];
 
 pub fn lookup(triple: &str) -> Option<&'static TargetSpec> {

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -172,23 +172,32 @@ pub const TARGETS: &[TargetSpec] = &[
     },
 ];
 
-/// Shared per-helper allowlist. Helpers whose bodies match any of these
-/// regexes are skipped during the reachability scan, because their
-/// `cmp/b.lt` branches are public-parameter loops (loop counter compared
-/// to compile-time `N`) rather than secret-dependent branches.
+/// Per-helper allowlist shared across every backend.
 ///
-/// Keep entries narrow — match on demangled-ish substrings of the rust
-/// symbol mangling so a typo or rename surfaces as a hard scope miss
-/// rather than a silent skip. Add an entry only when the smoke run
-/// confirms the helper's body is a public-bounded loop; document the
-/// reason inline.
+/// Sharing is intentional: each entry's CT-safety reasoning is
+/// **source-semantic** — the function body is a public-bounded loop
+/// (`for i in 0..N` with compile-time `N`, `while k < usize::BITS`,
+/// or a copy/zero of a compile-time-sized buffer) — not a property of
+/// any particular backend's lowering. A public-bounded loop compiles
+/// to a branchful `cmp/b.lt` on every architecture we target; the
+/// classification holds because the bound itself is public, not
+/// because aarch64 happens to lower it a certain way.
 ///
-/// Each helper here was inspected during the asm-grep helper-scope
-/// expansion (smoke run on aarch64-apple-darwin) — the flagged branches
-/// are public-parameter loops (`for i in 0..N` or
-/// `while k < usize::BITS`) rather than secret-dependent control flow.
-/// The corresponding CT property is also exercised by the existing
-/// ctgrind harness, which catches it directly through taint.
+/// Empirical check on this PR: each target in the CI matrix
+/// (thumbv6m/7m/7em, riscv32imc/imac, aarch64-linux, x86_64-linux,
+/// avr-none) was run through the helper-scope walker. Targets pass
+/// with zero residual helper violations once their target-specific
+/// upstream concerns are partitioned into `extra_allowed_helpers`
+/// (e.g., thumbv6m's missing CLZ pulls in `__clzsi2` etc.). Anything
+/// truly backend-specific belongs there, not here.
+///
+/// Keep entries narrow — match on demangled-ish substrings of the
+/// rust symbol mangling so a typo or rename surfaces as a hard scope
+/// miss rather than a silent skip. Add an entry only after confirming
+/// the helper's body is a public-bounded loop; document the reason
+/// inline. The same property is exercised independently by the
+/// ctgrind harness on its supported targets, which catches secret
+/// dependence directly through taint.
 const HELPER_ALLOWLIST: &[&str] = &[
     // Bit-shift helpers. const_shl_ct / shr_ct iterate usize::BITS times
     // with a per-iteration mask-AND-XOR select; const_shl_impl / shr_impl

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -216,6 +216,16 @@ const HELPER_ALLOWLIST: &[&str] = &[
     r"fixed_bigint\.\.fixeduint\.\.FixedUInt.*subtle\.\.ConstantTimeGreater",
     // subtle's primitive u32 ct_gt: loop bound is u32::BITS = 32.
     r"\$LT\$u32\$u20\$as\$u20\$subtle\.\.ConstantTimeGreater\$GT\$5ct_gt",
+    // Compiler-builtin and libc-class byte-copy / byte-zero helpers
+    // reached transitively from array initialisation. All branchful
+    // on size (public parameter), not on data — same shape as our own
+    // per-limb loops.
+    //
+    // ARM EABI variants on thumb targets:
+    r"^_?__aeabi_(?:memcpy|memset|memclr|memmove)\d*$",
+    // Bare libc-style names (Linux/Mach-O) and their `__` variants
+    // emitted by compiler-builtins:
+    r"^_?_?(?:mem(?:cpy|set|clr|move|cmp)|bcmp)$",
 ];
 
 pub fn lookup(triple: &str) -> Option<&'static TargetSpec> {

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -25,6 +25,17 @@ pub struct TargetSpec {
     pub allowed_cmov: &'static [&'static str],
     /// Engage the thumb IT-state machine.
     pub thumb_it_blocks: bool,
+    /// Call-instruction mnemonics for this arch (regex). Used by the
+    /// reachability walker to follow edges from fixtures into helpers;
+    /// these aren't flagged as violations themselves.
+    pub call_mnemonics: &'static [&'static str],
+    /// Helper symbol patterns whose forbidden mnemonics should be
+    /// suppressed — typically because the body is a public-parameter
+    /// loop (`for i in 0..N` where `N` is a compile-time constant),
+    /// which compiles to a branchful but CT-safe `cmp/b.lt`. Static
+    /// pattern matching can't distinguish those from secret-dependent
+    /// branches, so this list is a small per-target escape hatch.
+    pub allowed_helpers: &'static [&'static str],
     /// Extra cargo args needed for this target (e.g., `-Z build-std=core`
     /// for AVR).
     pub extra_cargo_args: &'static [&'static str],
@@ -40,6 +51,8 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: true,
+        call_mnemonics: mnemonics::THUMB_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &[],
     },
     TargetSpec {
@@ -49,6 +62,8 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: true,
+        call_mnemonics: mnemonics::THUMB_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &[],
     },
     // Priority 2: Cortex-M0
@@ -59,6 +74,8 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::THUMB_FORBIDDEN,
         allowed_cmov: mnemonics::THUMB_ALLOWED,
         thumb_it_blocks: false, // armv6m has no IT; no allowlist needed
+        call_mnemonics: mnemonics::THUMB_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &[],
     },
     // Priority 3: 32-bit RISC-V
@@ -69,6 +86,8 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::RISCV_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,
+        call_mnemonics: mnemonics::RISCV_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &[],
     },
     TargetSpec {
@@ -78,6 +97,8 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::RISCV_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,
+        call_mnemonics: mnemonics::RISCV_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &[],
     },
     // Priority 4: 8-bit AVR (nightly-only, needs build-std + target-cpu).
@@ -91,6 +112,8 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::AVR_FORBIDDEN,
         allowed_cmov: &[],
         thumb_it_blocks: false,
+        call_mnemonics: mnemonics::AVR_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &["-Z", "build-std=core"],
     },
     // Priority 5: aarch64
@@ -101,6 +124,8 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::AARCH64_FORBIDDEN,
         allowed_cmov: mnemonics::AARCH64_ALLOWED,
         thumb_it_blocks: false,
+        call_mnemonics: mnemonics::AARCH64_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &[],
     },
     // Priority 6: x86_64
@@ -111,6 +136,8 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::X86_64_FORBIDDEN,
         allowed_cmov: mnemonics::X86_64_ALLOWED,
         thumb_it_blocks: false,
+        call_mnemonics: mnemonics::X86_64_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &[],
     },
     // Host fallback: aarch64-apple-darwin. Same mnemonic tables as
@@ -123,8 +150,72 @@ pub const TARGETS: &[TargetSpec] = &[
         forbidden: mnemonics::AARCH64_FORBIDDEN,
         allowed_cmov: mnemonics::AARCH64_ALLOWED,
         thumb_it_blocks: false,
+        call_mnemonics: mnemonics::AARCH64_CALL,
+        allowed_helpers: HELPER_ALLOWLIST,
         extra_cargo_args: &[],
     },
+];
+
+/// Shared per-helper allowlist. Helpers whose bodies match any of these
+/// regexes are skipped during the reachability scan, because their
+/// `cmp/b.lt` branches are public-parameter loops (loop counter compared
+/// to compile-time `N`) rather than secret-dependent branches.
+///
+/// Keep entries narrow — match on demangled-ish substrings of the rust
+/// symbol mangling so a typo or rename surfaces as a hard scope miss
+/// rather than a silent skip. Add an entry only when the smoke run
+/// confirms the helper's body is a public-bounded loop; document the
+/// reason inline.
+///
+/// Each helper here was inspected during the asm-grep helper-scope
+/// expansion (smoke run on aarch64-apple-darwin) — the flagged branches
+/// are public-parameter loops (`for i in 0..N` or
+/// `while k < usize::BITS`) rather than secret-dependent control flow.
+/// The corresponding CT property is also exercised by the existing
+/// ctgrind harness, which catches it directly through taint.
+const HELPER_ALLOWLIST: &[&str] = &[
+    // Bit-shift helpers. const_shl_ct / shr_ct iterate usize::BITS times
+    // with a per-iteration mask-AND-XOR select; const_shl_impl / shr_impl
+    // are reached from them with a non-tainted `amount = 1 << k`.
+    r"fixed_bigint9fixeduint12const_shl_ct",
+    r"fixed_bigint9fixeduint12const_shr_ct",
+    r"fixed_bigint9fixeduint14const_shl_impl",
+    r"fixed_bigint9fixeduint14const_shr_impl",
+    // Shift-amount normaliser. Reached from Nct paths only after PR #121
+    // moved the Ct arm off it; the branches are on `bits >= bit_size`
+    // (Nct caller's concern).
+    r"fixed_bigint9fixeduint12bit_ops_impl22normalize_shift_amount",
+    // Per-limb CT select. Branches are loop counter < N (compile-time).
+    r"fixed_bigint9fixeduint15const_ct_select",
+    // Per-limb scanners — leading/trailing zero counts, is_zero / is_one.
+    // Loop bound is N (compile-time constant).
+    r"fixed_bigint9fixeduint16const_is_zero_ct",
+    r"fixed_bigint9fixeduint15const_is_one_ct",
+    r"fixed_bigint9fixeduint22const_leading_zeros_ct",
+    r"fixed_bigint9fixeduint23const_trailing_zeros_ct",
+    // Per-limb arithmetic — N-bounded loops.
+    r"fixed_bigint9fixeduint14add_with_carry",
+    r"fixed_bigint9fixeduint9const_mul",
+    r"fixed_bigint9fixeduint8add_impl",
+    r"fixed_bigint9fixeduint8sub_impl",
+    // ct_checked_pow's square-and-multiply ladder iterates u32::BITS
+    // times.
+    r"fixed_bigint9fixeduint.*ct_checked_pow",
+    // Trait impls on FixedUInt: bitwise ops, prim-int family, num_traits
+    // identity, subtle's ConditionallySelectable / ConstantTime*. All
+    // per-limb N-bounded loops.
+    r"core\.\.ops\.\.bit\.\.(?:Not|BitOr|BitAnd|BitXor).*fixed_bigint\.\.fixeduint\.\.FixedUInt",
+    r"fixed_bigint\.\.const_numtraits\.\.ConstBitPrimInt.*fixed_bigint\.\.fixeduint\.\.FixedUInt",
+    r"fixed_bigint\.\.const_numtraits\.\.ConstZero.*fixed_bigint\.\.fixeduint\.\.FixedUInt",
+    r"fixed_bigint\.\.const_numtraits\.\.ConstBounded.*fixed_bigint\.\.fixeduint\.\.FixedUInt",
+    // Subtle impls use `<Self as Trait>` mangling (Self first, then
+    // `as`, then trait) rather than the `<impl Trait for Self>`
+    // mangling the bitwise / num_traits impls above use.
+    r"fixed_bigint\.\.fixeduint\.\.FixedUInt.*subtle\.\.ConditionallySelectable",
+    r"fixed_bigint\.\.fixeduint\.\.FixedUInt.*subtle\.\.ConstantTimeEq",
+    r"fixed_bigint\.\.fixeduint\.\.FixedUInt.*subtle\.\.ConstantTimeGreater",
+    // subtle's primitive u32 ct_gt: loop bound is u32::BITS = 32.
+    r"\$LT\$u32\$u20\$as\$u20\$subtle\.\.ConstantTimeGreater\$GT\$5ct_gt",
 ];
 
 pub fn lookup(triple: &str) -> Option<&'static TargetSpec> {


### PR DESCRIPTION
Previously the gate scoped to `ct_fix__*` / `nct_fix__*` symbols only, on the assumption that LTO would inline every Ct helper into the fixture body and bring it under inspection. That assumption broke in PR #119 — `const_leading_zeros_ct` doesn't inline (too large), so when its `u32::leading_zeros()` intrinsic call lowered to `test/je/bsr` on baseline x86_64, asm-grep didn't see the `je` and the bug only surfaced via ctgrind. We worked around that one with a workflow RUSTFLAGS, but only ctgrind targets benefit from that mitigation.

Walk call-graph reachability instead. From each Ct fixture symbol, follow `bl` / `call` / `jal` / `rcall` / etc. edges transitively through the disassembly, building the set of helpers actually reached from a Ct call path. Scan every reachable helper for forbidden mnemonics. Negative-control fixtures are deliberately excluded from the seed set — their bodies pull in Nct helpers that have branchful behaviour by design.

Resolving call targets in a static archive uses `objdump --reloc`: unresolved cross-CGU calls print as self-relative placeholders otherwise, so the relocation entries are interleaved with the disassembly and a new parse line picks them up.

False positives — public-parameter loops like
`<FixedUInt as ConditionallySelectable>::conditional_select`'s `for i in 0..N` compiling to `cmp/b.lt` — are handled by a per-target `allowed_helpers` regex list in `TargetSpec`. The shared `HELPER_ALLOWLIST` covers every helper the smoke run on aarch64-apple-darwin surfaced: the bit-shift family, `const_ct_select`, the per-limb scanners, the bitwise / num_traits / subtle trait impls on `FixedUInt`. Each entry was inspected and confirmed to be a compile-time-bounded loop; the corresponding CT property is also exercised by ctgrind, so any future secret-dependent branch slipping in still gets caught at runtime.

The report distinguishes fixture-direct from helper-indirect violations so a regression's blast radius is obvious from the summary. Both classes hard-fail.

## Summary by Sourcery

Extend constant-time assembly scanning to traverse call graphs from Ct fixtures into reachable helpers and report violations separately for fixtures and helpers.

Enhancements:
- Parse objdump relocation entries and call mnemonics per-architecture to resolve call targets when walking reachability.
- Add a helper allowlist mechanism in the target spec to suppress known CT-safe public-parameter loops while still checking other helpers.
- Include reachability-based helper scanning and new counters in the CLI report, distinguishing fixture-direct from helper-indirect violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verification now scans helper functions transitively reachable from constant-time fixtures and reports any violations found within them.
  * Verification reports now include helper scan statistics, allowlisted helper counts, and helper-specific violation details.
  * Added architecture-specific support for identifying call instructions across Thumb, AArch64, RISC-V, AVR, and x86-64.

* **Improvements**
  * Improved call target resolution using relocation information during disassembly parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->