### PR TITLE
Impl HasPersonality: project the carrier's declared personality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ resolver = "2"
 
 [patch.crates-io]
 modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.4.0-alpha.0" }
-# Temporary until const-num-traits 0.1.1 is published; drop then.
-const-num-traits = { git = "https://github.com/kaidokert/num-traits", branch = "feat/has-personality" }
 
 # Pinned release profile: deterministic codegen so a passing PR locks
 # the inspection output.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ resolver = "2"
 
 [patch.crates-io]
 modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.4.0-alpha.0" }
+# Temporary until const-num-traits 0.1.1 is published; drop then.
+const-num-traits = { git = "https://github.com/kaidokert/num-traits", branch = "feat/has-personality" }
 
 # Pinned release profile: deterministic codegen so a passing PR locks
 # the inspection output.
@@ -53,7 +55,7 @@ optional = true
 default-features = false
 
 [dependencies.const-num-traits]
-version = "0.1"
+version = "0.1.1"
 default-features = false
 features = ["ct"]
 

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -37,6 +37,7 @@ mod div_ceil_impl;
 mod euclid;
 mod extended_precision_impl;
 pub mod has_nonzero_impl;
+mod has_personality_impl;
 mod ilog_impl;
 mod isqrt_impl;
 mod iter_impl;

--- a/src/fixeduint/has_personality_impl.rs
+++ b/src/fixeduint/has_personality_impl.rs
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `HasPersonality` projection for FixedUInt: the carrier's declared
+//! personality is its type parameter, so downstream personality gates
+//! (`T: HasPersonality<P = Nct>`) resolve without naming FixedUInt.
+
+use super::{FixedUInt, MachineWord};
+use const_num_traits::{HasPersonality, Personality};
+
+impl<T: MachineWord, const N: usize, P: Personality> HasPersonality for FixedUInt<T, N, P> {
+    type P = P;
+}
+
+#[cfg(test)]
+mod tests {
+    use const_num_traits::{Ct, HasPersonality, Nct};
+
+    type U64 = crate::FixedUInt<u32, 2>;
+    type U64Ct = crate::FixedUInt<u32, 2, Ct>;
+
+    #[test]
+    fn projects_declared_personality() {
+        fn assert_nct<T: HasPersonality<P = Nct>>() {}
+        fn assert_ct<T: HasPersonality<P = Ct>>() {}
+        assert_nct::<U64>();
+        assert_ct::<U64Ct>();
+    }
+}


### PR DESCRIPTION
One generic impl: `FixedUInt<T, N, P>` projects `P` via the new `const_num_traits::HasPersonality` trait (kaidokert/num-traits#12). This lets modmath's `NonCt` gate become a blanket impl over `HasPersonality<P = Nct>` and drop its fixed-bigint dependency — the backend-agnosticism objective of the modmath 0.4.0 release.

Carries a temporary `[patch.crates-io]` entry pointing const-num-traits at the feature branch; drop it once 0.1.1 is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement personality projection for FixedUInt and update const-num-traits dependency to the HasPersonality-enabled release.

New Features:
- Expose HasPersonality for FixedUInt so downstream code can gate on its personality type parameter without referencing FixedUInt explicitly.

Enhancements:
- Add a dedicated has_personality_impl module and tests validating personality projection for FixedUInt.

Build:
- Temporarily patch const-num-traits to a feature branch and bump the dependency to version 0.1.1.