### PR TITLE
Add Zeroize/ZeroizeOnDrop/Drop for BytesHolder

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,12 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Nightly is pinned because the `c0nst::c0nst!` macro tripped on
-        # a const-trait-syntax change in nightly toolchains shipped after
-        # ~2026-06-19. PR #123 fixed the earlier 06-19 break; the current
-        # break needs its own follow-up. Until then, hold at the last
-        # known-good nightly.
-        rust: ["1.86", stable, nightly-2026-06-19]
+        rust: ["1.86", stable, nightly]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.86", stable, nightly]
+        # Nightly is pinned because the `c0nst::c0nst!` macro tripped on
+        # a const-trait-syntax change in nightly toolchains shipped after
+        # ~2026-06-19. PR #123 fixed the earlier 06-19 break; the current
+        # break needs its own follow-up. Until then, hold at the last
+        # known-good nightly.
+        rust: ["1.86", stable, nightly-2026-06-19]
 
     steps:
     - uses: actions/checkout@v4
@@ -25,12 +30,12 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Run tests with nightly feature
-      if: matrix.rust == 'nightly'
+      if: startsWith(matrix.rust, 'nightly')
       run: cargo test --verbose --features nightly
     - name: Run tests with zeroize
       run: cargo test --verbose --features zeroize
     - name: Run tests with use-unsafe
       run: cargo test --verbose --features use-unsafe
     - name: Run tests with all features
-      if: matrix.rust == 'nightly'
+      if: startsWith(matrix.rust, 'nightly')
       run: cargo test --verbose --all-features

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -7,8 +7,13 @@ use core::hash::Hash;
 use super::FixedUInt;
 use crate::personality::Personality;
 
-// Helper, holds an owned copy of returned bytes
-#[derive(Eq, PartialEq, Clone, Copy, PartialOrd, Ord, Debug)]
+// Helper, holds an owned copy of returned bytes.
+//
+// Not `Copy`: when the `zeroize` feature is enabled this type carries
+// a `Drop` impl that wipes its contents, so copy semantics are not
+// available.  Consumers that previously relied on implicit `BytesHolder:
+// Copy` need an explicit `.clone()`.
+#[derive(Eq, PartialEq, Clone, PartialOrd, Ord, Debug)]
 pub struct BytesHolder<T: MachineWord, const N: usize> {
     array: [T; N],
 }
@@ -67,6 +72,27 @@ impl<T: MachineWord, const N: usize> AsMut<[u8]> for BytesHolder<T, N> {
 impl<T: MachineWord, const N: usize> Hash for BytesHolder<T, N> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.as_byte_slice().hash(state)
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<T: MachineWord, const N: usize> zeroize::Zeroize for BytesHolder<T, N> {
+    fn zeroize(&mut self) {
+        // Wipe via the byte view so the guarantee covers the actual
+        // memory representation, not just per-word `T::zeroize` (which
+        // could be sub-word-granular for composite limb types).
+        self.as_byte_slice_mut().zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl<T: MachineWord, const N: usize> zeroize::ZeroizeOnDrop for BytesHolder<T, N> {}
+
+#[cfg(feature = "zeroize")]
+impl<T: MachineWord, const N: usize> Drop for BytesHolder<T, N> {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.zeroize();
     }
 }
 
@@ -151,6 +177,18 @@ mod tests {
         bytes.as_mut().reverse();
         let result = T::from_le_bytes(&bytes);
         assert_eq!(result, expected);
+    }
+
+    #[cfg(feature = "zeroize")]
+    #[test]
+    fn test_zeroize_wipes_byte_view() {
+        use zeroize::Zeroize;
+
+        let value = FixedUInt::<u32, 4>::from_u32(0xDEAD_BEEF).unwrap();
+        let mut bytes = <FixedUInt<u32, 4> as num_traits::ToBytes>::to_be_bytes(&value);
+        assert!(bytes.as_ref().iter().any(|b| *b != 0));
+        bytes.zeroize();
+        assert!(bytes.as_ref().iter().all(|b| *b == 0));
     }
 
     #[test]

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -186,7 +186,14 @@ mod tests {
 
         let value = FixedUInt::<u32, 4>::from_u32(0xDEAD_BEEF).unwrap();
         let mut bytes = <FixedUInt<u32, 4> as num_traits::ToBytes>::to_be_bytes(&value);
-        assert!(bytes.as_ref().iter().any(|b| *b != 0));
+        // Seed every byte before the wipe — `from_u32` only fills the
+        // low limb, leaving most of the 16-byte holder already zero.
+        // A buggy `zeroize` that wiped only the populated bytes would
+        // pass an `all-zero` check without the seed.
+        for (index, byte) in bytes.as_mut().iter_mut().enumerate() {
+            *byte = (index as u8).wrapping_add(1);
+        }
+        assert!(bytes.as_ref().iter().all(|b| *b != 0));
         bytes.zeroize();
         assert!(bytes.as_ref().iter().all(|b| *b == 0));
     }


### PR DESCRIPTION
## Summary

- Implement `zeroize::Zeroize`, `zeroize::ZeroizeOnDrop`, and a wiping `Drop` for `BytesHolder<T, N>` under `feature = "zeroize"`.
- Wipe goes through the byte view (`as_byte_slice_mut()`) so the guarantee covers the actual memory representation, not per-word `T::zeroize` (which could be sub-word-granular for composite limb types).
- Satisfies the `T::Bytes: zeroize::Zeroize` bound that downstream crypto code (e.g. `rsa_heapless`'s `uint_to_zeroizing_be_pad_into` paths) needs to wipe the intermediate `to_be_bytes()` / `to_le_bytes()` buffer after copying into the output slice.

## Breaking change

`BytesHolder` is no longer `Copy`. A type with a `Drop` impl cannot be `Copy`, and the type carries key-material bytes for crypto-leaning downstream consumers, so an implicit-copy footgun is not worth keeping for the few callers that relied on it. Replace any `let b2 = b1;` with an explicit `.clone()` — the `Clone` derive remains.

`BytesHolder` is only constructible internally and reaches consumers as `<FixedUInt as ToBytes>::Bytes`; in practice consumers borrow it via `AsRef<[u8]>` / `Borrow<[u8]>` rather than copying it.

## Test plan

- [x] `cargo test --lib` (default features)
- [x] `cargo test --lib --features zeroize`
- [x] `cargo test --lib --features zeroize,use-unsafe` — exercises new `test_zeroize_wipes_byte_view` (asserts byte view is zero after `zeroize()`)
- [x] `cargo build --no-default-features`
- [x] `cargo build --features zeroize,use-unsafe`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure byte-value handling so sensitive data is wiped from memory when the secure-erase option is enabled.
  * Prevented unintended implicit duplication by removing automatic copy behavior from the byte container.

* **New Features**
  * Added automatic zeroing on drop for the byte container when the secure-erase option is enabled.
  * Added a test to confirm every byte of the value’s byte representation is cleared after zeroing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->