### PR TITLE
Switch modmath-cios from git tag to crates.io 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,8 +67,7 @@ version = "2.6"
 default-features = false
 
 [dependencies.modmath-cios]
-git = "https://github.com/kaidokert/modmath-rs"
-tag = "v0.4.0-alpha.0"
+version = "0.1"
 optional = true
 default-features = false
 


### PR DESCRIPTION
\`modmath-cios 0.1.0\` is now on crates.io, so drop the git+tag source on the optional \`cios\` feature and swap back to the registry version.

## Change

\`\`\`diff
 [dependencies.modmath-cios]
-git = "https://github.com/kaidokert/modmath-rs"
-tag = "v0.4.0-alpha.0"
+version = "0.1"
 optional = true
 default-features = false
\`\`\`

Same source revision, resolved via the registry checksum instead of a git clone. As a side effect, \`cargo check --no-default-features\` no longer touches the modmath-rs git URL at all — codex's original complaint on PR #128 is fully resolved.

## Test plan

- [x] \`cargo test --lib\` — 191/191
- [x] \`cargo test --lib --features cios cios_row\` — 7/7 (resolves \`modmath-cios v0.1.0\` from crates.io)
- [x] Cargo.lock shows \`source = "registry+https://github.com/rust-lang/crates.io-index"\` for modmath-cios
- [x] \`cargo clippy --lib --tests\` clean
- [x] \`cargo fmt --check\` clean