### PR TITLE
Drop MIGRATION.md cross-references

### DIFF
--- a/src/const_numtraits.rs
+++ b/src/const_numtraits.rs
@@ -1,13 +1,6 @@
-//! EXPERIMENT (branch `experiment/external-const-num-traits`):
-//!
-//! Curated re-export of the external `const-num-traits` crate. The
-//! previous in-tree `Const*` trait surface was bundled (one trait per
-//! concept); on this branch we follow the external crate's
-//! capability-split design (see `MIGRATION.md` in that crate). This
-//! module re-exports the external names so internal code can write
-//! `use crate::const_numtraits::Zero` etc. without spelling the
-//! external crate path, and downstream consumers see a stable
-//! re-export surface during the experiment.
+//! Curated re-export of the external `const-num-traits` crate.
+//! Internal code writes `use crate::const_numtraits::Zero` etc.
+//! without spelling the external crate path.
 
 #![allow(unused_imports)]
 

--- a/src/fixeduint/add_sub_impl.rs
+++ b/src/fixeduint/add_sub_impl.rs
@@ -181,15 +181,12 @@ c0nst::c0nst! {
 
     // --- Reference-receiver impls ------------------------------------------
     //
-    // MIGRATION.md §2.3 introduces the `type Output` associated type so the
-    // by-value trait surface can also be implemented for `&Self`. For Copy
-    // types like FixedUInt the body just dereferences and delegates to the
-    // owned impl above, but the ergonomic payoff is real: call sites can
-    // write `(&x).checked_add(&y)` (or call generically through a `T:
-    // CheckedAdd` bound where T is `&FixedUInt`) without sprinkling derefs
-    // through arithmetic helpers. The `Add<&FixedUInt> for &FixedUInt`
-    // impls in this file (lines 96+) supply the `Output = FixedUInt<T,N,P>`
-    // that the operator-backed supertrait expects.
+    // Mirror the by-value trait surface for `&Self` via the trait's
+    // `type Output` — for Copy carriers like FixedUInt the body just
+    // dereferences and delegates. Call sites can write
+    // `(&x).checked_add(&y)` (or use a `T: CheckedAdd` bound where T is
+    // `&FixedUInt`) without sprinkling derefs. The `Add<&FixedUInt> for
+    // &FixedUInt` impls above supply `Output = FixedUInt<T,N,P>`.
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> crate::const_numtraits::OverflowingAdd for &FixedUInt<T, N, P> {
         fn overflowing_add(self, other: Self) -> (FixedUInt<T, N, P>, bool) {

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -51,13 +51,12 @@ c0nst::c0nst! {
         if pos < N { lo[pos] = val; } else if pos < 2 * N { hi[pos - N] = val; }
     }
 
-    // `WideningMul` for FixedUInt is intentionally NOT implemented. Per
-    // MIGRATION.md §2.4, `WideningMul::Wide` is a single double-width
-    // primitive (`Wide = u16` for `u8` etc.). Arbitrary-precision /
-    // fixed-width-generic types like `FixedUInt<N>` have no
-    // `FixedUInt<2N>` to be `Wide` without `generic_const_exprs`. The
-    // schoolbook full product is exposed through `CarryingMul` below,
-    // which returns `(low, high)` natively — exactly the shape needed.
+    // `WideningMul` for FixedUInt is intentionally NOT implemented.
+    // `WideningMul::Wide` is a single double-width primitive (e.g.
+    // `Wide = u16` for `u8`); fixed-width-generic `FixedUInt<N>` has
+    // no `FixedUInt<2N>` to be `Wide` without `generic_const_exprs`.
+    // The schoolbook full product is exposed through `CarryingMul`
+    // below, which returns `(low, high)` natively.
 
     /// Schoolbook full product `self * rhs` returning the 2N-word result
     /// split into two N-word halves `(low, high)`. Private helper shared
@@ -235,9 +234,9 @@ mod tests {
         }
 
         /// Backwards-compatible test shim: returns the full `(low, high)`
-        /// product. `FixedUInt` no longer implements `WideningMul` (per
-        /// MIGRATION.md §2.4); this routes through `CarryingMul` with a
-        /// zero carry, which produces the same value.
+        /// product. `FixedUInt` no longer implements `WideningMul`; this
+        /// routes through `CarryingMul` with a zero carry, which produces
+        /// the same value.
         pub c0nst fn const_widening_mul<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality>(
             a: FixedUInt<T, N, P>,
             b: FixedUInt<T, N, P>,
@@ -584,9 +583,8 @@ mod tests {
         assert_eq!(hi, U16::from(0xFFFEu16));
 
         // Sanity: CarryingMul on FixedUInt produces deterministic results.
-        // (The original `WideningMul`-vs-`WideningMul` self-check is
-        // retired now that `FixedUInt` no longer implements `WideningMul`
-        // per MIGRATION.md §2.4.)
+        // (FixedUInt no longer implements `WideningMul`, so the earlier
+        // `WideningMul`-vs-`WideningMul` self-check doesn't apply.)
         let b = U32::from(0x1234_5678u32);
         let c = U32::from(0x9ABC_DEF0u32);
         let zero32 = <U32 as Zero>::zero();
@@ -642,11 +640,6 @@ mod tests {
     }
 
     /// Sanity check: CarryingMul is deterministic on primitives + FixedUInt.
-    ///
-    /// (Originally a "ref-based vs value-based" check that became
-    /// redundant once MIGRATION.md §2.1 unified everything to by-value,
-    /// and lost its FixedUInt half once §2.4 ruled out
-    /// `impl WideningMul for FixedUInt`.)
     #[test]
     fn test_ref_based_mul_traits() {
         assert_eq!(


### PR DESCRIPTION
Five in-code pointers to \`MIGRATION.md\` (§2.1, §2.3, §2.4) referenced a design doc that consumers of this crate don't have access to. Reworded each so the intent is described inline, or dropped the historical framing where the code no longer needs it. No behavior change.

## Sites touched

- \`src/const_numtraits.rs:6\` — module docstring pointing at MIGRATION.md's capability-split design → describe re-export purpose directly.
- \`src/fixeduint/add_sub_impl.rs:184\` — §2.3 associated-\`Output\` explanation → describe the ref-receiver pattern inline.
- \`src/fixeduint/extended_precision_impl.rs:55\` — §2.4 rationale for not-implementing \`WideningMul\` on \`FixedUInt\` → inline explanation.
- \`src/fixeduint/extended_precision_impl.rs:239\` — §2.4 mention on the test shim docstring → drop reference, keep the "shim routes through CarryingMul" fact.
- \`src/fixeduint/extended_precision_impl.rs:589, 647\` — §2.4 mentions in test-body comments → tighten to the fact that WideningMul isn't implemented.

## Test plan

- [x] \`cargo test --lib\` — 188/188
- [x] \`cargo clippy --lib --tests\` clean
- [x] \`cargo fmt --check\` clean

## Summary by Sourcery

Remove in-code references to MIGRATION.md by inlining concise explanations of trait design choices and FixedUInt multiplication behavior.

Documentation:
- Update module-level documentation for const-numtraits to describe the curated re-export surface without referencing external migration docs.

Chores:
- Clarify comments around FixedUInt reference-receiver arithmetic traits and extended-precision multiplication tests, eliminating historical MIGRATION.md cross-references.