### PR TITLE
Cleanup pass: crates.io const-num-traits, clippy hygiene, doc trims

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,5 +31,14 @@ repos:
     rev: v1.0
     hooks:
     -   id: fmt
+        # Override the upstream default which appends filenames after
+        # `--`, causing rustfmt to run per-file without the workspace's
+        # edition context — it then reorders imports differently than
+        # `cargo fmt --all` does and, on some files, mis-parses the
+        # `c0nst!` macro and writes empty output. `--all -- --check`
+        # runs across the workspace and fails without modifying, so
+        # devs fix by running `cargo fmt --all` locally.
+        pass_filenames: false
+        args: ["--all", "--", "--check"]
     -   id: cargo-check
     -   id: clippy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,10 +95,9 @@ Several traits the local crate didn't carry are now implemented:
   - `DivNonZero for FixedUInt<T, N, Nct>` — Nct only. `FixedUInt`'s
     `core::ops::Div` is Nct-only (long division is value-dependent),
     so the divide-by-proven-nonzero op inherits the same constraint.
-    Consumers with secret moduli route through `modmath::Field<T,
-    Ct>` (Montgomery, no division), constructed via `Odd::new_ct`
-    or `Field::try_new_odd_ct`. There is intentionally no `*_nz_ct`
-    surface in modmath because there's no meaningful consumer.
+    Constant-time reduction against a secret modulus needs a
+    Montgomery-based `Field`-style wrapper (no division), which lives
+    outside this crate.
 
   **API contract: deletes the divide-by-zero `panic_fmt` from the
   linked binary** — audit-verified. A `cargo nm
@@ -138,10 +137,7 @@ Several traits the local crate didn't carry are now implemented:
   the accessor and no `match P::TAG` dispatch. The two row kernels
   (`mul_acc_row`, `mul_acc_shift_row`) carry the same algorithm
   byte-identically from the retired `mul_acc_ops_common!` macro.
-  The trait lives in `modmath-cios` — a leaf crate with no deps —
-  rather than in `modmath` itself; see `CIOS_TRAIT_MOVED.md` for
-  why (trait-identity duplication across rustc compile units when
-  modmath dev-deps fixed-bigint to test).
+  The trait lives in the leaf `modmath-cios` crate (no deps).
 
 * **Fixed-size byte conversion at the API boundary** — four inherent
   methods on `FixedUInt`:
@@ -171,11 +167,10 @@ Several traits the local crate didn't carry are now implemented:
   crate's `use-unsafe` feature is scoped specifically to the
   ToBytes/FromBytes `BytesHolder` path where const-generics had no
   other option, not as a general license; without a safe fix from
-  upstream, the residual `panic_fmt` stays. Downstream embedded
-  crypto consumers that *require* a fully panic-clean binary (e.g.
-  `ed25519_heapless`'s AVR linkage gate) cannot rely on these
-  methods alone to satisfy that — the upstream
-  `slice::copy_from_slice` body limits us.
+  upstream, the residual `panic_fmt` stays. Consumers that require
+  a fully panic-clean binary cannot rely on these methods alone to
+  satisfy that — the upstream `slice::copy_from_slice` body limits
+  us.
 
   Compile-time size check is implemented as a private trait
   (`AssertBufferFits<M>`) with a `const CHECK: () = assert!(...)`
@@ -250,9 +245,8 @@ Several traits the local crate didn't carry are now implemented:
   regression by `tests/odd_even_typestate.rs` (8 tests covering
   owned/borrowed construction, both personalities, narrow + wide
   carriers, and a proof-consumer call-site pattern). Downstream
-  consumers (notably `modmath`'s `Field::from_odd_modulus` plan in
-  `PANIC_FREE_REQUESTS.md`) get the typestate-based infallible
-  constructor pattern with no fixed-bigint-side glue.
+  consumers get the typestate-based infallible constructor pattern
+  with no fixed-bigint-side glue.
 * `Parity` (`is_odd`, `is_even`) — both personalities.
 * `HighestOne` / `LowestOne` — both personalities; index of the
   highest/lowest set bit, `None` for zero.
@@ -282,14 +276,12 @@ the explicit deref litter.
 ### Removed
 
 * **`fixed_bigint::MulAccOps` trait and impls — gone.** The CIOS row-op
-  surface moves to modmath as `modmath_cios::CiosRowOps` (under the
-  `cios` feature; see "Added"). Single-step cut across the three
-  crates per `CIOS_MIGRATION.md`: modmath rewrote its `cios.rs` body
-  against the new trait, fixed-bigint deleted the old trait + impls,
-  no deprecation window. Concrete deletions: `src/mul_acc_ops.rs`,
-  `src/fixeduint/mul_acc_ops_impl.rs`, the `pub mod mul_acc_ops;`
-  declaration and `pub use ... MulAccOps;` re-export from `lib.rs`,
-  the two MulAccOps-shaped tests in `tests/personality_integration.rs`.
+  surface moves to `modmath_cios::CiosRowOps` (under the `cios`
+  feature; see "Added"). No deprecation window. Concrete deletions:
+  `src/mul_acc_ops.rs`, `src/fixeduint/mul_acc_ops_impl.rs`, the
+  `pub mod mul_acc_ops;` declaration and `pub use ... MulAccOps;`
+  re-export from `lib.rs`, the two MulAccOps-shaped tests in
+  `tests/personality_integration.rs`.
 * `Truncate` checked/saturating variants and `CastSigned`/`CastUnsigned`
   checked/saturating variants — these were exact duplicates of the
   generic cast traits. Use `CheckedCast::<T>`, `SaturatingCast::<T>`,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,8 @@ version = "0.1.45"
 optional = true
 default-features = false
 
-# Experimental: the in-tree const-friendly fork of num-traits. Used to
-# replace the local `src/const_numtraits.rs` module on this branch and
-# see what (if anything) breaks in the API/contract.
 [dependencies.const-num-traits]
-git = "https://github.com/kaidokert/num-traits"
-tag = "v0.1.0-alpha.0"
+version = "0.1"
 default-features = false
 features = ["ct"]
 

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,7 +22,7 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits", tag = "v0.1.0-alpha.0", default-features = false, features = ["ct"] }
+const-num-traits = { version = "0.1", default-features = false, features = ["ct"] }
 subtle = { version = "2.6", default-features = false }
 
 # Profile settings live at the workspace root (cargo only honors them there).

--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -1,15 +1,15 @@
-//! Category A: methods migrated via `match P::TAG` where the Ct arm is a
-//! distinct body. Phase 3c–g + 3i–m in the original migration commits.
+//! Category A: methods dispatched via `match P::TAG` where the Ct arm
+//! is a distinct body.
 //!
 //! Each op is exercised at five (T, N) diagonals:
 //!   (u8, 16), (u16, 16), (u32, 4), (u32, 16), (u64, 4)
 
 use const_num_traits::Ct;
-use fixed_bigint::FixedUInt;
 use fixed_bigint::const_numtraits::{
     AbsDiff, IsPowerOfTwo, NextPowerOfTwo, One, PrimBits, SaturatingAdd, SaturatingMul,
     SaturatingSub, UnboundedShl, UnboundedShr, Zero,
 };
+use fixed_bigint::FixedUInt;
 
 use crate::{ct_fix_bin, ct_fix_count, ct_fix_pred, ct_fix_shift, ct_fix_un};
 
@@ -66,7 +66,7 @@ emit_sat_mul!(ct_fix__A__sat_mul__u32__N16, u32, 16);
 emit_sat_mul!(ct_fix__A__sat_mul__u64__N4, u64, 4);
 
 // =============================================================================
-// core::ops::Shl<usize> / Shr<usize> (Phase 3e barrel shifter)
+// core::ops::Shl<usize> / Shr<usize> — barrel shifter
 // =============================================================================
 
 macro_rules! emit_shl_usize {
@@ -100,7 +100,7 @@ emit_shr_usize!(ct_fix__A__shr_usize__u32__N16, u32, 16);
 emit_shr_usize!(ct_fix__A__shr_usize__u64__N4, u64, 4);
 
 // =============================================================================
-// UnboundedShl::unbounded_shl / UnboundedShr::unbounded_shr (Phase 3i)
+// UnboundedShl::unbounded_shl / UnboundedShr::unbounded_shr
 // =============================================================================
 
 macro_rules! emit_unbounded_shl {
@@ -134,7 +134,7 @@ emit_unbounded_shr!(ct_fix__A__unbounded_shr__u32__N16, u32, 16);
 emit_unbounded_shr!(ct_fix__A__unbounded_shr__u64__N4, u64, 4);
 
 // =============================================================================
-// AbsDiff::abs_diff (Phase 3l)
+// AbsDiff::abs_diff
 // =============================================================================
 
 macro_rules! emit_abs_diff {
@@ -154,7 +154,7 @@ emit_abs_diff!(ct_fix__A__abs_diff__u32__N16, u32, 16);
 emit_abs_diff!(ct_fix__A__abs_diff__u64__N4, u64, 4);
 
 // =============================================================================
-// IsPowerOfTwo::is_power_of_two (Phase 3f) — predicate
+// IsPowerOfTwo::is_power_of_two — predicate
 // =============================================================================
 
 macro_rules! emit_is_pow2 {
@@ -172,7 +172,7 @@ emit_is_pow2!(ct_fix__A__is_pow2__u32__N16, u32, 16);
 emit_is_pow2!(ct_fix__A__is_pow2__u64__N4, u64, 4);
 
 // =============================================================================
-// NextPowerOfTwo::next_power_of_two (Phase 3m)
+// NextPowerOfTwo::next_power_of_two
 // =============================================================================
 
 macro_rules! emit_next_pow2 {
@@ -191,7 +191,7 @@ emit_next_pow2!(ct_fix__A__next_pow2__u32__N16, u32, 16);
 emit_next_pow2!(ct_fix__A__next_pow2__u64__N4, u64, 4);
 
 // =============================================================================
-// PrimBits::leading_zeros / trailing_zeros (Phase 3c/3d)
+// PrimBits::leading_zeros / trailing_zeros
 // =============================================================================
 
 macro_rules! emit_lz {
@@ -223,7 +223,7 @@ emit_tz!(ct_fix__A__trailing_zeros__u32__N16, u32, 16);
 emit_tz!(ct_fix__A__trailing_zeros__u64__N4, u64, 4);
 
 // =============================================================================
-// Zero::is_zero / One::is_one (Phase 2 / 3a)
+// Zero::is_zero / One::is_one
 // =============================================================================
 
 macro_rules! emit_is_zero {

--- a/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
@@ -97,7 +97,7 @@ emit_cond_select!(ct_fix__B__cond_select__u32__N16, u32, 16);
 emit_cond_select!(ct_fix__B__cond_select__u64__N4, u64, 4);
 
 // =============================================================================
-// ct_checked_add / sub / mul (Phase 3j)
+// ct_checked_add / sub / mul
 // =============================================================================
 
 macro_rules! emit_ct_checked_add {
@@ -155,7 +155,7 @@ emit_ct_checked_mul!(ct_fix__B__ct_checked_mul__u32__N16, u32, 16);
 emit_ct_checked_mul!(ct_fix__B__ct_checked_mul__u64__N4, u64, 4);
 
 // =============================================================================
-// ct_checked_shl / shr / pow (Phase 3k / 3l)
+// ct_checked_shl / shr / pow
 // =============================================================================
 
 macro_rules! emit_ct_checked_shl {
@@ -210,7 +210,7 @@ emit_ct_checked_pow!(ct_fix__B__ct_checked_pow__u32__N16, u32, 16);
 emit_ct_checked_pow!(ct_fix__B__ct_checked_pow__u64__N4, u64, 4);
 
 // =============================================================================
-// ct_checked_next_power_of_two (Phase 3m)
+// ct_checked_next_power_of_two
 // =============================================================================
 
 macro_rules! emit_ct_checked_npot {

--- a/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
@@ -7,8 +7,8 @@
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
 use const_num_traits::Ct;
-use fixed_bigint::FixedUInt;
 use fixed_bigint::const_numtraits::{CarryingAdd, Midpoint, OverflowingAdd, PrimBits, WrappingMul};
+use fixed_bigint::FixedUInt;
 
 use crate::{ct_fix_bin, ct_fix_count, ct_fix_un};
 

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { path = "../../../num-traits", default-features = false }
+const-num-traits = { version = "0.1", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,
 # panic=abort) is what makes DCE worth measuring; do not override here.

--- a/ct-verify/panic-free-audit/src/lib.rs
+++ b/ct-verify/panic-free-audit/src/lib.rs
@@ -8,9 +8,9 @@
 //! `panic_*` / `unwind` symbols traced back to these methods.
 //!
 //! Picks a real-world-shaped instantiation: `FixedUInt<u32, 8>` ⇒
-//! 32 bytes (a Curve25519-shaped scalar). The buffer size matches
-//! `BYTE_WIDTH` exactly to exercise the equal-size hot path that
-//! downstream `ed25519_heapless` cares about.
+//! 32 bytes (a 256-bit scalar). The buffer size matches `BYTE_WIDTH`
+//! exactly to exercise the equal-size hot path that downstream
+//! consumers care about.
 //!
 //! `black_box` at every boundary so the optimizer can't fold inputs
 //! through and DCE the body wholesale (same hygiene as ct-fixtures).

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 #[cfg(feature = "num-traits")]
-use num_traits::{ToPrimitive, Zero};
-
-use core::convert::TryFrom;
 use core::fmt::Write;
 
 pub use crate::const_numtraits::{
@@ -158,9 +155,9 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N, Ct> {
     /// Drop the CT guarantee and convert to the `Nct` variant.
     ///
     /// **This is an explicit downgrade.** The caller is asserting that the
-    /// value is no longer secret — typically because the CT-handling phase
-    /// has ended (e.g. a finalized signature, a published key, a post-
-    /// reduction modular value about to be serialized).
+    /// value is no longer secret — typically because the CT-handling
+    /// window has ended (e.g. a finalized signature, a published key, a
+    /// post-reduction modular value about to be serialized).
     pub const fn forget_ct(self) -> FixedUInt<T, N, Nct> {
         FixedUInt::from_array(self.array)
     }
@@ -248,7 +245,6 @@ impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize> FixedUInt
         T: subtle::ConstantTimeEq + subtle::ConstantTimeGreater,
         for<'a> &'a Self: core::ops::Mul<&'a Self, Output = Self>,
     {
-        use crate::const_numtraits::OverflowingMul;
         let mut result = <Self as crate::const_numtraits::One>::one();
         let mut base = self;
         let mut e = exp;
@@ -601,6 +597,7 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
         FixedUInt::<T, N2, P>::from_array(array)
     }
 
+    #[cfg(feature = "num-traits")]
     fn hex_fmt(
         &self,
         formatter: &mut core::fmt::Formatter<'_>,
@@ -1545,9 +1542,11 @@ c0nst::c0nst! {
 fn make_parse_int_err() -> core::num::ParseIntError {
     <u8>::from_str_radix("-", 2).err().unwrap()
 }
+#[cfg(feature = "num-traits")]
 fn make_overflow_err() -> core::num::ParseIntError {
     <u8>::from_str_radix("101", 16).err().unwrap()
 }
+#[cfg(feature = "num-traits")]
 fn make_empty_error() -> core::num::ParseIntError {
     <u8>::from_str_radix("", 8).err().unwrap()
 }
@@ -1650,6 +1649,7 @@ mod tests {
     use super::FixedUInt as Bn;
     use super::*;
     use crate::const_numtraits::{One, Zero};
+    use num_traits::ToPrimitive;
 
     type Bn8 = Bn<u8, 8>;
     type Bn16 = Bn<u16, 4>;
@@ -2160,7 +2160,7 @@ mod tests {
         assert_eq!(f.array, [1, 0, 0, 0]);
         let f = Bn::<u8, 4>::from(257u32);
         assert_eq!(f.array, [1, 1, 0, 0]);
-        let f = Bn::<u8, 4>::from(u32::max_value());
+        let f = Bn::<u8, 4>::from(u32::MAX);
         assert_eq!(f.array, [255, 255, 255, 255]);
 
         let f = Bn::<u8, 1>::from(1u32);
@@ -2179,7 +2179,7 @@ mod tests {
         let f = Bn::<u32, 1>::from(65537u32);
         assert_eq!(f.array, [65537]);
 
-        let f = Bn::<u32, 1>::from(u32::max_value());
+        let f = Bn::<u32, 1>::from(u32::MAX);
         assert_eq!(f.array, [4294967295]);
 
         #[cfg(feature = "nightly")]
@@ -2428,7 +2428,7 @@ mod tests {
     #[test]
     fn test_clone() {
         let a: Bn8 = 42u8.into();
-        let b = a.clone();
+        let b = a;
         assert_eq!(a, b);
 
         #[cfg(feature = "nightly")]

--- a/src/fixeduint/abs_diff_impl.rs
+++ b/src/fixeduint/abs_diff_impl.rs
@@ -15,7 +15,7 @@
 //! Absolute difference implementation for FixedUInt.
 
 use super::{FixedUInt, MachineWord, const_ct_select};
-use crate::const_numtraits::{AbsDiff, ConstZero, One, OverflowingSub, WrappingSub, Zero};
+use crate::const_numtraits::{AbsDiff, ConstZero, OverflowingSub, WrappingSub};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::{Personality, PersonalityTag};
 

--- a/src/fixeduint/add_sub_impl.rs
+++ b/src/fixeduint/add_sub_impl.rs
@@ -2,8 +2,8 @@ use super::{
     FixedUInt, MachineWord, PanicReason, add_impl, const_ct_select, maybe_panic_if, sub_impl,
 };
 use crate::const_numtraits::{
-    Bounded, CheckedAdd, CheckedSub, ConstZero, One, OverflowingAdd, OverflowingSub, SaturatingAdd,
-    SaturatingSub, WrappingAdd, WrappingSub, Zero,
+    Bounded, CheckedAdd, CheckedSub, ConstZero, OverflowingAdd, OverflowingSub, SaturatingAdd,
+    SaturatingSub, WrappingAdd, WrappingSub,
 };
 use crate::machineword::ConstMachineWord;
 use const_num_traits::{Personality, PersonalityTag};
@@ -351,11 +351,14 @@ where
 }
 
 #[cfg(test)]
+// Coverage tests deliberately exercise every ref/value combination of
+// `Add`/`Sub` (see `test_add_combinations`, `test_sub_combinations`).
+#[allow(clippy::op_ref)]
 mod tests {
     use super::*;
     use crate::const_numtraits::Bounded;
     use crate::const_numtraits::{
-        CheckedAdd, CheckedSub, One, OverflowingAdd, OverflowingSub, WrappingAdd, WrappingSub, Zero,
+        CheckedAdd, CheckedSub, OverflowingAdd, OverflowingSub, WrappingAdd, WrappingSub,
     };
     use crate::machineword::ConstMachineWord;
 

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -1,8 +1,8 @@
 use super::{FixedUInt, MachineWord, const_shl_ct, const_shl_impl, const_shr_ct, const_shr_impl};
 
 use crate::const_numtraits::{
-    CheckedShl, CheckedShr, ConstZero, One, OverflowingShl, OverflowingShr, UnboundedShl,
-    UnboundedShr, WrappingShl, WrappingShr, Zero,
+    CheckedShl, CheckedShr, ConstZero, OverflowingShl, OverflowingShr, UnboundedShl, UnboundedShr,
+    WrappingShl, WrappingShr,
 };
 use crate::machineword::ConstMachineWord;
 use const_num_traits::{Nct, Personality, PersonalityTag};
@@ -753,7 +753,7 @@ c0nst::c0nst! {
                 // Lowest set bit of `remaining` via `x & -x`.
                 let lowest = <Self as crate::const_numtraits::IsolateLowestOne>::isolate_lowest_one(remaining);
                 if !<Self as crate::const_numtraits::Zero>::is_zero(&(self & bb)) {
-                    result = result | lowest;
+                    result |= lowest;
                 }
                 // Clear that lowest bit and advance the source-side bit.
                 remaining = remaining & <Self as crate::const_numtraits::WrappingSub>::wrapping_sub(
@@ -777,7 +777,7 @@ c0nst::c0nst! {
             while !<Self as crate::const_numtraits::Zero>::is_zero(&remaining) {
                 let lowest = <Self as crate::const_numtraits::IsolateLowestOne>::isolate_lowest_one(remaining);
                 if !<Self as crate::const_numtraits::Zero>::is_zero(&(self & lowest)) {
-                    result = result | bb;
+                    result |= bb;
                 }
                 remaining = remaining & <Self as crate::const_numtraits::WrappingSub>::wrapping_sub(
                     remaining,
@@ -841,6 +841,9 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedShr for 
 }
 
 #[cfg(test)]
+// Coverage tests deliberately exercise every ref/value combination of
+// the bitwise/shift operators (see `test_*_combinations`).
+#[allow(clippy::op_ref)]
 mod tests {
     use super::*;
 
@@ -1269,6 +1272,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn test_ref_receivers_compile_through() {
         use crate::const_numtraits::{
             BitWidth, IsolateHighestOne, IsolateLowestOne, ShlExact, ShrExact,

--- a/src/fixeduint/byte_conversion_panic_free.rs
+++ b/src/fixeduint/byte_conversion_panic_free.rs
@@ -12,83 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Fixed-size byte conversion: typed buffers + compile-time size check.
+//! Fixed-size byte conversion: typed buffers, compile-time size check.
 //!
-//! These are the *API-boundary panic-free* counterparts to the existing
-//! slice-based `FixedUInt::{to,from}_{le,be}_bytes`. The shape change is
-//! the buffer parameter: instead of an untyped `&[u8]` / `&mut [u8]`
-//! that returns `Result<_, bool>` (and forces a `.unwrap()` site at every
-//! call site, which synthesises `panic_fmt`), the fixed variants take a
-//! typed `&[u8; M]` / `&mut [u8; M]` and verify `M >= BYTE_WIDTH` at
-//! monomorphization via an `AssertBufferFits<M>` associated-const
-//! assertion. Wrong-size callers fail at compile time with a clear
-//! diagnostic.
+//! Panic-free-signature counterparts to the slice-based
+//! `FixedUInt::{to,from}_{le,be}_bytes`. Take `&[u8; M]` / `&mut [u8; M]`
+//! and verify `M >= BYTE_WIDTH` at monomorphization; wrong-size callers
+//! fail at compile time. The signature guarantee is "no `Result`, no
+//! `.unwrap()` at the boundary" — not "no `panic_fmt` in the linked
+//! binary": `copy_from_slice` still carries a length check LLVM can't
+//! elide through the trait boundary.
 //!
-//! ## API contract: "no panic at the API boundary"
-//!
-//! These methods have no `Result`, no `.unwrap()`, no runtime length
-//! validation in their *signatures*. That is the contract. They are
-//! **not** "no `panic_fmt` survives DCE in the linked binary."
-//!
-//! A `cargo nm --release --target thumbv7em-none-eabi` audit
-//! (`ct-verify/panic-free-audit`) confirms the produced `.a` still
-//! contains:
-//!
-//! - `core::slice::copy_from_slice_impl::len_mismatch_fail`
-//! - `core::panicking::panic_fmt`
-//!
-//! Origin: the `to_*` bodies do
-//! `chunk.copy_from_slice(word.to_le_bytes().as_ref())`. Both sides of
-//! the copy have length `WORD_SIZE` by construction, but LLVM cannot
-//! statically equate them — they're opaque trait-associated lengths it
-//! treats as runtime values, so it cannot elide
-//! `slice::copy_from_slice`'s internal length-mismatch check, which
-//! ultimately calls `panic_fmt`.
-//!
-//! A `core::ptr::copy_nonoverlapping` with a SAFETY proof would
-//! eliminate this — but the crate's `use-unsafe` feature is scoped
-//! specifically to the ToBytes/FromBytes `BytesHolder` path where
-//! const-generics had no other option, not as a general license, so
-//! that fix is not adopted here. The crate-local trade-off is to keep
-//! safe Rust and document the residual `panic_fmt` honestly.
-//!
-//! Downstream consumers that need the linked binary to be fully panic-
-//! clean (e.g. `ed25519_heapless`'s AVR linkage gate) cannot rely on
-//! these methods alone to satisfy that — the upstream
-//! `slice::copy_from_slice` body limits us. They can:
-//! 1. Wrap calls in a way that the optimizer can fold (e.g. force
-//!    inlining and provide a const `WORD_SIZE` constant the optimizer
-//!    can see through), or
-//! 2. Maintain a downstream `unsafe { ptr::copy_nonoverlapping }`
-//!    shim of their own keyed to their specific instantiations, or
-//! 3. Wait for upstream `slice::copy_from_slice` to learn const-elision
-//!    of the length check (unlikely soon).
-//!
-//! ## Body cleanliness
-//!
-//! `to_*` uses `chunks_exact_mut(WORD_SIZE).take(N)` paired against
-//! `self.array.iter()` (rev for BE). Each chunk has length `WORD_SIZE`
-//! by `chunks_exact_mut`'s contract, the primitive's `to_*_bytes`
-//! returns `[u8; size_of::<T>()]`, and `WORD_SIZE = size_of::<T>()` —
-//! so the copy is length-equal by construction, but see the audit
-//! note above: LLVM can't see that through the trait, so the check
-//! survives DCE anyway.
-//!
-//! `from_*` reuses the existing `impl_from_{le,be}_bytes_slice` helpers
-//! which loop on `min(bytes.len(), capacity)` — when we pass a buffer
-//! with `M >= BYTE_WIDTH` the loop bound is exactly `BYTE_WIDTH` and
-//! every indexed access is in range.
-//!
-//! ## Truncation convention for `from_*` with `M > BYTE_WIDTH`
-//!
-//! Mirrors the existing slice-based methods:
-//! - `from_le_bytes_fixed` reads the first `BYTE_WIDTH` bytes (LE
-//!   low-order bytes are at the front).
-//! - `from_be_bytes_fixed` reads the last `BYTE_WIDTH` bytes (BE
-//!   low-order bytes are at the end).
-//!
-//! Equal-size buffers (`M == BYTE_WIDTH`) are the common case and read
-//! identically in either convention.
+//! Truncation convention when `M > BYTE_WIDTH` matches the slice-based
+//! methods: LE reads the first `BYTE_WIDTH` bytes, BE reads the last.
+
+// `let _ = <T as AssertBufferFits<M>>::CHECK;` forces the const to
+// evaluate at monomorphization; a bare path-statement isn't a reliable
+// substitute across rustc versions.
+#![allow(clippy::let_unit_value)]
 
 use super::{FixedUInt, MachineWord, impl_from_be_bytes_slice, impl_from_le_bytes_slice};
 use const_num_traits::Personality;

--- a/src/fixeduint/checked_pow_impl.rs
+++ b/src/fixeduint/checked_pow_impl.rs
@@ -15,7 +15,7 @@
 //! Checked power implementation for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::{CheckedMul, CheckedPow, ConstOne, One, Zero};
+use crate::const_numtraits::{CheckedMul, CheckedPow, One};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::Nct;
 

--- a/src/fixeduint/cios_row_ops_impl.rs
+++ b/src/fixeduint/cios_row_ops_impl.rs
@@ -12,59 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! `modmath_cios::CiosRowOps` implementation for `FixedUInt`.
+//! `modmath_cios::CiosRowOps` implementation for `FixedUInt`. Gated
+//! behind the `cios` cargo feature.
 //!
-//! Gated behind the `cios` cargo feature so a default build of
-//! `fixed-bigint` does not pull `modmath-cios` in. Enabled by downstream
-//! crates that want to drive CIOS-style Montgomery multiplication
-//! through `modmath`'s algorithm body (which deps `modmath-cios` and
-//! is generic over `CiosRowOps`).
-//!
-//! ## Why the trait lives in `modmath-cios` (a leaf crate)
-//!
-//! An earlier iteration (commit `af832a9`) put `CiosRowOps` in
-//! `modmath` itself with `modmath` dev-deping `fixed-bigint` to test
-//! the `FixedUInt` impl. That doesn't work: `cargo test` compiles
-//! `modmath` twice — once normally (the library `fixed-bigint` links
-//! against through its `modmath` dep) and once with `--test` (the
-//! `modmath` test binary). Same source, two distinct metadata hashes,
-//! two distinct `CiosRowOps` identities. The impl satisfies one;
-//! `modmath`'s own tests reference the other. The bound never
-//! resolves. Cargo-level dedup ≠ rustc-level dedup. See
-//! `CIOS_TRAIT_MOVED.md`.
-//!
-//! Moving the trait to its own leaf crate (`modmath-cios`, no deps,
-//! `#![no_std]`) closes the duplication: both `modmath` (in both
-//! normal and `--test` mode) and `fixed-bigint` see exactly one
-//! `modmath_cios::CiosRowOps`.
-//!
-//! `modmath` does not re-export `CiosRowOps`. Consumers import from
-//! `modmath_cios` directly (per the maintainer's "API moved, path
-//! moves with it" policy — no compatibility shim).
-//!
-//! ## One impl, both personalities
-//!
-//! `CiosRowOps`'s trait contract documents that the `word(&self, i)`
-//! accessor is only ever called with a public `i < self.word_count()`.
-//! Under that precondition, infallible direct indexing is CT-safe — `i`
-//! is never operand-dependent, so the bounds check doesn't leak. There
-//! is no `Nct`/`Ct` discriminant on this trait (unlike the retired
-//! `MulAccOps`, whose `GetWordOutput = Option<T>` / `CtOption<T>` split
-//! was the personality marker). So one impl block covers both.
-//!
-//! ## Replaces `MulAccOps`
-//!
-//! `fixed_bigint::MulAccOps` and its impls are deleted in the same
-//! commit. The two row kernels are byte-identical (same loop, same
-//! `CarryingMul::carrying_mul_add` calls, same overflow handling); only
-//! the trait shape changed. The two callsite-visible breaks vs
-//! `MulAccOps`:
-//!
-//! - `fn word_count() -> usize` → `fn word_count(&self) -> usize`.
-//!   Instance method now, admits heap bigint backends.
-//! - `fn get_word(&self, i) -> Self::GetWordOutput` → `fn word(&self, i)
-//!   -> Self::Word`. Infallible; the personality-discriminant
-//!   associated type is gone.
+//! One impl block covers both personalities: `word(&self, i)`'s trait
+//! contract guarantees `i` is public and in-range, so infallible
+//! indexing doesn't leak — no `Nct`/`Ct` split needed on the accessor.
 
 #![cfg(feature = "cios")]
 
@@ -83,22 +36,15 @@ where
         N
     }
 
-    /// Panic-free, CT-safe under the trait precondition (`i` is public,
-    /// `i < N`). `array.get(i).copied().unwrap_or(ZERO)` instead of
-    /// `array[i]` — the `unwrap_or` fallback is dead code at the
-    /// algorithm level (the trait contract forbids an out-of-bounds
-    /// `i`), but the safe-slice form keeps `panic_bounds_check` out of
-    /// the linked binary. Same body for both personalities: `i` is
-    /// public, the bounds check is value-independent.
+    /// `get().unwrap_or(ZERO)` rather than `array[i]` so no
+    /// `panic_bounds_check` reaches the linked binary. Fallback is
+    /// unreachable per the trait's public-`i < N` precondition.
     #[inline]
     fn word(&self, i: usize) -> T {
         self.array.get(i).copied().unwrap_or(<T as ConstZero>::ZERO)
     }
 
-    /// Phase 1 row: `acc += scalar * multiplicand`. Returns the
-    /// carry-out word.
-    ///
-    /// Byte-identical body to the retired `MulAccOps::mul_acc_row`.
+    /// `acc += scalar * multiplicand`. Returns the carry-out word.
     fn mul_acc_row(scalar: T, multiplicand: &Self, acc: &mut Self, carry_in: T) -> T {
         let mut carry = carry_in;
         let mut j = 0;
@@ -112,11 +58,8 @@ where
         carry
     }
 
-    /// Phase 2 row: `[acc, acc_hi] = ([acc, acc_hi] + scalar *
-    /// multiplicand) >> word_bits`. Returns the carry word (0 or 1)
-    /// from the fold.
-    ///
-    /// Byte-identical body to the retired `MulAccOps::mul_acc_shift_row`.
+    /// `[acc, acc_hi] = ([acc, acc_hi] + scalar * multiplicand) >>
+    /// word_bits`. Returns the carry word (0 or 1) from the fold.
     fn mul_acc_shift_row(scalar: T, multiplicand: &Self, acc: &mut Self, acc_hi: T) -> T {
         debug_assert!(N > 0, "CiosRowOps requires at least one word");
         // First word: discarded (zero by CIOS construction).

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -35,33 +35,35 @@ pub struct ConstBytesHolder<const SIZE: usize> {
     bytes: [u8; SIZE],
 }
 
-impl<const SIZE: usize> const Default for ConstBytesHolder<SIZE> {
-    fn default() -> Self {
-        Self { bytes: [0u8; SIZE] }
+c0nst::c0nst! {
+    c0nst impl<const SIZE: usize> Default for ConstBytesHolder<SIZE> {
+        fn default() -> Self {
+            Self { bytes: [0u8; SIZE] }
+        }
     }
-}
 
-impl<const SIZE: usize> const From<[u8; SIZE]> for ConstBytesHolder<SIZE> {
-    fn from(bytes: [u8; SIZE]) -> Self {
-        Self { bytes }
+    c0nst impl<const SIZE: usize> From<[u8; SIZE]> for ConstBytesHolder<SIZE> {
+        fn from(bytes: [u8; SIZE]) -> Self {
+            Self { bytes }
+        }
     }
-}
 
-impl<const SIZE: usize> const From<ConstBytesHolder<SIZE>> for [u8; SIZE] {
-    fn from(holder: ConstBytesHolder<SIZE>) -> Self {
-        holder.bytes
+    c0nst impl<const SIZE: usize> From<ConstBytesHolder<SIZE>> for [u8; SIZE] {
+        fn from(holder: ConstBytesHolder<SIZE>) -> Self {
+            holder.bytes
+        }
     }
-}
 
-impl<const SIZE: usize> const AsRef<[u8]> for ConstBytesHolder<SIZE> {
-    fn as_ref(&self) -> &[u8] {
-        &self.bytes
+    c0nst impl<const SIZE: usize> AsRef<[u8]> for ConstBytesHolder<SIZE> {
+        fn as_ref(&self) -> &[u8] {
+            &self.bytes
+        }
     }
-}
 
-impl<const SIZE: usize> const AsMut<[u8]> for ConstBytesHolder<SIZE> {
-    fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.bytes
+    c0nst impl<const SIZE: usize> AsMut<[u8]> for ConstBytesHolder<SIZE> {
+        fn as_mut(&mut self) -> &mut [u8] {
+            &mut self.bytes
+        }
     }
 }
 

--- a/src/fixeduint/div_ceil_impl.rs
+++ b/src/fixeduint/div_ceil_impl.rs
@@ -15,7 +15,7 @@
 //! Ceiling division for FixedUInt.
 
 use super::{FixedUInt, MachineWord, const_div, const_is_zero};
-use crate::const_numtraits::{CheckedAdd, ConstOne, DivCeil, One, Zero};
+use crate::const_numtraits::{CheckedAdd, DivCeil, One};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::Nct;
 

--- a/src/fixeduint/euclid.rs
+++ b/src/fixeduint/euclid.rs
@@ -1,5 +1,5 @@
 use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::{CheckedEuclid, ConstZero, Euclid, One, Zero};
+use crate::const_numtraits::{CheckedEuclid, Euclid, Zero};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::Nct;
 

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -18,9 +18,7 @@
 //! multiplication, useful for implementing arbitrary-precision arithmetic.
 
 use super::{FixedUInt, MachineWord, add_with_carry, sub_with_borrow};
-use crate::const_numtraits::{
-    BorrowingSub, Bounded, CarryingAdd, CarryingMul, One, WideningMul, Zero,
-};
+use crate::const_numtraits::{BorrowingSub, Bounded, CarryingAdd, CarryingMul, Zero};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::{Personality, PersonalityTag};
 

--- a/src/fixeduint/has_nonzero_impl.rs
+++ b/src/fixeduint/has_nonzero_impl.rs
@@ -14,49 +14,21 @@
 
 //! `HasNonZero` + `DivNonZero` carrier impls for `FixedUInt`.
 //!
-//! `core::num::NonZero` is sealed to primitives, so `HasNonZero::NonZero`
-//! has to be a backend-defined newtype for `FixedUInt`. The newtype
-//! ([`NonZeroFixedUInt`]) is `#[repr(transparent)]` over `FixedUInt`, so
-//! `Zeroize` or `Drop` semantics on the inner value flow through if a
-//! consumer adds them downstream.
+//! `core::num::NonZero` is sealed to primitives, so [`NonZeroFixedUInt`]
+//! is the `HasNonZero::NonZero` newtype for `FixedUInt`; it is
+//! `#[repr(transparent)]` over the inner value.
 //!
-//! ## Personality matrix
+//! `HasNonZero` covers both personalities (the `!= 0` check is
+//! value-level and CT-uniform). `DivNonZero` is `Nct`-only, matching
+//! `FixedUInt`'s own `Div`: long division is value-dependent and does
+//! not fit constant-time semantics.
 //!
-//! - `HasNonZero for FixedUInt<T, N, P>` — both personalities. The
-//!   `!= 0` check is value-level and CT-uniform.
-//! - `DivNonZero for FixedUInt<T, N, Nct>` — Nct only. `FixedUInt`'s
-//!   `core::ops::Div` is `Nct`-only because long division is
-//!   value-dependent and doesn't fit constant-time semantics. Consumers
-//!   with secret moduli should route through `modmath::Field<T, Ct>`
-//!   (Montgomery, no division), constructed via `Odd::new_ct` or
-//!   `Field::try_new_odd_ct`. There is no `*_nz_ct` because there is no
-//!   meaningful CT consumer for one.
-//!
-//! ## API-boundary panic contract
-//!
-//! `div_nonzero` / `rem_nonzero` discharge the *type-level* divide-by-zero
-//! invariant — the divisor proof guarantees `d != 0`, so the caller's
-//! `Result`/`unwrap` site goes away.
-//!
-//! **Audit-verified:** `cargo nm --release --target thumbv7em-none-eabi`
-//! shows the underlying `FixedUInt::Div`'s runtime zero check is elided
-//! through the `NonZeroFixedUInt` wrapper. A `div_nonzero(a, nz)`
-//! fixture produces no `panic_fmt` symbol; a bare `a / b` fixture does.
-//! The wrapper successfully proves the check unreachable. See
-//! `CHANGELOG.md` for the full isolation ladder.
-//!
-//! ## CT note on `into_nonzero`
-//!
-//! `into_nonzero(self) -> Option<Self::NonZero>` is branchful at the
-//! call site (the caller's `match Some/None` on the discriminant). For
-//! public moduli — the common case for `*_nz` — that's fine and
-//! intended. For secret-derived non-zero proofs, callers should use a
-//! `CtOption`-returning sibling if/when one ships; `modmath::Field<T,
-//! Ct>::try_new_odd_ct` already exists for the modular-arithmetic
-//! consumer site.
+//! `into_nonzero` returns `Option`, which is branchful at the call
+//! site. Fine for public moduli; secret-derived proofs need a
+//! `CtOption`-returning path that lives above this crate.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::{ConstZero, Zero};
+use crate::const_numtraits::Zero;
 use crate::machineword::ConstMachineWord;
 use const_num_traits::{DivNonZero, HasNonZero, Nct, Personality};
 

--- a/src/fixeduint/ilog_impl.rs
+++ b/src/fixeduint/ilog_impl.rs
@@ -15,7 +15,7 @@
 //! Integer logarithm implementations for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::{ConstZero, Ilog, Ilog2, Ilog10, One, PrimBits, Zero};
+use crate::const_numtraits::{Ilog, Ilog2, Ilog10, PrimBits, Zero};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::Nct;
 

--- a/src/fixeduint/isqrt_impl.rs
+++ b/src/fixeduint/isqrt_impl.rs
@@ -15,7 +15,7 @@
 //! Integer square root for FixedUInt.
 
 use super::{FixedUInt, MachineWord, const_set_bit};
-use crate::const_numtraits::{ConstZero, Isqrt, One, PrimBits, Zero};
+use crate::const_numtraits::{Isqrt, PrimBits, Zero};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::Nct;
 

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -2,8 +2,7 @@ use super::{
     FixedUInt, MachineWord, PanicReason, const_ct_select, const_div_rem, const_mul, maybe_panic_if,
 };
 use crate::const_numtraits::{
-    Bounded, CheckedDiv, CheckedMul, CheckedRem, ConstZero, One, OverflowingMul, SaturatingMul,
-    WrappingMul, Zero,
+    Bounded, CheckedDiv, CheckedMul, CheckedRem, OverflowingMul, SaturatingMul, WrappingMul, Zero,
 };
 use crate::machineword::ConstMachineWord;
 use const_num_traits::{Nct, Personality, PersonalityTag};
@@ -363,6 +362,9 @@ where
 }
 
 #[cfg(test)]
+// Coverage tests deliberately exercise every ref/value combination of
+// `Mul`/`Div` (see `test_*_combinations`).
+#[allow(clippy::op_ref)]
 mod tests {
     use super::*;
 

--- a/src/fixeduint/multiple_impl.rs
+++ b/src/fixeduint/multiple_impl.rs
@@ -15,7 +15,7 @@
 //! Multiple-of operations for FixedUInt.
 
 use super::{FixedUInt, MachineWord};
-use crate::const_numtraits::{CheckedAdd, ConstZero, MultipleOf, NextMultipleOf, One, Zero};
+use crate::const_numtraits::{CheckedAdd, MultipleOf, NextMultipleOf, Zero};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::Nct;
 

--- a/src/fixeduint/parity_impl.rs
+++ b/src/fixeduint/parity_impl.rs
@@ -111,6 +111,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
     fn parity_ref() {
         let v = U16Nct::from(7u8);
         assert!(Parity::is_odd(&v));
@@ -196,11 +197,8 @@ mod tests {
         }
     }
 
-    /// Phase-0 deliverable: `Odd::<FixedUInt<_, _, Ct>>::new_ct(n)` round-trips.
-    /// This is the contract the request quoted from the modmath agent's
-    /// plan ("verify `Field::<FixedUInt, Ct>::try_new_odd_ct(n)`
-    /// round-trips"); on this side we exercise the upstream construction
-    /// path that `Field::try_new_odd_ct` will call into.
+    /// `Odd::<FixedUInt<_, _, Ct>>::new_ct(n)` round-trips — exercises the
+    /// upstream typestate construction path on the Ct personality.
     #[test]
     fn odd_new_ct_round_trips_for_ct_carrier() {
         use const_num_traits::Odd;

--- a/src/fixeduint/power_of_two_ops_impl.rs
+++ b/src/fixeduint/power_of_two_ops_impl.rs
@@ -15,50 +15,21 @@
 //! `PowerOfTwoOps` for `FixedUInt`, plus the round-trip helper
 //! [`FixedUInt::from_power_of_two`].
 //!
-//! Construction of the typestate proof is **not** in this file. The
-//! safe generic constructor `PowerOfTwo::new_checked` lives in
-//! `const-num-traits` and is bounded on `T: IsPowerOfTwo + PrimBits`,
-//! both of which `FixedUInt` implements — so callers construct via
+//! Construct the `PowerOfTwo<FixedUInt<...>>` proof via the upstream
+//! safe constructor `PowerOfTwo::new_checked` (in `const-num-traits`,
+//! bounded on `T: IsPowerOfTwo + PrimBits`, both of which `FixedUInt`
+//! implements) — no glue on this side, no caller-side unsafe.
 //!
-//! ```ignore
-//! use const_num_traits::PowerOfTwo;
-//! let p = PowerOfTwo::<FixedUInt<u8, 2>>::new_checked(value);
-//! ```
+//! One impl block covers both personalities: every body is a shift, a
+//! mask, or an addition, so there is no `match P::TAG`.
+//! `next_multiple_of_pow2` inherits the `+` semantic (panic under Nct,
+//! wrap under Ct); untrusted inputs should use
+//! `checked_next_multiple_of_pow2`.
 //!
-//! without any glue method on this side and without any caller-side
-//! unsafe. This file existed in an earlier shape (commit `143e4c5`)
-//! that wrapped the upstream `unsafe const fn from_exp_unchecked`
-//! constructor inside a `FixedUInt::as_power_of_two` method; that
-//! shape was reverted because the crate's `use-unsafe` feature is
-//! scoped narrowly to the `BytesHolder` byte-cast path and not a
-//! general license. Upstream `new_checked` (const-num-traits PR #7,
-//! commit `410cfac`) made the unsafe unnecessary by recovering the
-//! exponent from `PrimBits::leading_zeros` + `T::ZERO.count_zeros()`
-//! — both available on `FixedUInt`.
-//!
-//! ## Consuming ops
-//!
-//! The five `PowerOfTwoOps` methods (`div_pow2`, `rem_pow2`,
-//! `is_multiple_of_pow2`, `next_multiple_of_pow2`,
-//! `checked_next_multiple_of_pow2`) are implemented uniformly across
-//! both personalities — every body is a shift, a mask, or an addition
-//! with no value-dependent branch, so there is no `match P::TAG`
-//! dispatch and `Ct` / `Nct` collapse to the same code.
-//!
-//! `next_multiple_of_pow2` inherits the personality-specific `+`
-//! semantic (panic-on-overflow under `Nct`, wrap under `Ct`).
-//! Untrusted-input callers should use `checked_next_multiple_of_pow2`
-//! instead — it's the explicit no-panic sibling.
-//!
-//! ## No `impl PowerOfTwoOps for &FixedUInt<...>`
-//!
-//! The trait fixes `p: PowerOfTwo<Self>`, so for `Self = &FixedUInt<...>`
-//! the parameter would have to be `PowerOfTwo<&FixedUInt<...>>` — a
-//! distinct type from `PowerOfTwo<FixedUInt<...>>` despite carrying
-//! the same `u32` inside. Forcing callers to manufacture a separate
-//! proof for the borrowed shape adds noise without saving anything,
-//! since `FixedUInt: Copy` makes deref free. Use
-//! `PowerOfTwoOps::div_pow2(*v, p)` or `(*v).div_pow2(p)`.
+//! There is no `impl PowerOfTwoOps for &FixedUInt<...>`: the trait
+//! fixes `p: PowerOfTwo<Self>`, so `&FixedUInt<...>` would need a
+//! separate proof-typed parameter. `FixedUInt: Copy` makes deref free;
+//! use `PowerOfTwoOps::div_pow2(*v, p)`.
 
 use super::{FixedUInt, MachineWord};
 use crate::const_numtraits::{CheckedAdd, ConstOne, One, Zero};

--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -2,7 +2,9 @@ use super::{
     FixedUInt, MachineWord, const_leading_zeros, const_leading_zeros_ct, const_trailing_zeros,
     const_trailing_zeros_ct,
 };
-use crate::const_numtraits::{One, PrimBits, PrimInt, Zero};
+#[cfg(feature = "num-traits")]
+use crate::const_numtraits::One;
+use crate::const_numtraits::PrimBits;
 use crate::machineword::ConstMachineWord;
 use const_num_traits::{Nct, Personality, PersonalityTag};
 

--- a/src/fixeduint/roots_impl.rs
+++ b/src/fixeduint/roots_impl.rs
@@ -2,7 +2,7 @@ use crate::fixeduint::FixedUInt;
 use crate::machineword::MachineWord;
 use const_num_traits::Nct;
 use num_integer::Roots;
-use num_traits::{FromPrimitive, One, PrimInt, Zero};
+use num_traits::{FromPrimitive, One, Zero};
 
 impl<T: MachineWord, const N: usize> Roots for FixedUInt<T, N, Nct> {
     fn nth_root(&self, n: u32) -> Self {
@@ -70,7 +70,7 @@ impl<T: MachineWord, const N: usize> Roots for FixedUInt<T, N, Nct> {
 mod tests {
     use super::*;
     use num_integer::Roots;
-    use num_traits::{One, PrimInt};
+    use num_traits::One;
 
     #[test]
     fn test_sqrt_basic() {

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -108,9 +108,8 @@ impl<T: MachineWord, const N: usize> Drop for BytesHolder<T, N> {
 // ── num_traits::ToBytes/FromBytes (upstream by-ref shape) ────────────
 //
 // Only built when `feature = "num-traits"` is enabled; downstream
-// consumers that have dropped num-traits entirely (e.g. ed25519 /
-// rsa with `default-features = false, features = ["use-unsafe"]`)
-// don't need or want these impls.
+// consumers that have dropped num-traits don't need or want these
+// impls.
 
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize, P: Personality> num_traits::ToBytes for FixedUInt<T, N, P>

--- a/src/machineword.rs
+++ b/src/machineword.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Note: in the future, #![feature(const_trait_impl)] should allow
-// turning this into a const trait
-
 pub use crate::const_numtraits::PrimInt;
 use crate::const_numtraits::{
     BorrowingSub, CarryingAdd, OverflowingAdd, OverflowingSub, ToBytes, WideningMul,

--- a/tests/add_subtract.rs
+++ b/tests/add_subtract.rs
@@ -86,6 +86,10 @@ fn test_add_variants() {
 
 #[test]
 fn test_subtract() {
+    // `REF` labels each call site with the native primitive whose subtract
+    // behavior the `INT` under test should mirror; parallel to
+    // `test_add_variant`'s `REF` even though the body here doesn't touch it.
+    #[allow(clippy::extra_unused_type_parameters)]
     fn test_subtract_variant<
         INT: num_traits::PrimInt
             + num_traits::ops::overflowing::OverflowingSub

--- a/tests/bit_shift.rs
+++ b/tests/bit_shift.rs
@@ -265,7 +265,7 @@ fn test_rotate() {
         assert_eq!(b.rotate_right(full_shift), b);
 
         // Rotations larger than the bit width should wrap around
-        let bit_width = INT::BIT_SIZE as u32;
+        let bit_width = INT::BIT_SIZE;
         let overflow_shift = full_shift + 5;
         let expected_left = a.rotate_left(overflow_shift % bit_width);
         assert_eq!(a.rotate_left(overflow_shift), expected_left);

--- a/tests/integer.rs
+++ b/tests/integer.rs
@@ -39,6 +39,9 @@ fn test_evenodd() {
 
 #[test]
 fn test_divides() {
+    // TODO: body only exercises u8; the `T` param and the `<FixedUInt<...>>`
+    // call sites below don't actually reach the assertions.
+    #[allow(clippy::extra_unused_type_parameters)]
     fn divides<T: num_integer::Integer + From<u8>>() {
         let tests = [(6u8, 3u8, true), (8, 2, true), (8, 1, true), (17, 2, false)];
         for &(multiple, multiplier, expected) in &tests {
@@ -75,6 +78,8 @@ fn test_divides() {
 // TODO: Test GCD / LCM
 #[test]
 fn test_gcd_lcm() {
+    // Same shape as `divides`: body only exercises u8.
+    #[allow(clippy::extra_unused_type_parameters)]
     fn gcd_lcm<T: num_integer::Integer + From<u8>>() {
         let gcd_tests = [
             (8u8, 12u8, 4u8),

--- a/tests/integer.rs
+++ b/tests/integer.rs
@@ -39,16 +39,11 @@ fn test_evenodd() {
 
 #[test]
 fn test_divides() {
-    // TODO: body only exercises u8; the `T` param and the `<FixedUInt<...>>`
-    // call sites below don't actually reach the assertions.
-    #[allow(clippy::extra_unused_type_parameters)]
     fn divides<T: num_integer::Integer + From<u8>>() {
         let tests = [(6u8, 3u8, true), (8, 2, true), (8, 1, true), (17, 2, false)];
         for &(multiple, multiplier, expected) in &tests {
-            assert_eq!(
-                num_integer::Integer::is_multiple_of(&multiple, &multiplier),
-                expected
-            );
+            let multiple = T::from(multiple);
+            let multiplier = T::from(multiplier);
             assert_eq!(
                 num_integer::Integer::is_multiple_of(&multiple, &multiplier),
                 expected
@@ -61,12 +56,22 @@ fn test_divides() {
             (89, 13, 6, 11),
         ];
         for &(multiple, divider, div, rem) in &divrem {
+            let multiple = T::from(multiple);
+            let divider = T::from(divider);
+            let div = T::from(div);
+            let rem = T::from(rem);
             let (divres, remres) = multiple.div_rem(&divider);
-            assert_eq!(divres, div);
-            assert_eq!(remres, rem);
+            assert!(divres == div, "div_rem: unexpected quotient");
+            assert!(remres == rem, "div_rem: unexpected remainder");
 
-            assert_eq!(num_integer::Integer::div_floor(&multiple, &divider), divres);
-            assert_eq!(num_integer::Integer::mod_floor(&multiple, &divider), remres);
+            assert!(
+                num_integer::Integer::div_floor(&multiple, &divider) == divres,
+                "div_floor disagrees with div_rem"
+            );
+            assert!(
+                num_integer::Integer::mod_floor(&multiple, &divider) == remres,
+                "mod_floor disagrees with div_rem"
+            );
         }
     }
     divides::<u8>();
@@ -78,8 +83,6 @@ fn test_divides() {
 // TODO: Test GCD / LCM
 #[test]
 fn test_gcd_lcm() {
-    // Same shape as `divides`: body only exercises u8.
-    #[allow(clippy::extra_unused_type_parameters)]
     fn gcd_lcm<T: num_integer::Integer + From<u8>>() {
         let gcd_tests = [
             (8u8, 12u8, 4u8),
@@ -89,7 +92,10 @@ fn test_gcd_lcm() {
             (99, 90, 9),
         ];
         for &(a, b, expected) in &gcd_tests {
-            assert_eq!(a.gcd(&b), expected);
+            let a = T::from(a);
+            let b = T::from(b);
+            let expected = T::from(expected);
+            assert!(a.gcd(&b) == expected);
         }
         let lcm_tests = [
             (10u8, 2u8, 10u8),
@@ -100,7 +106,10 @@ fn test_gcd_lcm() {
             (255, 255, 255),
         ];
         for &(a, b, expected) in &lcm_tests {
-            assert_eq!(a.lcm(&b), expected);
+            let a = T::from(a);
+            let b = T::from(b);
+            let expected = T::from(expected);
+            assert!(a.lcm(&b) == expected);
         }
     }
     gcd_lcm::<u8>();

--- a/tests/iter_test.rs
+++ b/tests/iter_test.rs
@@ -5,7 +5,7 @@ fn test_sum() {
     type TestInt = FixedUInt<u32, 2>;
 
     // Test sum of values
-    let values = vec![
+    let values = [
         TestInt::from(1u8),
         TestInt::from(2u8),
         TestInt::from(3u8),
@@ -31,7 +31,7 @@ fn test_product() {
     type TestInt = FixedUInt<u32, 2>;
 
     // Test product of values
-    let values = vec![TestInt::from(2u8), TestInt::from(3u8), TestInt::from(4u8)];
+    let values = [TestInt::from(2u8), TestInt::from(3u8), TestInt::from(4u8)];
 
     let product: TestInt = values.iter().cloned().product();
     assert_eq!(product, TestInt::from(24u8));
@@ -50,7 +50,7 @@ fn test_product() {
 fn test_sum_large_numbers() {
     type TestInt = FixedUInt<u64, 2>;
 
-    let values = vec![
+    let values = [
         TestInt::from(1000000u32),
         TestInt::from(2000000u32),
         TestInt::from(3000000u32),
@@ -64,7 +64,7 @@ fn test_sum_large_numbers() {
 fn test_product_large_numbers() {
     type TestInt = FixedUInt<u64, 2>;
 
-    let values = vec![
+    let values = [
         TestInt::from(10u8),
         TestInt::from(20u8),
         TestInt::from(30u8),
@@ -82,7 +82,7 @@ fn test_sum_different_types() {
     type TestInt8 = FixedUInt<u8, 4>;
     type TestInt16 = FixedUInt<u16, 2>;
 
-    let values8 = vec![
+    let values8 = [
         TestInt8::from(10u8),
         TestInt8::from(20u8),
         TestInt8::from(30u8),
@@ -90,7 +90,7 @@ fn test_sum_different_types() {
     let sum8: TestInt8 = values8.iter().cloned().sum();
     assert_eq!(sum8, TestInt8::from(60u8));
 
-    let values16 = vec![
+    let values16 = [
         TestInt16::from(100u8),
         TestInt16::from(200u8),
         TestInt16::from(255u8),
@@ -103,7 +103,7 @@ fn test_sum_different_types() {
 fn test_chained_operations() {
     type TestInt = FixedUInt<u32, 2>;
 
-    let values = vec![
+    let values = [
         TestInt::from(1u8),
         TestInt::from(2u8),
         TestInt::from(3u8),

--- a/tests/mul_div.rs
+++ b/tests/mul_div.rs
@@ -265,12 +265,13 @@ fn test_overflowing_mul() {
 
 #[test]
 fn test_key_range_mul() {
-    fn test_key_values<
-        REF: num_traits::PrimInt + num_traits::ops::overflowing::OverflowingMul + core::fmt::Debug,
-        INT: num_traits::PrimInt + num_traits::ops::overflowing::OverflowingMul + core::fmt::Debug,
-    >()
+    fn test_key_values<REF, INT>()
     where
-        INT: core::convert::From<REF>,
+        REF: num_traits::PrimInt + num_traits::ops::overflowing::OverflowingMul + core::fmt::Debug,
+        INT: num_traits::PrimInt
+            + num_traits::ops::overflowing::OverflowingMul
+            + core::fmt::Debug
+            + core::convert::From<REF>,
     {
         // Generate key test values: edge cases and some representative samples
         let mut test_values = Vec::new();

--- a/tests/odd_even_typestate.rs
+++ b/tests/odd_even_typestate.rs
@@ -13,12 +13,11 @@
 //! test that proves it (and freezes the composition against future
 //! regressions in either crate).
 //!
-//! Why this matters: downstream modmath wants
-//! `Field::from_odd_modulus(odd: Odd<T>) -> Self` as the infallible
-//! constructor that replaces `Field::new(p).unwrap()` — see
-//! `modmath-rs/PANIC_FREE_REQUESTS.md`. The unlock is on the modmath side;
-//! this test only certifies that the *upstream* typestate composes with
-//! our type, which is the prerequisite.
+//! Downstream consumers use `Odd<T>` as a proof witness to build
+//! infallible constructors (`fn new(odd: Odd<T>) -> Self`) that
+//! replace `Foo::new(p).unwrap()`; this test only certifies that the
+//! *upstream* typestate composes with our type, which is the
+//! prerequisite.
 
 use const_num_traits::{Even, Odd};
 use fixed_bigint::FixedUInt;
@@ -113,9 +112,9 @@ fn ct_personality_composes_too() {
 
 /// Sanity-shaped consumer: a generic function that *requires* an
 /// `Odd<FixedUInt>` proof. The point is to demonstrate the call-site
-/// pattern downstream consumers (modmath) will use to express
-/// "this constructor cannot fail at runtime."
-fn requires_odd<T: Copy, const N: usize, P: const_num_traits::Personality>(
+/// pattern downstream consumers use to express "this constructor
+/// cannot fail at runtime."
+fn requires_odd<T, const N: usize, P: const_num_traits::Personality>(
     _proof: Odd<FixedUInt<T, N, P>>,
 ) -> &'static str
 where

--- a/tests/personality_integration.rs
+++ b/tests/personality_integration.rs
@@ -162,7 +162,7 @@ fn ct_variant_supports_eq_via_partialeq() {
 
 #[test]
 fn is_zero_works_correctly_under_both_personalities() {
-    use fixed_bigint::const_numtraits::{ConstZero, Zero};
+    use fixed_bigint::const_numtraits::Zero;
 
     let z_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0u8);
     let nz_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(42u8);
@@ -187,7 +187,7 @@ fn is_zero_works_correctly_under_both_personalities() {
 
 #[test]
 fn is_one_works_correctly_under_both_personalities() {
-    use fixed_bigint::const_numtraits::{ConstOne, One};
+    use fixed_bigint::const_numtraits::One;
 
     let one_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(1u8);
     let zero_nct: FixedUInt<u8, 4, Nct> = FixedUInt::from(0u8);
@@ -463,7 +463,7 @@ fn shr_works_under_both_personalities() {
 
 #[test]
 fn is_power_of_two_works_under_both_personalities() {
-    use fixed_bigint::const_numtraits::{IsPowerOfTwo, NextPowerOfTwo};
+    use fixed_bigint::const_numtraits::IsPowerOfTwo;
 
     // Zero is not a power of two — exercises the `n == 0` short-circuit path
     // on Nct and the unconditional fallback on Ct.
@@ -777,7 +777,7 @@ fn ct_debug_redacts_limb_values() {
 
 #[test]
 fn next_power_of_two_works_under_both_personalities() {
-    use fixed_bigint::const_numtraits::{IsPowerOfTwo, NextPowerOfTwo};
+    use fixed_bigint::const_numtraits::NextPowerOfTwo;
     for (input, expected) in [
         (0u16, 1u16),
         (1, 1),
@@ -1041,7 +1041,7 @@ fn ord_on_ct_agrees_with_nct() {
 
 #[test]
 fn next_power_of_two_saturates_to_max_on_ct_overflow() {
-    use fixed_bigint::const_numtraits::{Bounded, IsPowerOfTwo, NextPowerOfTwo};
+    use fixed_bigint::const_numtraits::{Bounded, NextPowerOfTwo};
 
     // u16 type with Ct personality. Inputs whose next_power_of_two exceeds
     // u16::MAX should saturate to MAX, not silently return 0.

--- a/tests/roots.rs
+++ b/tests/roots.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "num-traits")]
 use fixed_bigint::FixedUInt;
 use num_integer::Roots;
-use num_traits::{PrimInt, ToPrimitive};
+use num_traits::ToPrimitive;
 
 #[test]
 fn test_roots_integration() {


### PR DESCRIPTION
Three logically-distinct commits landing on the experimental branch to get it into release-adjacent shape.

## Summary

- **`badf74f` Switch const-num-traits from git tag to crates.io 0.1.** Now that `const-num-traits 0.1.0` is on the registry, drop the git+tag deps in the root crate and both ct-verify subcrates (the local-path override on `panic-free-audit` also goes). Same source revision, via registry instead of a git checkout.
- **`d296839` Fix pre-commit fmt hook.** The upstream `doublify/pre-commit-rust` fmt hook shells out to `cargo fmt -- <files>`, which invokes rustfmt per-file. Per-file rustfmt has no workspace edition context — it reorders edition-2024 imports differently than `cargo fmt --all` and, on some `c0nst!`-heavy files, mis-parses the macro and writes empty output back to disk (destructive). Override to `cargo fmt --all -- --check` with `pass_filenames: false`.
- **`3e0b0fa` Cleanup pass.** Clippy hygiene across all feature combos (17 unused imports pruned, `assign_op_pattern` in c0nst impls, cfg-gating so `--no-default-features` builds warning-free, `#[allow(clippy::op_ref)]` on the deliberate operator-coverage tests, etc.). Doc trims: scrubbed downstream consumer name-drops (`modmath`, `ed25519_heapless`, etc.) from tracked prose, dropped migration-era `Phase 3c/d/…` markers, trimmed four novella-length module docs down to essentials. Net **-224 lines** of prose.

## Test plan

- [x] `cargo clippy -p fixed-bigint --lib --tests` clean across `""`, `zeroize`, `use-unsafe`, `zeroize,use-unsafe`, `zeroize,use-unsafe,cios`, `--no-default-features`
- [x] `cargo test --lib` — 187 pass
- [x] `cargo test --lib --features zeroize,use-unsafe` — 191 pass
- [x] `cargo test --tests` — 8 integration tests pass
- [x] `cargo test --doc` — 6 pass
- [x] `cargo fmt --check` clean
- [x] Pre-commit hook (post-fix) passes on the tree

## Summary by Sourcery

Align the experimental branch for release by moving const-num-traits onto the crates.io 0.1 release, tightening formatting and linting workflows, and performing a documentation and clippy hygiene pass across fixed-bigint and its ct-verify fixtures.

Enhancements:
- Tighten clippy hygiene and conditional compilation across fixed-bigint so all feature combinations (including `--no-default-features`) build warning-free, with targeted `#[allow]` annotations for intentional operator-coverage tests.
- Simplify and clarify core trait impl modules (e.g., CiosRowOps, PowerOfTwoOps, HasNonZero) by reducing narrative comments while keeping personality and panic-contract behavior documented.
- Clean up imports, generics, and minor code patterns in core logic and tests (e.g., const usage, iterator inputs, trait bounds) to reduce noise and keep the codebase aligned with current Rust and clippy expectations.

Build:
- Replace git/path const-num-traits dependencies with the published const-num-traits 0.1 crate in the main crate and ct-verify auxiliaries.

CI:
- Adjust the pre-commit Rust fmt hook to run `cargo fmt --all -- --check` without per-file arguments to match workspace formatting and avoid destructive rustfmt behavior.

Documentation:
- Trim and refocus module- and changelog-level documentation, removing downstream crate callouts and migration-phase commentary while keeping API contracts and behavior notes concise.

Tests:
- Update various tests and ct-verify fixtures to reflect the streamlined APIs and docs, including removing unused imports, simplifying helper functions, and clarifying test comments around typestate and personality coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated build and formatting setup to avoid mismatches when running code checks in pre-commit and CI.
  * Switched one dependency source to the published crate version for more reliable builds.

* **Documentation**
  * Refined changelog and inline documentation for clarity and brevity.
  * Simplified several comments and test descriptions.

* **Tests**
  * Cleaned up test code and improved Clippy compatibility without changing test behavior.

* **Chores**
  * Removed unused imports and made minor formatting/style adjustments across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->