### PR TITLE
Drop "legacy shim retired" journey comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
 /target
 Cargo.lock
 *~
-/CLAUDE.md
-/CT_VERIFY.md
-/PANIC_FREE_REQUESTS.md
-/CIOS_MIGRATION.md
-/CIOS_TRAIT_MOVED.md
-/HASNONZERO_REQUEST.md
+notes/

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -805,9 +805,6 @@ c0nst::c0nst! {
 }
 
 // num_traits wrappers - delegate to const impls
-// (OverflowingShl/OverflowingShr legacy shim impls retired — the const
-// impls above ARE the OverflowingShl/Shr impls now that we depend on
-// the external const-num-traits crate directly.)
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingShl
     for FixedUInt<T, N, P>

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -1292,7 +1292,7 @@ mod tests {
         use const_num_traits::{FunnelShl, FunnelShr};
         type U16 = FixedUInt<u8, 2>;
 
-        // 0x0180 << 1 = 0x0300 -> high half (16 bits) = 0x0003
+        // 0x0001_8000 << 1 = 0x0003_0000; high half = 0x0003.
         assert_eq!(
             FunnelShl::funnel_shl(U16::from(0x0001u16), U16::from(0x8000u16), 1),
             U16::from(0x0003u16),
@@ -1302,9 +1302,7 @@ mod tests {
             FunnelShl::funnel_shl(U16::from(0xABCDu16), U16::from(0xFFFFu16), 0),
             U16::from(0xABCDu16),
         );
-        // 0x0180 >> 1 = 0x00C0 -> low half (16 bits) = 0x00C0... wait
-        // hi=0x0001 lo=0x8000, double = 0x00018000.
-        // funnel_shr n=1 → low half of (>> 1) = 0x0001_8000 >> 1 = 0x0000_C000, low = 0xC000.
+        // 0x0001_8000 >> 1 = 0x0000_C000; low half = 0xC000.
         assert_eq!(
             FunnelShr::funnel_shr(U16::from(0x0001u16), U16::from(0x8000u16), 1),
             U16::from(0xC000u16),
@@ -1508,7 +1506,8 @@ mod tests {
             // Sanity-check a representative subset of the const results.
             assert_eq!(OSHL.0.array, [16, 0]);
             assert!(!OSHL.1);
-            assert!(OSHR.1 || !OSHR.1); // shape check; value 0x0F shifted right by 4 is 0
+            assert_eq!(OSHR.0.array, [0x0F, 0]);
+            assert!(!OSHR.1);
             assert_eq!(WSHL.array, [16, 0]);
             assert_eq!(WSHR.array, [0x0F, 0]);
             assert!(CSHL.is_none());

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -314,12 +314,9 @@ c0nst::c0nst! {
         }
     }
 
-    // Shared body for `Shl<u32>` and `UnboundedShl::unbounded_shl`.
-    // Both want the same semantics — shift by a u32 amount, with values
-    // outside [0, BIT_SIZE) collapsing to zero — and previously had
-    // parallel implementations. The Ct fix in PR #120 was applied to
-    // `unbounded_shl` but missed the `Shl<u32>` copy; centralizing here
-    // makes that class of drift impossible.
+    // Shared body for `Shl<u32>` and `UnboundedShl::unbounded_shl`:
+    // shift by a u32 amount, with values outside [0, BIT_SIZE) collapsing
+    // to zero. Centralizing keeps the two entry points in sync.
     pub(crate) c0nst fn const_unbounded_shl_u32<
         T: [c0nst] ConstMachineWord + MachineWord,
         const N: usize,
@@ -479,10 +476,9 @@ c0nst::c0nst! {
 
     // --- Reference-receiver shift impls (see add_sub_impl.rs for rationale) ---
     //
-    // The shift Output comes from the operator supertrait
-    // (`Shl<u32>` / `Shr<u32>`); both `Shl<u32> for &FixedUInt` and
-    // `Shr<u32> for &FixedUInt` are defined above (lines 235, 242),
-    // so Output resolves to `FixedUInt<T,N,P>`.
+    // Output comes from the operator supertrait (`Shl<u32>` / `Shr<u32>`
+    // for `&FixedUInt`, defined earlier in this c0nst! block), so
+    // Output resolves to `FixedUInt<T,N,P>`.
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingShl for &FixedUInt<T, N, P> {
         fn overflowing_shl(self, bits: u32) -> (FixedUInt<T, N, P>, bool) {
@@ -755,7 +751,6 @@ c0nst::c0nst! {
                 if !<Self as const_num_traits::Zero>::is_zero(&(self & bb)) {
                     result |= lowest;
                 }
-                // Clear that lowest bit and advance the source-side bit.
                 remaining = remaining & <Self as const_num_traits::WrappingSub>::wrapping_sub(
                     remaining,
                     <Self as const_num_traits::ConstOne>::ONE,

--- a/src/fixeduint/byte_conversion_panic_free.rs
+++ b/src/fixeduint/byte_conversion_panic_free.rs
@@ -183,11 +183,9 @@ mod tests {
     #[test]
     fn to_le_bytes_fixed_oversized_leaves_trailing_untouched() {
         let v = U16::from(0x1234u16);
-        let mut buf = [0xFFu8; 4]; // BYTE_WIDTH == 2; M == 4
+        let mut buf = [0xFFu8; 4];
         let written = v.to_le_bytes_fixed(&mut buf);
-        // Returned slice is the written prefix.
         assert_eq!(written, &[0x34, 0x12]);
-        // Trailing bytes left as 0xFF.
         assert_eq!(buf, [0x34, 0x12, 0xFF, 0xFF]);
     }
 
@@ -306,7 +304,7 @@ mod tests {
     #[test]
     fn u32_single_limb_le() {
         let v = U32::from(0x12345678u32);
-        let mut buf = [0u8; U32::BYTE_WIDTH]; // 4
+        let mut buf = [0u8; U32::BYTE_WIDTH];
         let written = v.to_le_bytes_fixed(&mut buf);
         assert_eq!(written, &[0x78, 0x56, 0x34, 0x12]);
         let back: U32 = U32::from_le_bytes_fixed(&buf);
@@ -323,21 +321,12 @@ mod tests {
         assert_eq!(back, v);
     }
 
-    // ─── const-context callability (the whole point) ──────────────────
-    //
-    // These are NOT c0nst — the bodies use `chunks_exact_mut` which
-    // isn't const-fn — but exercising them in #[test] form alongside
-    // the inherent-const `BYTE_WIDTH` confirms the buffer-sizing
-    // pattern downstream callers want.
-
     #[test]
     fn byte_width_is_usable_as_array_length() {
-        // The whole API ergonomic ask: `[0u8; T::BYTE_WIDTH]` works.
         const BUF_LEN: usize = U64::BYTE_WIDTH;
         let mut buf = [0u8; BUF_LEN];
         let v = U64::from(42u32);
         let _ = v.to_le_bytes_fixed(&mut buf);
-        // First byte of the value is the LE low byte.
         assert_eq!(buf[0], 42);
     }
 }

--- a/src/fixeduint/cios_row_ops_impl.rs
+++ b/src/fixeduint/cios_row_ops_impl.rs
@@ -84,7 +84,8 @@ where
         let (sum, overflow) = <T as CarryingAdd>::carrying_add(acc_hi, carry, false);
         acc.array[N - 1] = sum;
 
-        // Branchless: convert overflow bool to word via carrying_add(0, 0, overflow).
+        // No `bool as T` cast is generically available; convert the
+        // overflow bool to a T-word via `carrying_add(0, 0, overflow)`.
         let (overflow_word, _) = <T as CarryingAdd>::carrying_add(
             <T as ConstZero>::ZERO,
             <T as ConstZero>::ZERO,
@@ -126,10 +127,8 @@ mod tests {
 
     #[test]
     fn word_returns_zero_on_out_of_bounds() {
-        // Documented dead-code branch: the trait contract forbids
-        // `i >= word_count()`, but the body avoids panic_bounds_check
-        // by returning ZERO instead. Exercising it just confirms the
-        // safe-slice path is wired correctly.
+        // Trait contract forbids `i >= word_count()`; the safe-slice
+        // fallback keeps `panic_bounds_check` out of the binary.
         let v = U16Nct::from(0x1234u16);
         assert_eq!(CiosRowOps::word(&v, 2), 0);
         assert_eq!(CiosRowOps::word(&v, 999), 0);
@@ -158,9 +157,8 @@ mod tests {
 
     #[test]
     fn ct_personality_uses_same_body() {
-        // Same numeric result regardless of personality (the trait body
-        // is uniform). If a future change accidentally introduces a
-        // `match P::TAG` split that diverges, this catches it.
+        // Both personalities must produce identical numeric results —
+        // the impl is uniform and this pins that invariant.
         let mult_n = U16Nct::from(0x10u16);
         let mut acc_n = U16Nct::from(0x20u16);
         let c_n = <U16Nct as CiosRowOps>::mul_acc_row(0x3, &mult_n, &mut acc_n, 0);

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -128,11 +128,9 @@ c0nst::c0nst! {
     where
         [(); byte_len::<T, N>()]:,
     {
-        // External `FromBytes::Bytes` is `?Sized` + `NumBytes`-bounded.
-        // We keep using the sized `ConstBytesHolder` (the c0nst const
-        // generic path needs a concrete return type for `ToBytes`
-        // anyway); `from_*_bytes` takes it by reference per the
-        // reverted-in upstream signature.
+        // `FromBytes::Bytes` is `?Sized + NumBytes` upstream; we pin it
+        // to `ConstBytesHolder` here so the c0nst const-generic path
+        // sees the same concrete return type as `ToBytes`.
         type Bytes = ConstBytesHolder<{ byte_len::<T, N>() }>;
 
         fn from_le_bytes(bytes: &Self::Bytes) -> Self {
@@ -240,10 +238,8 @@ mod tests {
         assert_eq!(CONST_FROM_LE.array, [0x01, 0x02, 0x03, 0x04]);
     }
 
-    // Empirical const-eval proofs for the big-endian half too — completes
-    // the audit coverage of `ToBytes` / `FromBytes`. (This module is
-    // already `#[cfg(feature = "nightly")]`, so these consts only exist
-    // under that feature.)
+    // BE const-eval round-trip; the LE half is `CONST_LE_BYTES` /
+    // `CONST_FROM_LE` above.
     const CONST_BE_BYTES: [u8; 4] = {
         let val: FixedUInt<u8, 4> = FixedUInt::from_array([0x01, 0x02, 0x03, 0x04]);
         let holder = ToBytes::to_be_bytes(val);

--- a/src/fixeduint/div_ceil_impl.rs
+++ b/src/fixeduint/div_ceil_impl.rs
@@ -63,19 +63,12 @@ c0nst::c0nst! {
 }
 
 impl<T: ConstMachineWord + MachineWord, const N: usize> FixedUInt<T, N, Nct> {
-    /// Backwards-compatible inherent `checked_div_ceil`. External
-    /// `DivCeil` doesn't surface a checked variant; we keep this so
-    /// downstream callers can still get `None` on division-by-zero or
-    /// overflow rather than a panic.
+    /// `div_ceil` variant returning `None` on divide-by-zero or overflow.
     ///
-    /// Note on const-callability: this inherent shim is **not** itself
-    /// `const fn`, because the `c0nst` macro does not translate
-    /// `[c0nst]` trait bounds on inherent `impl` blocks (Rust syntax
-    /// only allows `[const]` bounds in trait-impl headers and standalone
-    /// `const fn` items). Nightly callers who need the const path can
-    /// call `checked_div_ceil_impl(a, b)` directly — it's a free
-    /// `pub(crate) c0nst fn` defined above, exercised in const context
-    /// by the existing `test_const_div_ceil` test.
+    /// Not itself `const fn` — the `c0nst!` macro can't emit `[c0nst]`
+    /// bounds on inherent impls. Nightly callers wanting the const path
+    /// call `checked_div_ceil_impl` (the free `pub(crate) c0nst fn`
+    /// above) directly.
     pub fn checked_div_ceil(self, rhs: Self) -> Option<Self> {
         checked_div_ceil_impl(self, rhs)
     }

--- a/src/fixeduint/euclid.rs
+++ b/src/fixeduint/euclid.rs
@@ -71,10 +71,6 @@ c0nst::c0nst! {
     }
 }
 
-// (legacy num_traits::Euclid / CheckedEuclid shim impls retired — the
-// `c0nst Euclid` / `c0nst CheckedEuclid` impls above ARE the impls
-// of the external traits now.)
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -229,10 +229,8 @@ mod tests {
             BorrowingSub::borrowing_sub(a, b, borrow)
         }
 
-        /// Backwards-compatible test shim: returns the full `(low, high)`
-        /// product. `FixedUInt` no longer implements `WideningMul`; this
-        /// routes through `CarryingMul` with a zero carry, which produces
-        /// the same value.
+        /// Full `(low, high)` product via `CarryingMul` with a zero
+        /// carry — `FixedUInt` doesn't implement `WideningMul`.
         pub c0nst fn const_widening_mul<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality>(
             a: FixedUInt<T, N, P>,
             b: FixedUInt<T, N, P>,

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -205,10 +205,6 @@ c0nst::c0nst! {
     }
 }
 
-// (Legacy non-const WideningMul / CarryingMul shim impls retired —
-// the `c0nst WideningMul` / `c0nst CarryingMul` impls above are now
-// the impls of the external traits.)
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -552,10 +552,9 @@ mod tests {
         );
     }
 
-    /// Test the non-const WideningMul trait for primitives and FixedUInt.
+    /// `CarryingMul::carrying_mul` full-product on primitives and FixedUInt.
     #[test]
-    fn test_widening_mul_trait() {
-        // Test primitive types via WideningMul trait
+    fn test_carrying_mul_full_product() {
         assert_eq!(CarryingMul::carrying_mul(255u8, 255u8, 0u8), (1, 254)); // 0xFE01
         assert_eq!(
             CarryingMul::carrying_mul(0xFFFFu16, 0xFFFFu16, 0u16),
@@ -570,103 +569,46 @@ mod tests {
             (0xFFFF_FFFF_FFFF_FFFE, 1)
         );
 
-        // Test FixedUInt via WideningMul trait
         let a = U16::from(0xFFFFu16);
         let (lo, hi) = CarryingMul::carrying_mul(a, a, <U16 as Zero>::zero());
         assert_eq!(lo, U16::from(0x0001u16));
         assert_eq!(hi, U16::from(0xFFFEu16));
-
-        // Sanity: CarryingMul on FixedUInt produces deterministic results.
-        // (FixedUInt no longer implements `WideningMul`, so the earlier
-        // `WideningMul`-vs-`WideningMul` self-check doesn't apply.)
-        let b = U32::from(0x1234_5678u32);
-        let c = U32::from(0x9ABC_DEF0u32);
-        let zero32 = <U32 as Zero>::zero();
-        let (lo_a, hi_a) = CarryingMul::carrying_mul(b, c, zero32);
-        let (lo_b, hi_b) = CarryingMul::carrying_mul(b, c, zero32);
-        assert_eq!(lo_a, lo_b);
-        assert_eq!(hi_a, hi_b);
     }
 
-    /// Test the non-const CarryingMul trait for primitives and FixedUInt.
+    /// `CarryingMul::carrying_mul` / `carrying_mul_add` for primitives and
+    /// FixedUInt, cross-checked against the free const-fn path.
     #[test]
     fn test_carrying_mul_trait() {
-        // Test primitive types via CarryingMul trait
-        // 10 * 10 + 5 = 105
         assert_eq!(CarryingMul::carrying_mul(10u8, 10u8, 5u8), (105, 0));
-        // 255 * 255 + 255 = 65280 = 0xFF00
         assert_eq!(CarryingMul::carrying_mul(255u8, 255u8, 255u8), (0, 255));
-
-        // Test carrying_mul_add: 10 * 10 + 3 + 2 = 105
         assert_eq!(
             CarryingMul::carrying_mul_add(10u8, 10u8, 3u8, 2u8),
             (105, 0)
         );
-        // 255 * 255 + 255 + 255 = 65535 = 0xFFFF
         assert_eq!(
             CarryingMul::carrying_mul_add(255u8, 255u8, 255u8, 255u8),
             (255, 255)
         );
 
-        // Test FixedUInt via CarryingMul trait
         let a = U16::from(100u8);
         let b = U16::from(100u8);
         let carry = U16::from(5u8);
         let (lo, hi) = CarryingMul::carrying_mul(a, b, carry);
-        assert_eq!(lo, U16::from(10005u16)); // 100 * 100 + 5 = 10005
+        assert_eq!(lo, U16::from(10005u16));
         assert_eq!(hi, U16::from(0u8));
 
-        // Verify CarryingMul produces same result as CarryingMul
+        // Trait method and free const-fn must agree on FixedUInt.
         let x = U32::from(0x1234u32);
         let y = U32::from(0x5678u32);
         let c = U32::from(0xABCDu32);
-        let (lo_trait, hi_trait) = CarryingMul::carrying_mul(x, y, c);
-        let (lo_const, hi_const) = CarryingMul::carrying_mul(x, y, c);
-        assert_eq!(lo_trait, lo_const);
-        assert_eq!(hi_trait, hi_const);
-
-        // Test carrying_mul_add for FixedUInt
+        assert_eq!(
+            CarryingMul::carrying_mul(x, y, c),
+            const_carrying_mul(x, y, c),
+        );
         let addend = U32::from(0x9999u32);
-        let (lo_trait, hi_trait) = CarryingMul::carrying_mul_add(x, y, addend, c);
-        let (lo_const, hi_const) = CarryingMul::carrying_mul_add(x, y, addend, c);
-        assert_eq!(lo_trait, lo_const);
-        assert_eq!(hi_trait, hi_const);
-    }
-
-    /// Sanity check: CarryingMul is deterministic on primitives + FixedUInt.
-    #[test]
-    fn test_ref_based_mul_traits() {
         assert_eq!(
-            CarryingMul::carrying_mul(0xFFFFu16, 0xFFFFu16, 0u16),
-            CarryingMul::carrying_mul(0xFFFFu16, 0xFFFFu16, 0u16),
-        );
-        assert_eq!(
-            CarryingMul::carrying_mul(255u8, 255u8, 255u8),
-            CarryingMul::carrying_mul(255u8, 255u8, 255u8),
-        );
-        assert_eq!(
-            CarryingMul::carrying_mul_add(10u8, 10u8, 3u8, 2u8),
-            CarryingMul::carrying_mul_add(10u8, 10u8, 3u8, 2u8),
-        );
-
-        let a = U32::from(0x1234_5678u32);
-        let b = U32::from(0x9ABC_DEF0u32);
-        let zero32 = <U32 as Zero>::zero();
-        assert_eq!(
-            CarryingMul::carrying_mul(a, b, zero32),
-            CarryingMul::carrying_mul(a, b, zero32),
-        );
-
-        let carry = U16::from(5u8);
-        let x = U16::from(100u8);
-        assert_eq!(
-            CarryingMul::carrying_mul(x, x, carry),
-            CarryingMul::carrying_mul(x, x, carry),
-        );
-        let addend = U16::from(10u8);
-        assert_eq!(
-            CarryingMul::carrying_mul_add(x, x, addend, carry),
-            CarryingMul::carrying_mul_add(x, x, addend, carry),
+            CarryingMul::carrying_mul_add(x, y, addend, c),
+            const_carrying_mul_add(x, y, addend, c),
         );
     }
 }

--- a/src/fixeduint/has_nonzero_impl.rs
+++ b/src/fixeduint/has_nonzero_impl.rs
@@ -247,20 +247,15 @@ mod tests {
         assert_eq!(<U128 as DivNonZero>::rem_nonzero(a, nz), a % m);
     }
 
-    #[test]
-    fn divnonzero_not_impld_for_ct() {
-        // Compile-time guard: `DivNonZero for FixedUInt<_, _, Ct>` does
-        // NOT exist (Div on FixedUInt is Nct-only). The following SHOULD
-        // fail to compile if uncommented:
-        //
-        //     let a: U32Ct = U32Ct::from(100u32);
-        //     let nz: NonZeroFixedUInt<u8, 4, Ct> = a.into_nonzero().unwrap();
-        //     let _ = <U32Ct as DivNonZero>::div_nonzero(a, nz);
-        //
-        // The HasNonZero impl is still generic in P (see
-        // `into_nonzero_works_under_ct_too`), so the proof type still
-        // exists for Ct carriers — it just can't be divided.
-    }
+    // Compile-time guard: `DivNonZero for FixedUInt<_, _, Ct>` does NOT
+    // exist (Div on FixedUInt is Nct-only). The `HasNonZero` impl stays
+    // generic in P — the proof type exists for Ct, it just can't be
+    // divided by. `static_assertions::assert_not_impl_any!` fires at
+    // compile time if a future `impl DivNonZero for FixedUInt<_, _, Ct>`
+    // sneaks in.
+    static_assertions::assert_not_impl_any!(
+        FixedUInt<u32, 4, const_num_traits::Ct>: DivNonZero
+    );
 
     #[test]
     fn into_nonzero_ct_masks_zero() {

--- a/src/fixeduint/isqrt_impl.rs
+++ b/src/fixeduint/isqrt_impl.rs
@@ -26,10 +26,6 @@ c0nst::c0nst! {
         fn isqrt(self) -> Self {
             // Bit-by-bit algorithm for integer square root.
             // Returns the largest r such that r * r <= self.
-            // (External `CheckedIsqrt` is signed-only; unsigned isqrt
-            // can never fail, so we don't implement that trait. A
-            // backwards-compatible inherent `checked_isqrt` returning
-            // `Option<Self>` is provided below for downstream callers.)
             if <Self as Zero>::is_zero(&self) {
                 return <Self as Zero>::zero();
             }
@@ -65,9 +61,7 @@ c0nst::c0nst! {
 }
 
 impl<T: ConstMachineWord + MachineWord, const N: usize> FixedUInt<T, N, Nct> {
-    /// Backwards-compatible inherent shim for `checked_isqrt`. External
-    /// `CheckedIsqrt` is signed-only; for unsigned types the operation
-    /// can never fail, so we always return `Some`.
+    /// Unsigned isqrt cannot fail; always returns `Some`.
     pub fn checked_isqrt(self) -> Option<Self> {
         Some(<Self as Isqrt>::isqrt(self))
     }

--- a/src/fixeduint/num_traits_identity.rs
+++ b/src/fixeduint/num_traits_identity.rs
@@ -74,7 +74,6 @@ impl<T: ConstMachineWord + MachineWord, const N: usize, P: Personality> ConstOne
     for FixedUInt<T, N, P>
 {
     const ONE: Self = {
-        // Construct array with T::ONE in slot 0, T::ZERO elsewhere.
         let mut a = [<T as ConstZero>::ZERO; N];
         if N > 0 {
             a[0] = <T as ConstOne>::ONE;

--- a/src/fixeduint/parity_impl.rs
+++ b/src/fixeduint/parity_impl.rs
@@ -49,8 +49,8 @@ c0nst::c0nst! {
     }
 
     // The reference-receiver impl is provided by const_num_traits's blanket
-    // `impl<T: Parity + Copy> Parity for &T` (the D1 fix from the typestate
-    // synthesis). Manually impl'ing it here now conflicts (E0119).
+    // `impl<T: Parity + Copy> Parity for &T`; a manual impl here would
+    // conflict (E0119).
 }
 
 // `CtParity` is **not** a `c0nst trait` upstream — `subtle::Choice`
@@ -72,7 +72,6 @@ where
             return Choice::from(0);
         }
         let lsb = self.array[0] & <T as const_num_traits::ConstOne>::ONE;
-        // `Choice::TRUE` when `lsb != 0`.
         !lsb.ct_eq(&<T as const_num_traits::ConstZero>::ZERO)
     }
 
@@ -218,8 +217,6 @@ mod tests {
             "Odd::new_ct(8) should mask None"
         );
 
-        // Round-trip: unwrap the masked Some, then check the inner value
-        // matches the input.
         let recovered = p_odd.unwrap();
         assert_eq!(recovered.get(), odd_ct);
     }

--- a/src/fixeduint/power_of_two_ops_impl.rs
+++ b/src/fixeduint/power_of_two_ops_impl.rs
@@ -144,7 +144,6 @@ mod tests {
             PowerOfTwoOps::div_pow2(U16::from(1000u16), p4),
             U16::from(62u8)
         );
-        // exp == 0 (divisor == 1) is identity.
         let p0 = pow2_from_value(U16::from(1u8)).unwrap();
         assert_eq!(
             PowerOfTwoOps::div_pow2(U16::from(12345u16), p0),
@@ -212,16 +211,12 @@ mod tests {
     #[test]
     fn checked_next_multiple_of_pow2_is_the_no_panic_sibling() {
         let p4 = pow2_from_value(U16::from(16u8)).unwrap();
-        // Already aligned.
         assert_eq!(
             PowerOfTwoOps::checked_next_multiple_of_pow2(U16::from(65520u16), p4),
             Some(U16::from(65520u16))
         );
-        // 65521 → next multiple of 16 = 65536 = 2^16, doesn't fit U16.
-        // mask = 15, 65521 + 15 = 65536 overflows U16's MAX (65535).
-        // This is the case where `next_multiple_of_pow2` would panic under
-        // Nct; the checked sibling returns None instead — the design
-        // principle "every panicking API ships a Try* sibling" applied.
+        // 65521 + mask (15) = 65536, overflows U16::MAX. Under Nct that
+        // would panic; the checked variant returns None.
         assert_eq!(
             PowerOfTwoOps::checked_next_multiple_of_pow2(U16::from(65521u16), p4),
             None
@@ -276,10 +271,9 @@ mod tests {
         assert_eq!(const_div_pow2(U16::from(100u8), p), U16::from(6u8));
         assert_eq!(const_rem_pow2(U16::from(100u8), p), U16::from(4u8));
 
-        // Empirical const-eval proof on nightly: `new_checked` is
-        // `pub c0nst fn` upstream and our `IsPowerOfTwo` + `PrimBits`
-        // impls are c0nst-bounded, so the full construction-and-
-        // consumption chain is const-callable.
+        // Full construct-and-consume chain in const context: upstream
+        // `new_checked` is `c0nst fn` and our `IsPowerOfTwo` + `PrimBits`
+        // impls carry `[c0nst]` bounds.
         #[cfg(feature = "nightly")]
         {
             const HUNDRED: U16 = FixedUInt::from_array([100, 0]);

--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -110,18 +110,12 @@ c0nst::c0nst! {
             self
         }
     }
-    // External `PrimInt` requires `Num + NumCast + Saturating` (among
-    // other things). Implementing those on FixedUInt is real follow-up
-    // work — for the experiment we leave `pow` as an inherent method
-    // on FixedUInt below so callers can still use it without the bundle.
 }
 
 c0nst::c0nst! {
-    /// Standalone const-fn body for `pow`, exposed for nightly users who
-    /// want the const-callable path (the inherent `FixedUInt::pow`
-    /// method shim below delegates here). Kept free-floating because the
-    /// c0nst macro doesn't translate `[c0nst]` trait bounds on inherent
-    /// `impl` blocks — only on c0nst-fn items directly.
+    /// Const-callable `pow` body. Free-floating because the c0nst macro
+    /// only accepts `[c0nst]` bounds on trait-impl headers and
+    /// standalone `const fn` items, not on inherent `impl` blocks.
     pub(crate) c0nst fn pow_impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(
         v: FixedUInt<T, N, Nct>, exp: u32,
     ) -> FixedUInt<T, N, Nct> {
@@ -145,12 +139,10 @@ c0nst::c0nst! {
 }
 
 impl<T: ConstMachineWord + MachineWord, const N: usize> FixedUInt<T, N, Nct> {
-    /// Inherent `pow` retained while the external `PrimInt` bundle is
-    /// not yet implementable on `FixedUInt` (it requires `Num`,
-    /// `NumCast`, and `Saturating` — out of scope for this experiment).
-    /// For const-callable use on nightly, call the free `pow_impl`
-    /// function above directly (the c0nst-macro limitation on inherent
-    /// `impl` blocks means we can't make this method itself `const`).
+    /// Inherent `pow`. `FixedUInt` does not implement external `PrimInt`
+    /// (which supertrait-bundles `Num + NumCast + Saturating`), so this
+    /// stays on the type itself. For const-callable use on nightly, call
+    /// the free `pow_impl` function above directly.
     pub fn pow(self, exp: u32) -> Self {
         pow_impl(self, exp)
     }
@@ -377,8 +369,8 @@ mod tests {
             const THREE_TO_THE_FIVE: U16 = super::pow_impl(THREE, 5);
             const ZERO_EXP: U16 = super::pow_impl(TWO, 0);
             assert_eq!(TWO_TO_THE_EIGHT, FixedUInt::from_array([0, 1])); // 256
-            assert_eq!(THREE_TO_THE_FIVE, FixedUInt::from_array([243, 0])); // 243
-            assert_eq!(ZERO_EXP, FixedUInt::from_array([1, 0])); // pow(x, 0) = 1
+            assert_eq!(THREE_TO_THE_FIVE, FixedUInt::from_array([243, 0]));
+            assert_eq!(ZERO_EXP, FixedUInt::from_array([1, 0]));
         }
     }
 }

--- a/src/fixeduint/strict_impl.rs
+++ b/src/fixeduint/strict_impl.rs
@@ -234,7 +234,7 @@ mod tests {
         assert_eq!(StrictAdd::strict_add(&a, &b), U16::from(30u8));
     }
 
-    // --- Empirical const-evaluability proofs --------------------------------
+    // --- Const-eval smoke ---------------------------------------------------
     c0nst::c0nst! {
         pub c0nst fn const_strict_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize>(a: FixedUInt<T, N, Nct>, b: FixedUInt<T, N, Nct>) -> FixedUInt<T, N, Nct> {
             StrictAdd::strict_add(a, b)
@@ -264,7 +264,6 @@ mod tests {
 
     #[test]
     fn nightly_const_eval_strict() {
-        // runtime smoke
         assert_eq!(
             const_strict_add(U16::from(10u8), U16::from(20u8)),
             U16::from(30u8)
@@ -300,7 +299,7 @@ mod tests {
             assert_eq!(SUB, FixedUInt::from_array([20, 0]));
             assert_eq!(MUL, FixedUInt::from_array([20, 0]));
             assert_eq!(DIV, FixedUInt::from_array([20, 0]));
-            assert_eq!(REM, FixedUInt::from_array([4, 0])); // 200 % 7 = 4
+            assert_eq!(REM, FixedUInt::from_array([4, 0]));
             assert_eq!(SHL, FixedUInt::from_array([16, 0]));
             assert_eq!(SHR, FixedUInt::from_array([4, 0]));
             assert_eq!(POW, TWO_FIFTY_SIX);

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -106,10 +106,6 @@ impl<T: MachineWord, const N: usize> Drop for BytesHolder<T, N> {
 }
 
 // ── num_traits::ToBytes/FromBytes (upstream by-ref shape) ────────────
-//
-// Only built when `feature = "num-traits"` is enabled; downstream
-// consumers that have dropped num-traits don't need or want these
-// impls.
 
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize, P: Personality> num_traits::ToBytes for FixedUInt<T, N, P>
@@ -281,18 +277,8 @@ mod tests {
         );
     }
 
-    // --- Empirical const-evaluability of `Default` -------------------------
-    //
-    // `core::default::Default` becomes a `const trait` on nightly under
-    // `feature(const_default)`, which our `nightly` feature enables. The
-    // `impl c0nst Default for BytesHolder` above is rendered as
-    // `impl const Default for BytesHolder` on nightly and as the plain
-    // impl on stable. This test binds the result of `Default::default()`
-    // to a `const` item, proving the const path is real on nightly.
-
     #[test]
     fn nightly_const_eval_default() {
-        // runtime smoke (works on stable + nightly).
         let h: BytesHolder<u8, 4> = Default::default();
         assert_eq!(h.array, [0u8; 4]);
 


### PR DESCRIPTION
## Summary

Three parenthesized comment blocks in \`bit_ops_impl.rs\`, \`euclid.rs\`, and \`extended_precision_impl.rs\` all followed the same shape:

> \`(legacy num_traits::Foo / CheckedFoo shim impls retired — the c0nst Foo impls above ARE the impls of the external traits now)\`

Pure history. The impls are visible directly above the removed comments — a reader doesn't need a note explaining what used to sit in their place.

- \`src/fixeduint/bit_ops_impl.rs:807-810\` — OverflowingShl/OverflowingShr.
- \`src/fixeduint/euclid.rs:74-76\` — Euclid / CheckedEuclid.
- \`src/fixeduint/extended_precision_impl.rs:208-210\` — WideningMul / CarryingMul.

## Test plan

- [x] \`cargo build --lib\` clean
- [x] \`cargo test --lib\` — 188/188
- [x] \`cargo clippy --lib --tests\` clean
- [x] \`cargo fmt --check\` clean

## Summary by Sourcery

Chores:
- Clean up historical commentary blocks in fixeduint bit operations, Euclid, and extended precision modules to reduce noise around current const trait implementations.