### PR TITLE
Add FromByteSlice impl and by-reference ToBytes for FixedUInt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ members = [
 ]
 resolver = "2"
 
-
 # Pinned release profile: deterministic codegen so a passing PR locks
 # the inspection output.
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,16 +50,8 @@ version = "0.1.45"
 optional = true
 default-features = false
 
-# TEMPORARY: git dep on v0.1.2-alpha.0 (adds `FromByteSlice`) while
-# the byte-trait alignment is being prototyped across fixed-bigint,
-# rsa/new_reduce, and ed25519_heapless. Switches back to `version =
-# "0.1.2"` (crates.io) once the release lands. Direct git dep — not
-# a `[patch.crates-io]` block — so downstream consumers get the tag
-# transitively without having to repeat the patch in their own
-# workspace manifests.
 [dependencies.const-num-traits]
-git = "https://github.com/kaidokert/num-traits.git"
-tag = "v0.1.2-alpha.0"
+version = "0.1.2"
 default-features = false
 features = ["ct"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ members = [
 ]
 resolver = "2"
 
+# TEMPORARY: pull the v0.1.2-alpha.0 const-num-traits (adds
+# `FromByteSlice`) from git while the byte-trait alignment is being
+# prototyped across fixed-bigint / rsa/new_reduce / ed25519_heapless.
+# Drop this block once 0.1.2 is on crates.io.
+[patch.crates-io]
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.1.2-alpha.0" }
+
 # Pinned release profile: deterministic codegen so a passing PR locks
 # the inspection output.
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,6 @@ members = [
 ]
 resolver = "2"
 
-# TEMPORARY: pull the v0.1.2-alpha.0 const-num-traits (adds
-# `FromByteSlice`) from git while the byte-trait alignment is being
-# prototyped across fixed-bigint / rsa/new_reduce / ed25519_heapless.
-# Drop this block once 0.1.2 is on crates.io.
-[patch.crates-io]
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.1.2-alpha.0" }
 
 # Pinned release profile: deterministic codegen so a passing PR locks
 # the inspection output.
@@ -56,8 +50,16 @@ version = "0.1.45"
 optional = true
 default-features = false
 
+# TEMPORARY: git dep on v0.1.2-alpha.0 (adds `FromByteSlice`) while
+# the byte-trait alignment is being prototyped across fixed-bigint,
+# rsa/new_reduce, and ed25519_heapless. Switches back to `version =
+# "0.1.2"` (crates.io) once the release lands. Direct git dep — not
+# a `[patch.crates-io]` block — so downstream consumers get the tag
+# transitively without having to repeat the patch in their own
+# workspace manifests.
 [dependencies.const-num-traits]
-version = "0.1.1"
+git = "https://github.com/kaidokert/num-traits.git"
+tag = "v0.1.2-alpha.0"
 default-features = false
 features = ["ct"]
 

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,7 +22,10 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { version = "0.1", default-features = false, features = ["ct"] }
+# TEMPORARY: kept in sync with the root manifest (v0.1.2-alpha.0
+# adds `FromByteSlice`). Reverts to `version = "0.1.2"` once on
+# crates.io.
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.1.2-alpha.0", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,10 +22,7 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-# TEMPORARY: kept in sync with the root manifest (v0.1.2-alpha.0
-# adds `FromByteSlice`). Reverts to `version = "0.1.2"` once on
-# crates.io.
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.1.2-alpha.0", default-features = false, features = ["ct"] }
+const-num-traits = { version = "0.1.2", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -14,10 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-# TEMPORARY: kept in sync with the root manifest (v0.1.2-alpha.0
-# adds `FromByteSlice`). Reverts to `version = "0.1.2"` once on
-# crates.io.
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.1.2-alpha.0", default-features = false }
+const-num-traits = { version = "0.1.2", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,
 # panic=abort) is what makes DCE worth measuring; do not override here.

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -14,7 +14,10 @@ crate-type = ["staticlib"]
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { version = "0.1", default-features = false }
+# TEMPORARY: kept in sync with the root manifest (v0.1.2-alpha.0
+# adds `FromByteSlice`). Reverts to `version = "0.1.2"` once on
+# crates.io.
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.1.2-alpha.0", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,
 # panic=abort) is what makes DCE worth measuring; do not override here.

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -31,6 +31,7 @@ mod cios_row_ops_impl;
 mod div_ceil_impl;
 mod euclid;
 mod extended_precision_impl;
+mod from_byte_slice_impl;
 mod has_nonzero_impl;
 mod has_personality_impl;
 mod ilog_impl;

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -141,6 +141,54 @@ c0nst::c0nst! {
             Self::from_array(impl_from_be_bytes_slice::<T, N>(bytes.as_ref()))
         }
     }
+
+    // `ToBytes for &FixedUInt` — CT nonce path counterpart of the owned
+    // impl above. See `to_from_bytes.rs` for the rationale (calling
+    // `.to_le_bytes()` on `Zeroizing<T>` via `(*r)` deref-copies the
+    // secret onto the stack; the by-reference impl reads limbs through
+    // the reference so no owned `FixedUInt` materializes).
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> ToBytes for &FixedUInt<T, N, P>
+    where
+        [(); byte_len::<T, N>()]:,
+        <T as ToBytes>::Bytes: Copy + [c0nst] AsRef<[u8]>,
+    {
+        type Bytes = ConstBytesHolder<{ byte_len::<T, N>() }>;
+
+        fn to_le_bytes(self) -> Self::Bytes {
+            let mut result = ConstBytesHolder { bytes: [0u8; byte_len::<T, N>()] };
+            let word_size = size_of::<T>();
+            let mut i = 0;
+            while i < N {
+                let word_bytes = ToBytes::to_le_bytes(self.array[i]);
+                let src = word_bytes.as_ref();
+                let mut j = 0;
+                while j < word_size {
+                    result.bytes[i * word_size + j] = src[j];
+                    j += 1;
+                }
+                i += 1;
+            }
+            result
+        }
+
+        fn to_be_bytes(self) -> Self::Bytes {
+            let mut result = ConstBytesHolder { bytes: [0u8; byte_len::<T, N>()] };
+            let word_size = size_of::<T>();
+            let mut i = 0;
+            while i < N {
+                let word_idx = N - 1 - i;
+                let word_bytes = ToBytes::to_be_bytes(self.array[word_idx]);
+                let src = word_bytes.as_ref();
+                let mut j = 0;
+                while j < word_size {
+                    result.bytes[i * word_size + j] = src[j];
+                    j += 1;
+                }
+                i += 1;
+            }
+            result
+        }
+    }
 }
 
 // Note: num_traits::ToBytes/FromBytes impls are in to_from_bytes.rs

--- a/src/fixeduint/from_byte_slice_impl.rs
+++ b/src/fixeduint/from_byte_slice_impl.rs
@@ -15,18 +15,29 @@
 use super::{FixedUInt, MachineWord};
 use const_num_traits::{ByteSliceError, ByteSliceErrorKind, FromByteSlice, Personality};
 
-impl<T: MachineWord, const N: usize, P: Personality> FromByteSlice for FixedUInt<T, N, P> {
-    fn from_be_slice(bytes: &[u8]) -> Result<Self, ByteSliceError> {
-        if bytes.is_empty() {
+impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
+    /// Length-check for the `FromByteSlice` methods: empty → `Empty`,
+    /// wider-than-`BYTE_WIDTH` → `Overflow`. Kept out-of-line so both
+    /// endianness bodies can share the same failure paths.
+    #[inline]
+    fn check_slice_len(len: usize) -> Result<(), ByteSliceError> {
+        if len == 0 {
             return Err(ByteSliceError {
                 kind: ByteSliceErrorKind::Empty,
             });
         }
-        if bytes.len() > Self::BYTE_WIDTH {
+        if len > Self::BYTE_WIDTH {
             return Err(ByteSliceError {
                 kind: ByteSliceErrorKind::Overflow,
             });
         }
+        Ok(())
+    }
+}
+
+impl<T: MachineWord, const N: usize, P: Personality> FromByteSlice for FixedUInt<T, N, P> {
+    fn from_be_slice(bytes: &[u8]) -> Result<Self, ByteSliceError> {
+        Self::check_slice_len(bytes.len())?;
         // `from_be_bytes` already zero-extends shorter input (BE
         // reads from the trailing window and initialises the array
         // to zero).
@@ -34,16 +45,7 @@ impl<T: MachineWord, const N: usize, P: Personality> FromByteSlice for FixedUInt
     }
 
     fn from_le_slice(bytes: &[u8]) -> Result<Self, ByteSliceError> {
-        if bytes.is_empty() {
-            return Err(ByteSliceError {
-                kind: ByteSliceErrorKind::Empty,
-            });
-        }
-        if bytes.len() > Self::BYTE_WIDTH {
-            return Err(ByteSliceError {
-                kind: ByteSliceErrorKind::Overflow,
-            });
-        }
+        Self::check_slice_len(bytes.len())?;
         Ok(Self::from_le_bytes(bytes))
     }
 }

--- a/src/fixeduint/from_byte_slice_impl.rs
+++ b/src/fixeduint/from_byte_slice_impl.rs
@@ -1,0 +1,142 @@
+//! `const_num_traits::FromByteSlice` for FixedUInt.
+//!
+//! Parses a big/little-endian byte slice of *arbitrary* length up to
+//! `Self::BYTE_WIDTH`, zero-extending shorter input and rejecting
+//! wider input with `ByteSliceErrorKind::Overflow`. Empty input is
+//! `ByteSliceErrorKind::Empty` per upstream — a missing buffer
+//! shouldn't masquerade as zero.
+//!
+//! This is the additive first hop of the byte-trait alignment across
+//! `fixed-bigint` / `rsa/new_reduce` / `ed25519_heapless`. Enables
+//! downstream to drop the `<T as FromBytes>::Bytes: Default +
+//! AsMut<[u8]>` padding-and-dance idiom and bind a single
+//! `T: FromByteSlice` supertrait instead.
+
+use super::{FixedUInt, MachineWord};
+use const_num_traits::{ByteSliceError, ByteSliceErrorKind, FromByteSlice, Personality};
+
+impl<T: MachineWord, const N: usize, P: Personality> FromByteSlice for FixedUInt<T, N, P> {
+    fn from_be_slice(bytes: &[u8]) -> Result<Self, ByteSliceError> {
+        if bytes.is_empty() {
+            return Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Empty,
+            });
+        }
+        if bytes.len() > Self::BYTE_WIDTH {
+            return Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Overflow,
+            });
+        }
+        // `from_be_bytes` already zero-extends shorter input (BE
+        // reads from the trailing window and initialises the array
+        // to zero).
+        Ok(Self::from_be_bytes(bytes))
+    }
+
+    fn from_le_slice(bytes: &[u8]) -> Result<Self, ByteSliceError> {
+        if bytes.is_empty() {
+            return Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Empty,
+            });
+        }
+        if bytes.len() > Self::BYTE_WIDTH {
+            return Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Overflow,
+            });
+        }
+        Ok(Self::from_le_bytes(bytes))
+    }
+}
+
+// No `&FixedUInt: FromByteSlice` mirror — an associated fn returning
+// `Self = &FixedUInt` has no storage source. Consumers who want to
+// parse into an owned `FixedUInt` bind on `FixedUInt: FromByteSlice`;
+// no reference-projection bound is needed on the read side.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type U16 = FixedUInt<u8, 2>;
+    type U32 = FixedUInt<u8, 4>;
+
+    #[test]
+    fn from_be_slice_exact() {
+        assert_eq!(U16::from_be_slice(&[0x12, 0x34]), Ok(U16::from(0x1234u16)));
+    }
+
+    #[test]
+    fn from_be_slice_short_zero_extends() {
+        // Two-byte target reading one byte: value is 0x00_12.
+        assert_eq!(U16::from_be_slice(&[0x12]), Ok(U16::from(0x12u8)));
+    }
+
+    #[test]
+    fn from_be_slice_overflow() {
+        assert!(matches!(
+            U16::from_be_slice(&[1, 2, 3]),
+            Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Overflow
+            })
+        ));
+    }
+
+    #[test]
+    fn from_be_slice_empty() {
+        assert!(matches!(
+            U16::from_be_slice(&[]),
+            Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Empty
+            })
+        ));
+    }
+
+    #[test]
+    fn from_le_slice_exact() {
+        assert_eq!(
+            U32::from_le_slice(&[1, 2, 3, 4]),
+            Ok(U32::from(0x04030201u32))
+        );
+    }
+
+    #[test]
+    fn from_le_slice_short_zero_extends() {
+        // Four-byte target reading two bytes: value is 0x00_00_02_01.
+        assert_eq!(U32::from_le_slice(&[1, 2]), Ok(U32::from(0x0201u16)));
+    }
+
+    #[test]
+    fn from_le_slice_overflow() {
+        assert!(matches!(
+            U32::from_le_slice(&[1, 2, 3, 4, 5]),
+            Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Overflow
+            })
+        ));
+    }
+
+    #[test]
+    fn from_le_slice_empty() {
+        assert!(matches!(
+            U32::from_le_slice(&[]),
+            Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Empty
+            })
+        ));
+    }
+
+    #[test]
+    fn le_be_roundtrip_matches_slice_readers() {
+        // Cross-check: FromByteSlice::from_*_slice for exact-width
+        // input agrees with the inherent from_*_bytes.
+        let bytes = [0x12u8, 0x34, 0x56, 0x78];
+        assert_eq!(
+            U32::from_be_slice(&bytes).unwrap(),
+            U32::from_be_bytes(&bytes)
+        );
+        assert_eq!(
+            U32::from_le_slice(&bytes).unwrap(),
+            U32::from_le_bytes(&bytes)
+        );
+    }
+}

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -176,6 +176,27 @@ where
     }
 }
 
+// `ToBytes for &FixedUInt` — needed by CT nonce paths where the value
+// lives behind `Zeroizing<T>` and `(*r).to_le_bytes()` would deref-copy
+// an unwrapped secret onto the stack. `<&T as ToBytes>::to_le_bytes(&*r)`
+// reads through the reference; only the output `BytesHolder` is
+// unwrapped material and the caller can wrap that (or rely on the
+// crate-side `ZeroizeOnDrop` when the feature is on).
+#[cfg(not(feature = "nightly"))]
+impl<T: MachineWord, const N: usize, P: Personality> const_num_traits::ToBytes
+    for &FixedUInt<T, N, P>
+where
+    T: core::fmt::Debug,
+{
+    type Bytes = BytesHolder<T, N>;
+    fn to_be_bytes(self) -> Self::Bytes {
+        self.holder_be()
+    }
+    fn to_le_bytes(self) -> Self::Bytes {
+        self.holder_le()
+    }
+}
+
 #[cfg(not(feature = "nightly"))]
 impl<T: MachineWord, const N: usize, P: Personality> const_num_traits::FromBytes
     for FixedUInt<T, N, P>

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -118,16 +118,24 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P>
 where
     T: core::fmt::Debug,
 {
+    // Zero-init (`BytesHolder::default()`) rather than
+    // `BytesHolder::from_array(self.array)`. On the `&FixedUInt` path
+    // the latter would materialise the secret limb array on the stack
+    // as a Copy of the referenced `[T; N]` before the serialisation
+    // step overwrites it — defeating the CT/Zeroize goal of the
+    // by-reference impl. Zero-init writes serialised bytes through
+    // the reference directly. Also removes a wasted Copy on the
+    // owned path.
     #[inline]
     fn holder_be(&self) -> BytesHolder<T, N> {
-        let mut ret = BytesHolder::from_array(self.array);
+        let mut ret = BytesHolder::default();
         let _ = self.to_be_bytes(ret.as_byte_slice_mut());
         ret
     }
 
     #[inline]
     fn holder_le(&self) -> BytesHolder<T, N> {
-        let mut ret = BytesHolder::from_array(self.array);
+        let mut ret = BytesHolder::default();
         let _ = self.to_le_bytes(ret.as_byte_slice_mut());
         ret
     }


### PR DESCRIPTION
## Summary

- Adds `impl const_num_traits::FromByteSlice for FixedUInt<T, N, P>` — length-checked slice parser. Empty → `Empty`, wider-than-`BYTE_WIDTH` → `Overflow`, shorter zero-extends. Capability (b) of the byte-trait alignment.
- Adds `impl const_num_traits::ToBytes for &FixedUInt<T, N, P>` on both stable and nightly. Body reads limbs through the reference so a `Zeroizing<FixedUInt>` secret nonce isn't deref-copied onto the stack when its bytes are exported. Path (1) / capability (w-CT).
- Temporary `[patch.crates-io]` pointing `const-num-traits` at git tag `v0.1.2-alpha.0` (where the trait ships). Drop once 0.1.2 hits crates.io.

Additive only — no existing behavior changes, no associated types flipped. Full context and the four-way capability split in `notes/BYTES_TRAIT_ALIGNMENT.md` (local, gitignored); upstream design in `num-traits/notes/BYTE_TRAIT_ECOSYSTEM.md`.

## Deferred

- **Path (2)** — the semver-breaking flip of `const_num_traits::FromBytes::Bytes` from `BytesHolder<T, N>` to `[u8]`. Lands after `rsa/new_reduce` migrates off its `<T as FromBytes>::Bytes: Default + AsMut<[u8]>` structural bound. Sequencing keeps every consumer in a compilable state at every hop.
- **Capability (c)** — const-eval `from_{le,be}_bytes_const<K>(&[u8; K])` inherents. The `c0nst` DSL rejects `[c0nst]` bounds on inherent impls (nightly requirement), and `impl_from_*_bytes_slice` is const-callable only from within a c0nst trait impl. Needs either a stable rewrite of the slice reader or a separate const-trait home. Not blocking the RSA migration; follow-up PR.

## Test plan

- [ ] Prototype `rsa/new_reduce` against this branch as a git dep — confirm `try_from_be_bytes_vartime` migrates to `T::from_be_slice(bytes)` cleanly and the `Bytes: Default + AsMut<[u8]>` bound drops.
- [ ] Prototype `ed25519_heapless` blanket `impl UnsignedModularInt for T where T: ToBytes + FromBytes<Bytes = [u8]>` — will need Path (2) first, but the `&T: ToBytes` bound this PR adds is exercised.
- [ ] Confirm the `[patch.crates-io]` block resolves in workspace-parent lockfiles without requiring downstream consumers to add their own patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for parsing and emitting byte slices for FixedUInt, including reference-based ToBytes implementations and a temporary dependency patch to const-num-traits.

New Features:
- Implement const_num_traits::FromByteSlice for FixedUInt to parse variable-length big- and little-endian byte slices with overflow and empty-input error handling.
- Add const_num_traits::ToBytes for &FixedUInt on both nightly and stable builds to allow by-reference byte extraction for CT nonce paths.

Enhancements:
- Introduce dedicated from_byte_slice_impl module and basic roundtrip tests for FixedUInt byte-slice parsing semantics.

Build:
- Patch const-num-traits to a specific git tag providing FromByteSlice while the byte-trait alignment is being prototyped.

Tests:
- Add unit tests covering FromByteSlice behavior for exact-width, short, overflow, empty, and roundtrip byte-slice conversions for FixedUInt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added byte-slice constructors for fixed-size integers with little-endian and big-endian parsing (up to the maximum width).
  * Added serialization support for borrowed fixed-size integers into byte representations (non-nightly builds).
* **Bug Fixes**
  * Improved byte-slice parsing error handling for empty input and overflow-length slices.
* **Maintenance**
  * Updated crate and dependency versions.
* **Tests**
  * Added/expanded coverage to validate endianness, exact-width equivalence, zero-extension, and error kinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->