### PR TITLE
Address PR #128 review feedback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ members = [
 ]
 resolver = "2"
 
-[patch.crates-io]
-modmath-cios = { git = "https://github.com/kaidokert/modmath-rs", tag = "v0.4.0-alpha.0" }
-
 # Pinned release profile: deterministic codegen so a passing PR locks
 # the inspection output.
 [profile.release]
@@ -70,7 +67,8 @@ version = "2.6"
 default-features = false
 
 [dependencies.modmath-cios]
-version = "0.1"
+git = "https://github.com/kaidokert/modmath-rs"
+tag = "v0.4.0-alpha.0"
 optional = true
 default-features = false
 

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -244,7 +244,7 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // `ct_eq` against ZERO, or delegation to existing branchless
     // ops). Same shape as the predicate / arithmetic impls already
     // allowlisted.
-    r"const_num_traits\.\.ops\.\.ct\.\.Ct[A-Z][a-zA-Z]+.*fixed_bigint\.\.fixeduint\.\.FixedUInt",
+    r"const_num_traits\.\.ops\.\.ct\.\.Ct(?:IsZero|Parity|IsPowerOfTwo|CheckedAdd|CheckedSub|CheckedMul)\b.*fixed_bigint\.\.fixeduint\.\.FixedUInt",
     // CtNonZero lives at `const_num_traits::typestate::CtNonZero`
     // (not in `ops::ct`); body is `ct_is_zero() + new_unchecked` so
     // covered by the CtIsZero allowance above, but spell it out so

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -596,6 +596,13 @@ c0nst::c0nst! {
     //   (which yields 0 for 0 input automatically) — and uses arithmetic
     //   already implemented uniformly across personalities.
 
+    // NOTE: `isolate_highest_one` is NOT constant-time for FixedUInt under
+    // Ct. The `if lz as usize == Self::BIT_SIZE` branch is value-dependent
+    // (it leaks whether `self == 0`), and the `pos`-parameterized shift's
+    // bit-count is value-dependent too. `IsolateLowestOne` below uses the
+    // `self & (0 - self)` trick and IS branchless; callers needing a
+    // constant-time highest-bit isolation on a Ct carrier should mask
+    // through a different path.
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::IsolateHighestOne for FixedUInt<T, N, P> {
         type Output = Self;
         fn isolate_highest_one(self) -> Self {

--- a/src/fixeduint/byte_conversion_panic_free.rs
+++ b/src/fixeduint/byte_conversion_panic_free.rs
@@ -22,8 +22,12 @@
 //! binary": `copy_from_slice` still carries a length check LLVM can't
 //! elide through the trait boundary.
 //!
-//! Truncation convention when `M > BYTE_WIDTH` matches the slice-based
-//! methods: LE reads the first `BYTE_WIDTH` bytes, BE reads the last.
+//! Oversized-buffer convention when `M > BYTE_WIDTH`, matching the
+//! slice-based methods: LE uses the leading `BYTE_WIDTH` bytes and BE
+//! uses the trailing `BYTE_WIDTH` bytes. `to_*_bytes_fixed` writes into
+//! that window and returns it; `from_*_bytes_fixed` reads from it. So
+//! a `to_be`/`from_be` (or `to_le`/`from_le`) round-trip through an
+//! oversized buffer is symmetric.
 
 // `let _ = <T as AssertBufferFits<M>>::CHECK;` forces the const to
 // evaluate at monomorphization; a bare path-statement isn't a reliable
@@ -93,6 +97,11 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
     /// Big-endian counterpart of [`to_le_bytes_fixed`](Self::to_le_bytes_fixed);
     /// same const-asserted size guarantee and same panic-free intent.
     ///
+    /// Returns the written window `&out[M - BYTE_WIDTH ..]`. If
+    /// `M > BYTE_WIDTH`, the leading bytes of `out` are left untouched
+    /// — mirror image of `to_le_bytes_fixed`, aligning the value with
+    /// the trailing window that `from_be_bytes_fixed` reads.
+    ///
     /// ```
     /// use fixed_bigint::FixedUInt;
     /// type U16 = FixedUInt<u8, 2>;
@@ -105,15 +114,18 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
     pub fn to_be_bytes_fixed<'a, const M: usize>(&self, out: &'a mut [u8; M]) -> &'a [u8] {
         let _ = <Self as AssertBufferFits<M>>::CHECK;
         let word_size = Self::WORD_SIZE;
-        // Walk words from MSB to LSB so the output is BE.
-        for (chunk, word) in out
+        let start = M - Self::BYTE_WIDTH;
+        // Walk words from MSB to LSB so the output is BE. Align to the
+        // trailing window so oversized buffers round-trip through
+        // `from_be_bytes_fixed`.
+        for (chunk, word) in out[start..]
             .chunks_exact_mut(word_size)
             .take(N)
             .zip(self.array.iter().rev())
         {
             chunk.copy_from_slice(word.to_be_bytes().as_ref());
         }
-        &out[..Self::BYTE_WIDTH]
+        &out[start..]
     }
 
     /// Deserialize from a fixed-size little-endian buffer. The const
@@ -221,12 +233,24 @@ mod tests {
     }
 
     #[test]
-    fn to_be_bytes_fixed_oversized_leaves_trailing_untouched() {
+    fn to_be_bytes_fixed_oversized_writes_trailing_window() {
         let v = U16::from(0x1234u16);
         let mut buf = [0xFFu8; 4];
         let written = v.to_be_bytes_fixed(&mut buf);
         assert_eq!(written, &[0x12, 0x34]);
-        assert_eq!(buf, [0x12, 0x34, 0xFF, 0xFF]);
+        assert_eq!(buf, [0xFF, 0xFF, 0x12, 0x34]);
+    }
+
+    #[test]
+    fn to_be_fixed_from_be_fixed_round_trip_oversized() {
+        // The window `to_be_bytes_fixed` writes must match the window
+        // `from_be_bytes_fixed` reads, or oversized BE round-trips
+        // decode the untouched leading bytes.
+        let v = U16::from(0x1234u16);
+        let mut buf = [0u8; 4];
+        let _ = v.to_be_bytes_fixed(&mut buf);
+        let back: U16 = U16::from_be_bytes_fixed(&buf);
+        assert_eq!(back, v);
     }
 
     // ─── from_le_bytes_fixed ──────────────────────────────────────────

--- a/src/fixeduint/cios_row_ops_impl.rs
+++ b/src/fixeduint/cios_row_ops_impl.rs
@@ -156,6 +156,33 @@ mod tests {
     }
 
     #[test]
+    fn mul_acc_shift_row_hand_checked() {
+        // (scalar * mult + [acc, acc_hi * B^N]) shifted right by one word.
+        // scalar=1, mult=1, acc=2, acc_hi=3 → the low byte (=3) is
+        // discarded by the shift, acc becomes [0, acc_hi + carry] with
+        // carry = 0 from the tiny product.
+        let mult = U16Nct::from(1u8);
+        let mut acc = U16Nct::from(2u8);
+        let overflow = <U16Nct as CiosRowOps>::mul_acc_shift_row(1, &mult, &mut acc, 3);
+        assert_eq!(acc.array, [0, 3]);
+        assert_eq!(overflow, 0);
+    }
+
+    #[test]
+    fn mul_acc_shift_row_ct_matches_nct() {
+        let mult_n = U16Nct::from(0xABCDu16);
+        let mut acc_n = U16Nct::from(0x1234u16);
+        let ov_n = <U16Nct as CiosRowOps>::mul_acc_shift_row(0x7, &mult_n, &mut acc_n, 0x11);
+
+        let mult_c = U16Ct::from(0xABCDu16);
+        let mut acc_c = U16Ct::from(0x1234u16);
+        let ov_c = <U16Ct as CiosRowOps>::mul_acc_shift_row(0x7, &mult_c, &mut acc_c, 0x11);
+
+        assert_eq!(acc_n.array, acc_c.array);
+        assert_eq!(ov_n, ov_c);
+    }
+
+    #[test]
     fn ct_personality_uses_same_body() {
         // Both personalities must produce identical numeric results —
         // the impl is uniform and this pins that invariant.

--- a/src/fixeduint/has_nonzero_impl.rs
+++ b/src/fixeduint/has_nonzero_impl.rs
@@ -104,7 +104,17 @@ where
     T: MachineWord,
 {
     fn default() -> Self {
-        // SAFETY: `FixedUInt::from(1u8)` is statically non-zero.
+        // `FixedUInt::<T, 0>::from(1u8)` truncates to an empty array,
+        // which represents zero — the non-zero invariant would fail
+        // silently. Refuse the degenerate case at monomorphization.
+        const {
+            assert!(
+                N > 0,
+                "NonZeroFixedUInt::default() requires N > 0 (an N=0 carrier can only represent zero)"
+            );
+        };
+        // SAFETY: `FixedUInt::<T, N, _>::from(1u8)` places `1u8` in the low
+        // limb, which under the N > 0 assertion above is non-zero.
         unsafe { NonZeroFixedUInt::new_unchecked(FixedUInt::from(1u8)) }
     }
 }

--- a/src/fixeduint/has_nonzero_impl.rs
+++ b/src/fixeduint/has_nonzero_impl.rs
@@ -27,6 +27,12 @@
 //! site. Fine for public moduli; secret-derived proofs need a
 //! `CtOption`-returning path that lives above this crate.
 
+// `let _ = <T as AssertNonzeroCarrier>::CHECK;` in `Default::default()`
+// binds a unit-typed associated const to force monomorphization-time
+// evaluation of the `N > 0` assertion. Same idiom as
+// `byte_conversion_panic_free.rs`.
+#![allow(clippy::let_unit_value)]
+
 use super::{FixedUInt, MachineWord};
 use crate::machineword::ConstMachineWord;
 use const_num_traits::Zero;
@@ -94,6 +100,24 @@ where
     }
 }
 
+// Type-level compile-time assertion `N > 0`. `const { assert!(N > 0) }`
+// inside a fn body is rejected on nightly with `generic_const_exprs` as
+// "overly complex generic constant" (blocks aren't supported there).
+// Moving the assertion to an associated const on a trait impl sidesteps
+// that — same pattern as `AssertBufferFits` in
+// `byte_conversion_panic_free.rs`.
+trait AssertNonzeroCarrier {
+    const CHECK: ();
+}
+impl<T: MachineWord, const N: usize, P: Personality> AssertNonzeroCarrier
+    for NonZeroFixedUInt<T, N, P>
+{
+    const CHECK: () = assert!(
+        N > 0,
+        "NonZeroFixedUInt::default() requires N > 0 (an N=0 carrier can only represent zero)"
+    );
+}
+
 // `Default` returns the smallest non-zero value (1). Convention: the
 // "default non-zero" is the multiplicative identity, the same shape
 // `core::num::NonZero` uses (`NonZero::<u32>::new(1).unwrap()`). Needed
@@ -104,15 +128,8 @@ where
     T: MachineWord,
 {
     fn default() -> Self {
-        // `FixedUInt::<T, 0>::from(1u8)` truncates to an empty array,
-        // which represents zero — the non-zero invariant would fail
-        // silently. Refuse the degenerate case at monomorphization.
-        const {
-            assert!(
-                N > 0,
-                "NonZeroFixedUInt::default() requires N > 0 (an N=0 carrier can only represent zero)"
-            );
-        };
+        // Fires at monomorphization when N == 0.
+        let _ = <Self as AssertNonzeroCarrier>::CHECK;
         // SAFETY: `FixedUInt::<T, N, _>::from(1u8)` places `1u8` in the low
         // limb, which under the N > 0 assertion above is non-zero.
         unsafe { NonZeroFixedUInt::new_unchecked(FixedUInt::from(1u8)) }

--- a/src/fixeduint/power_of_two_impl.rs
+++ b/src/fixeduint/power_of_two_impl.rs
@@ -42,17 +42,29 @@ c0nst::c0nst! {
         type Output = Self;
 
         fn wrapping_next_power_of_two(self) -> Self {
-            // For unsigned: on Nct, the value-dependent overflow case
-            // (`next_power_of_two` would exceed MAX) panics; here we
-            // wrap to ZERO instead, matching std's primitive
-            // `wrapping_next_power_of_two`. For Ct we reuse the
-            // saturating `next_power_of_two` (overflow → MAX).
+            // Overflow wraps to ZERO under both personalities, matching
+            // std's primitive `wrapping_next_power_of_two`. The Ct arm
+            // is the same branchless body as `next_power_of_two` below,
+            // but selects ZERO on overflow instead of MAX.
             match P::TAG {
                 PersonalityTag::Nct => match self.checked_next_power_of_two() {
                     Some(v) => v,
                     None => <Self as ConstZero>::ZERO,
                 },
-                PersonalityTag::Ct => self.next_power_of_two(),
+                PersonalityTag::Ct => {
+                    let m_one = <Self as WrappingSub>::wrapping_sub(self, Self::one());
+                    let leading = PrimBits::leading_zeros(m_one);
+                    let bits = Self::BIT_SIZE as u32 - leading;
+                    let shifted = Self::one() << (bits as usize);
+                    let is_zero = <Self as Zero>::is_zero(&self) as u8;
+                    let overflow = ((bits >= Self::BIT_SIZE as u32) as u8) & (1u8 ^ is_zero);
+                    let wrapped = crate::fixeduint::const_ct_select(
+                        shifted,
+                        <Self as ConstZero>::ZERO,
+                        overflow,
+                    );
+                    crate::fixeduint::const_ct_select(wrapped, Self::one(), is_zero)
+                }
             }
         }
 
@@ -281,6 +293,41 @@ mod tests {
             assert!(!IS_POW2_FALSE);
             assert_eq!(NEXT_POW2, FixedUInt::from_array([8, 0]));
         }
+    }
+
+    #[test]
+    fn wrapping_next_power_of_two_wraps_to_zero_under_both_personalities() {
+        use const_num_traits::{Ct, Nct};
+        type U16Nct = FixedUInt<u8, 2, Nct>;
+        type U16Ct = FixedUInt<u8, 2, Ct>;
+        // 32769 > 2^15; next power of two is 2^16 = 0x1_0000, doesn't fit u16.
+        // std's `u16::wrapping_next_power_of_two(32769) == 0`.
+        assert_eq!(
+            U16Nct::from(32769u16).wrapping_next_power_of_two(),
+            U16Nct::from_array([0, 0])
+        );
+        assert_eq!(
+            U16Ct::from(32769u16).wrapping_next_power_of_two(),
+            U16Ct::from_array([0, 0])
+        );
+        // MAX-input overflow behaves the same way.
+        assert_eq!(
+            U16Nct::from(0xFFFFu16).wrapping_next_power_of_two(),
+            U16Nct::from_array([0, 0])
+        );
+        assert_eq!(
+            U16Ct::from(0xFFFFu16).wrapping_next_power_of_two(),
+            U16Ct::from_array([0, 0])
+        );
+        // Non-overflow: both personalities agree on the same real result.
+        assert_eq!(
+            U16Nct::from(100u8).wrapping_next_power_of_two(),
+            U16Nct::from(128u8)
+        );
+        assert_eq!(
+            U16Ct::from(100u8).wrapping_next_power_of_two(),
+            U16Ct::from(128u8)
+        );
     }
 
     #[test]

--- a/src/fixeduint/strict_impl.rs
+++ b/src/fixeduint/strict_impl.rs
@@ -211,9 +211,30 @@ mod tests {
     }
 
     #[test]
+    fn strict_shr_ok() {
+        assert_eq!(StrictShr::strict_shr(U16::from(256u16), 4), U16::from(16u8));
+    }
+
+    #[test]
     #[should_panic(expected = "strict_shr shift exceeds bit width")]
     fn strict_shr_too_wide() {
         let _ = StrictShr::strict_shr(U16::from(1u8), 16);
+    }
+
+    #[test]
+    fn strict_div_ok() {
+        assert_eq!(
+            StrictDiv::strict_div(U16::from(100u8), U16::from(10u8)),
+            U16::from(10u8)
+        );
+    }
+
+    #[test]
+    fn strict_rem_ok() {
+        assert_eq!(
+            StrictRem::strict_rem(U16::from(100u8), U16::from(7u8)),
+            U16::from(2u8)
+        );
     }
 
     #[test]

--- a/tests/integer.rs
+++ b/tests/integer.rs
@@ -39,7 +39,7 @@ fn test_evenodd() {
 
 #[test]
 fn test_divides() {
-    fn divides<T: num_integer::Integer + From<u8>>() {
+    fn divides<T: num_integer::Integer + From<u8> + core::fmt::Debug>() {
         let tests = [(6u8, 3u8, true), (8, 2, true), (8, 1, true), (17, 2, false)];
         for &(multiple, multiplier, expected) in &tests {
             let multiple = T::from(multiple);
@@ -61,15 +61,17 @@ fn test_divides() {
             let div = T::from(div);
             let rem = T::from(rem);
             let (divres, remres) = multiple.div_rem(&divider);
-            assert!(divres == div, "div_rem: unexpected quotient");
-            assert!(remres == rem, "div_rem: unexpected remainder");
+            assert_eq!(divres, div, "div_rem: unexpected quotient");
+            assert_eq!(remres, rem, "div_rem: unexpected remainder");
 
-            assert!(
-                num_integer::Integer::div_floor(&multiple, &divider) == divres,
+            assert_eq!(
+                num_integer::Integer::div_floor(&multiple, &divider),
+                divres,
                 "div_floor disagrees with div_rem"
             );
-            assert!(
-                num_integer::Integer::mod_floor(&multiple, &divider) == remres,
+            assert_eq!(
+                num_integer::Integer::mod_floor(&multiple, &divider),
+                remres,
                 "mod_floor disagrees with div_rem"
             );
         }
@@ -83,7 +85,7 @@ fn test_divides() {
 // TODO: Test GCD / LCM
 #[test]
 fn test_gcd_lcm() {
-    fn gcd_lcm<T: num_integer::Integer + From<u8>>() {
+    fn gcd_lcm<T: num_integer::Integer + From<u8> + core::fmt::Debug>() {
         let gcd_tests = [
             (8u8, 12u8, 4u8),
             (1, 1, 1),
@@ -95,7 +97,7 @@ fn test_gcd_lcm() {
             let a = T::from(a);
             let b = T::from(b);
             let expected = T::from(expected);
-            assert!(a.gcd(&b) == expected);
+            assert_eq!(a.gcd(&b), expected);
         }
         let lcm_tests = [
             (10u8, 2u8, 10u8),
@@ -109,7 +111,7 @@ fn test_gcd_lcm() {
             let a = T::from(a);
             let b = T::from(b);
             let expected = T::from(expected);
-            assert!(a.lcm(&b) == expected);
+            assert_eq!(a.lcm(&b), expected);
         }
     }
     gcd_lcm::<u8>();


### PR DESCRIPTION
Bundles the four review responses on the umbrella PR #128 (coderabbit + codex). Each finding gets its own commit so the log stays reviewable.

## Commits

- \`8ffe440\` — **Align \`to_be_bytes_fixed\`'s window with \`from_be_bytes_fixed\`** (coderabbit Major). BE oversized-buffer round-trip was decoding the untouched leading window. \`to_be_bytes_fixed\` now writes into the trailing window \`out[M - BYTE_WIDTH ..]\`; new round-trip test.
- \`acdf1ce\` — **Ct \`wrapping_next_power_of_two\` wraps to 0** (codex P2). Ct branch delegated to the saturating \`next_power_of_two\`, returning \`MAX\` where both Nct and std primitives wrap to \`0\`. Dedicated CT-branchless body added; \`wrapping_next_power_of_two_wraps_to_zero_under_both_personalities\` test covers 32769, MAX, and a non-overflow value across both personalities.
- \`dbb181c\` — **Minor / hardening bundle**:
  - \`Cargo.toml\`: drop workspace-root \`[patch.crates-io]\` for \`modmath-cios\`; move the git source onto the optional dep entry itself.
  - \`bit_ops_impl.rs\`: NOTE on \`IsolateHighestOne\` documenting that the value-dependent branch and shift make it NOT constant-time for \`FixedUInt\` under \`Ct\`; \`IsolateLowestOne\` (\`self & (0 - self)\`) is the CT-safe alternative.
  - \`has_nonzero_impl.rs\`: monomorphization-time \`const { assert!(N > 0) }\` on \`NonZeroFixedUInt::default()\` so the \`N=0\` degenerate case (where \`FixedUInt::from(1u8)\` truncates to zero) fails at compile time instead of silently violating the non-zero invariant.
  - \`ct-verify/ct-driver/src/target.rs\`: tighten the \`Ct*\` allowlist regex from \`Ct[A-Z][a-zA-Z]+\` to the six known trait names.
- \`2540694\` — **Coverage / diagnostic tweaks**:
  - \`tests/integer.rs\`: switch back to \`assert_eq!(a, b, "msg")\` from \`assert!(a == b, "msg")\` so failures show actual/expected values.
  - \`strict_impl.rs\`: add direct happy-path tests for \`strict_div\`, \`strict_rem\`, \`strict_shr\` (previously only asserted inside the nightly-gated const-eval block).
  - \`cios_row_ops_impl.rs\`: add a hand-checked N=2 test for \`mul_acc_shift_row\` plus a Ct/Nct parity check.

## Test plan

- [x] \`cargo test --lib\`: 191/191
- [x] \`cargo test --tests\`: 8/8 integration
- [x] \`cargo clippy --lib --tests\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo +nightly test --lib --features nightly\` passes
- [x] \`cargo test --lib --features cios cios_row\` covers the new \`mul_acc_shift_row\` cases

## Summary by Sourcery

Align fixed-width byte conversions, power-of-two semantics, and row ops tests with review feedback while tightening invariants and CT tooling.

Bug Fixes:
- Make big-endian fixed-width byte serialization use the trailing window so oversized buffers round-trip correctly.
- Ensure constant-time personality of wrapping_next_power_of_two wraps to zero on overflow, matching the non-CT personality and std primitives.
- Reject NonZeroFixedUInt default construction for N=0 at compile time to preserve the non-zero invariant.

Enhancements:
- Clarify IsolateHighestOne documentation regarding non-constant-time behavior and point to a CT-safe alternative.
- Strengthen ct-verify helper allowlist to match only the known FixedUInt CT trait implementations.
- Improve integer test diagnostics by requiring Debug and using assert_eq for clearer failure output.
- Add explicit happy-path tests for strict_shr, strict_div, strict_rem to exercise strict arithmetic APIs.
- Add targeted tests for mul_acc_shift_row, including a hand-checked case and Ct/Nct parity check.

Build:
- Move modmath-cios git source configuration from a workspace-level patch to the dependency entry itself to simplify crate wiring.