### PR TITLE
Adopt const-num-traits v0.2 and fix &FixedUInt CT deref-copies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.5.1"
+version = "0.5.0"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"
@@ -49,8 +49,16 @@ version = "0.1.45"
 optional = true
 default-features = false
 
+# TEMPORARY: git dep on v0.2.0-alpha.1 while the breaking
+# operator-supertrait decoupling (each checked/wrapping/saturating/
+# overflowing/strict/euclid/rounding/carrying trait carries its own
+# `type Output`, no longer supertraits `core::ops::*`) is being
+# integrated. Switches back to `version = "0.2"` (crates.io) once the
+# release lands. Direct git dep — not `[patch.crates-io]` — so
+# downstream consumers get the tag transitively.
 [dependencies.const-num-traits]
-version = "0.1.2"
+git = "https://github.com/kaidokert/num-traits.git"
+tag = "v0.2.0-alpha.1"
 default-features = false
 features = ["ct"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,16 +49,8 @@ version = "0.1.45"
 optional = true
 default-features = false
 
-# TEMPORARY: git dep on v0.2.0-alpha.1 while the breaking
-# operator-supertrait decoupling (each checked/wrapping/saturating/
-# overflowing/strict/euclid/rounding/carrying trait carries its own
-# `type Output`, no longer supertraits `core::ops::*`) is being
-# integrated. Switches back to `version = "0.2"` (crates.io) once the
-# release lands. Direct git dep — not `[patch.crates-io]` — so
-# downstream consumers get the tag transitively.
 [dependencies.const-num-traits]
-git = "https://github.com/kaidokert/num-traits.git"
-tag = "v0.2.0-alpha.1"
+version = "0.2"
 default-features = false
 features = ["ct"]
 

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -220,6 +220,7 @@ const HELPER_ALLOWLIST: &[&str] = &[
     r"fixed_bigint9fixeduint23const_trailing_zeros_ct",
     // Per-limb arithmetic — N-bounded loops.
     r"fixed_bigint9fixeduint14add_with_carry",
+    r"fixed_bigint9fixeduint15sub_with_borrow",
     r"fixed_bigint9fixeduint9const_mul",
     r"fixed_bigint9fixeduint8add_impl",
     r"fixed_bigint9fixeduint8sub_impl",

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,9 +22,7 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-# TEMPORARY: kept in sync with the root manifest (v0.2.0-alpha.1).
-# Reverts to `version = "0.2"` once on crates.io.
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
+const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,7 +22,9 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { version = "0.1.2", default-features = false, features = ["ct"] }
+# TEMPORARY: kept in sync with the root manifest (v0.2.0-alpha.1).
+# Reverts to `version = "0.2"` once on crates.io.
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -14,9 +14,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-# TEMPORARY: kept in sync with the root manifest (v0.2.0-alpha.1).
-# Reverts to `version = "0.2"` once on crates.io.
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false }
+const-num-traits = { version = "0.2", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,
 # panic=abort) is what makes DCE worth measuring; do not override here.

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -14,7 +14,9 @@ crate-type = ["staticlib"]
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { version = "0.1.2", default-features = false }
+# TEMPORARY: kept in sync with the root manifest (v0.2.0-alpha.1).
+# Reverts to `version = "0.2"` once on crates.io.
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.0-alpha.1", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,
 # panic=abort) is what makes DCE worth measuring; do not override here.

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -188,21 +188,24 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N, Ct> {
     /// validity Choice carries the overflow flag without exposing it as
     /// a control-flow signal.
     pub fn ct_checked_add(&self, other: &Self) -> subtle::CtOption<Self> {
-        let (res, overflow) = <Self as OverflowingAdd>::overflowing_add(*self, *other);
+        // Route through `&Self: OverflowingAdd` — reads limbs through
+        // the references (see `add_sub_impl.rs`), avoiding an
+        // intermediate deref-copy of the wrapped secret onto the stack.
+        let (res, overflow) = <&Self as OverflowingAdd>::overflowing_add(self, other);
         let valid = subtle::Choice::from((!overflow) as u8);
         subtle::CtOption::new(res, valid)
     }
 
     /// CT-friendly counterpart to `num_traits::CheckedSub::checked_sub`.
     pub fn ct_checked_sub(&self, other: &Self) -> subtle::CtOption<Self> {
-        let (res, overflow) = <Self as OverflowingSub>::overflowing_sub(*self, *other);
+        let (res, overflow) = <&Self as OverflowingSub>::overflowing_sub(self, other);
         let valid = subtle::Choice::from((!overflow) as u8);
         subtle::CtOption::new(res, valid)
     }
 
     /// CT-friendly counterpart to `num_traits::CheckedMul::checked_mul`.
     pub fn ct_checked_mul(&self, other: &Self) -> subtle::CtOption<Self> {
-        let (res, overflow) = <Self as OverflowingMul>::overflowing_mul(*self, *other);
+        let (res, overflow) = <&Self as OverflowingMul>::overflowing_mul(self, other);
         let valid = subtle::Choice::from((!overflow) as u8);
         subtle::CtOption::new(res, valid)
     }
@@ -216,8 +219,13 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N, Ct> {
     /// `OverflowingShl::overflowing_shl` which routes through
     /// `normalize_shift_amount`'s tainted branch + variable-time modulo.
     pub fn ct_checked_shl(&self, bits: u32) -> subtle::CtOption<Self> {
+        // `const_unbounded_shl_u32` takes owned `FixedUInt<T,N,Ct>` and
+        // materialises a shifted copy on the stack regardless of input
+        // shape — same cost as `*self`. Kept explicit here so a future
+        // slice-based helper can replace this line without changing
+        // callers.
         subtle::CtOption::new(
-            bit_ops_impl::const_unbounded_shl_u32::<T, N, Ct>(*self, bits),
+            bit_ops_impl::const_unbounded_shl_u32::<T, N, Ct>(Self::from_array(self.array), bits),
             ct_checked_shift_valid(bits, Self::BIT_SIZE),
         )
     }
@@ -228,7 +236,7 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N, Ct> {
     /// `const_unbounded_shr_u32`, validity flag derived branchlessly.
     pub fn ct_checked_shr(&self, bits: u32) -> subtle::CtOption<Self> {
         subtle::CtOption::new(
-            bit_ops_impl::const_unbounded_shr_u32::<T, N, Ct>(*self, bits),
+            bit_ops_impl::const_unbounded_shr_u32::<T, N, Ct>(Self::from_array(self.array), bits),
             ct_checked_shift_valid(bits, Self::BIT_SIZE),
         )
     }
@@ -386,7 +394,10 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P> {
 
     /// Returns number of used bits.
     pub fn bit_length(&self) -> u32 {
-        Self::BIT_SIZE as u32 - PrimBits::leading_zeros(*self)
+        // `PrimBits::leading_zeros` takes `self` by value; slice-based
+        // `const_leading_zeros` in the same crate reads the array
+        // directly and avoids materialising a fresh FixedUInt.
+        Self::BIT_SIZE as u32 - const_leading_zeros(&self.array)
     }
 }
 

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -181,7 +181,7 @@ fn ct_checked_shift_valid(bits: u32, bit_size: usize) -> subtle::Choice {
     subtle::Choice::from(1 ^ overflow)
 }
 
-impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize> FixedUInt<T, N, Ct> {
+impl<T: MachineWord, const N: usize> FixedUInt<T, N, Ct> {
     /// CT-friendly counterpart to `num_traits::CheckedAdd::checked_add`.
     /// Returns `CtOption::new(res, Choice::from(!overflow))` — the result is
     /// always computed (always-iterate via overflowing_add), and the
@@ -233,41 +233,7 @@ impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize> FixedUInt
         )
     }
 
-    /// CT-friendly counterpart to `NextPowerOfTwo::checked_next_power_of_two`.
-    pub fn ct_checked_next_power_of_two(self) -> subtle::CtOption<Self>
-    where
-        T: subtle::ConstantTimeEq,
-    {
-        let one = <Self as One>::one();
-        let m_one = <Self as const_num_traits::WrappingSub>::wrapping_sub(self, one);
-        let leading = <Self as PrimBits>::leading_zeros(m_one);
-        let bits = Self::BIT_SIZE as u32 - leading;
-        let shifted = one << (bits as usize);
-        let is_zero_choice =
-            <Self as subtle::ConstantTimeEq>::ct_eq(&self, &<Self as Zero>::zero());
-        // result = is_zero ? 1 : shifted
-        let result = <Self as subtle::ConditionallySelectable>::conditional_select(
-            &shifted,
-            &one,
-            is_zero_choice,
-        );
-        // overflow iff bits >= BIT_SIZE; when input == 0 we treat as valid
-        // (the answer is 1).
-        let overflow = (bits >= Self::BIT_SIZE as u32) as u8;
-        let valid_otherwise = subtle::Choice::from(1u8 ^ overflow);
-        let valid = <subtle::Choice as subtle::ConditionallySelectable>::conditional_select(
-            &valid_otherwise,
-            &subtle::Choice::from(1u8),
-            is_zero_choice,
-        );
-        subtle::CtOption::new(result, valid)
-    }
-
-    pub fn ct_checked_pow(self, exp: u32) -> subtle::CtOption<Self>
-    where
-        T: subtle::ConstantTimeEq + subtle::ConstantTimeGreater,
-        for<'a> &'a Self: core::ops::Mul<&'a Self, Output = Self>,
-    {
+    pub fn ct_checked_pow(self, exp: u32) -> subtle::CtOption<Self> {
         let mut result = <Self as One>::one();
         let mut base = self;
         let mut e = exp;
@@ -295,6 +261,44 @@ impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize> FixedUInt
             base = new_base;
         }
         let valid = subtle::Choice::from(1u8 ^ any_overflow);
+        subtle::CtOption::new(result, valid)
+    }
+}
+
+// `ct_checked_next_power_of_two` is the only Ct inherent that consumes
+// `T: subtle::ConditionallySelectable` (via the branchless "1 iff zero
+// else shifted" select). Kept in its own impl block so the six
+// sibling `ct_checked_{add,sub,mul,shl,shr,pow}` methods are reachable
+// under the bare `T: MachineWord` bound that a CT-secure downstream
+// generic normally carries.
+impl<T: MachineWord + subtle::ConditionallySelectable, const N: usize> FixedUInt<T, N, Ct> {
+    /// CT-friendly counterpart to `NextPowerOfTwo::checked_next_power_of_two`.
+    pub fn ct_checked_next_power_of_two(self) -> subtle::CtOption<Self>
+    where
+        T: subtle::ConstantTimeEq,
+    {
+        let one = <Self as One>::one();
+        let m_one = <Self as const_num_traits::WrappingSub>::wrapping_sub(self, one);
+        let leading = <Self as PrimBits>::leading_zeros(m_one);
+        let bits = Self::BIT_SIZE as u32 - leading;
+        let shifted = one << (bits as usize);
+        let is_zero_choice =
+            <Self as subtle::ConstantTimeEq>::ct_eq(&self, &<Self as Zero>::zero());
+        // result = is_zero ? 1 : shifted
+        let result = <Self as subtle::ConditionallySelectable>::conditional_select(
+            &shifted,
+            &one,
+            is_zero_choice,
+        );
+        // overflow iff bits >= BIT_SIZE; when input == 0 we treat as valid
+        // (the answer is 1).
+        let overflow = (bits >= Self::BIT_SIZE as u32) as u8;
+        let valid_otherwise = subtle::Choice::from(1u8 ^ overflow);
+        let valid = <subtle::Choice as subtle::ConditionallySelectable>::conditional_select(
+            &valid_otherwise,
+            &subtle::Choice::from(1u8),
+            is_zero_choice,
+        );
         subtle::CtOption::new(result, valid)
     }
 }

--- a/src/fixeduint/abs_diff_impl.rs
+++ b/src/fixeduint/abs_diff_impl.rs
@@ -45,7 +45,7 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> AbsDiff for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn abs_diff(self, other: Self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as AbsDiff>::abs_diff(*self, *other)
+            <FixedUInt<T, N, P> as AbsDiff>::abs_diff(FixedUInt::from_array(self.array), FixedUInt::from_array(other.array))
         }
     }
 }

--- a/src/fixeduint/add_sub_impl.rs
+++ b/src/fixeduint/add_sub_impl.rs
@@ -110,16 +110,19 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Add<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn add(self, other: FixedUInt<T, N, P>) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N, P> as OverflowingAdd>::overflowing_add(*self, other);
+            // Read `self.array` through the reference (no `*self`
+            // deref-copy of the full FixedUInt). `other` is already
+            // owned on this frame, so passing its array by ref is free.
+            let (array, overflow) = add_with_carry(&self.array, &other.array, false);
             maybe_panic_if::<P>(overflow, PanicReason::Add);
-            res
+            FixedUInt::from_array(array)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Add<Self> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn add(self, other: Self) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N, P> as OverflowingAdd>::overflowing_add(*self, *other);
+            let (res, overflow) = <Self as OverflowingAdd>::overflowing_add(self, other);
             maybe_panic_if::<P>(overflow, PanicReason::Add);
             res
         }
@@ -137,17 +140,17 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Sub<FixedUInt<T, N, P>> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn sub(self, other: FixedUInt<T, N, P>) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N, P> as OverflowingSub>::overflowing_sub(*self, other);
-            maybe_panic_if::<P>(overflow, PanicReason::Sub);
-            res
+            let (array, borrow) = sub_with_borrow(&self.array, &other.array, false);
+            maybe_panic_if::<P>(borrow, PanicReason::Sub);
+            FixedUInt::from_array(array)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Sub<Self> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn sub(self, other: Self) -> Self::Output {
-            let (res, overflow) = <FixedUInt<T, N, P> as OverflowingSub>::overflowing_sub(*self, *other);
-            maybe_panic_if::<P>(overflow, PanicReason::Sub);
+            let (res, borrow) = <Self as OverflowingSub>::overflowing_sub(self, other);
+            maybe_panic_if::<P>(borrow, PanicReason::Sub);
             res
         }
     }
@@ -284,7 +287,7 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::overflowin
     for FixedUInt<T, N, P>
 {
     fn overflowing_add(&self, other: &Self) -> (Self, bool) {
-        <Self as OverflowingAdd>::overflowing_add(*self, *other)
+        <&Self as OverflowingAdd>::overflowing_add(self, other)
     }
 }
 
@@ -293,14 +296,14 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingAdd
     for FixedUInt<T, N, P>
 {
     fn wrapping_add(&self, other: &Self) -> Self {
-        <Self as WrappingAdd>::wrapping_add(*self, *other)
+        <&Self as WrappingAdd>::wrapping_add(self, other)
     }
 }
 
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedAdd for FixedUInt<T, N, P> {
     fn checked_add(&self, other: &Self) -> Option<Self> {
-        <Self as CheckedAdd>::checked_add(*self, *other)
+        <&Self as CheckedAdd>::checked_add(self, other)
     }
 }
 
@@ -309,7 +312,7 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::saturating
     for FixedUInt<T, N, P>
 {
     fn saturating_add(&self, other: &Self) -> Self {
-        <Self as SaturatingAdd>::saturating_add(*self, *other)
+        <&Self as SaturatingAdd>::saturating_add(self, other)
     }
 }
 
@@ -318,7 +321,7 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::overflowin
     for FixedUInt<T, N, P>
 {
     fn overflowing_sub(&self, other: &Self) -> (Self, bool) {
-        <Self as OverflowingSub>::overflowing_sub(*self, *other)
+        <&Self as OverflowingSub>::overflowing_sub(self, other)
     }
 }
 
@@ -327,14 +330,14 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingSub
     for FixedUInt<T, N, P>
 {
     fn wrapping_sub(&self, other: &Self) -> Self {
-        <Self as WrappingSub>::wrapping_sub(*self, *other)
+        <&Self as WrappingSub>::wrapping_sub(self, other)
     }
 }
 
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedSub for FixedUInt<T, N, P> {
     fn checked_sub(&self, other: &Self) -> Option<Self> {
-        <Self as CheckedSub>::checked_sub(*self, *other)
+        <&Self as CheckedSub>::checked_sub(self, other)
     }
 }
 
@@ -343,7 +346,7 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::saturating
     for FixedUInt<T, N, P>
 {
     fn saturating_sub(&self, other: &Self) -> Self {
-        <Self as SaturatingSub>::saturating_sub(*self, *other)
+        <&Self as SaturatingSub>::saturating_sub(self, other)
     }
 }
 
@@ -367,14 +370,14 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::Saturating for 
 // overflow flag to a `Choice`. Same shape upstream uses for the primitives.
 impl<T: MachineWord, const N: usize, P: Personality> CtCheckedAdd for FixedUInt<T, N, P> {
     fn ct_checked_add(&self, v: &Self) -> subtle::CtOption<Self> {
-        let (val, overflow) = <Self as OverflowingAdd>::overflowing_add(*self, *v);
+        let (val, overflow) = <&Self as OverflowingAdd>::overflowing_add(self, v);
         subtle::CtOption::new(val, subtle::Choice::from(!overflow as u8))
     }
 }
 
 impl<T: MachineWord, const N: usize, P: Personality> CtCheckedSub for FixedUInt<T, N, P> {
     fn ct_checked_sub(&self, v: &Self) -> subtle::CtOption<Self> {
-        let (val, overflow) = <Self as OverflowingSub>::overflowing_sub(*self, *v);
+        let (val, overflow) = <&Self as OverflowingSub>::overflowing_sub(self, v);
         subtle::CtOption::new(val, subtle::Choice::from(!overflow as u8))
     }
 }

--- a/src/fixeduint/add_sub_impl.rs
+++ b/src/fixeduint/add_sub_impl.rs
@@ -1,11 +1,12 @@
 use super::{
-    FixedUInt, MachineWord, PanicReason, add_impl, const_ct_select, maybe_panic_if, sub_impl,
+    FixedUInt, MachineWord, PanicReason, add_impl, add_with_carry, const_ct_select, maybe_panic_if,
+    sub_impl, sub_with_borrow,
 };
 use crate::machineword::ConstMachineWord;
 use const_num_traits::ops::ct::{CtCheckedAdd, CtCheckedSub};
 use const_num_traits::{
     Bounded, CheckedAdd, CheckedSub, ConstZero, OverflowingAdd, OverflowingSub, Personality,
-    PersonalityTag, SaturatingAdd, SaturatingSub, WrappingAdd, WrappingSub,
+    PersonalityTag, SaturatingAdd, SaturatingSub, WrappingAdd, WrappingSub, Zero,
 };
 
 c0nst::c0nst! {
@@ -196,59 +197,84 @@ c0nst::c0nst! {
     // `&FixedUInt`) without sprinkling derefs. The `Add<&FixedUInt> for
     // &FixedUInt` impls above supply `Output = FixedUInt<T,N,P>`.
 
+    // Read-through-ref primitives. The bodies MUST NOT deref-copy — that
+    // materialises the owned operand on the stack, defeating the CT /
+    // Zeroize defense-in-depth reason `&T` is used in the first place
+    // (nonce path in ed25519's CT sign, e.g. `Zeroizing<FixedUInt>` +
+    // `.wrapping_add(&r)`). `add_with_carry` / `sub_with_borrow` take
+    // `&[T; N]` and produce a fresh `[T; N]`; each `self.array[i]` /
+    // `other.array[i]` read is a per-limb Copy of `T`, not of the whole
+    // FixedUInt. `Checked*` / `Saturating*` for `&FixedUInt` below
+    // delegate here to inherit the same read-through-ref behaviour.
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingAdd for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn overflowing_add(self, other: Self) -> (FixedUInt<T, N, P>, bool) {
-            <FixedUInt<T, N, P> as OverflowingAdd>::overflowing_add(*self, *other)
+            let (array, overflow) = add_with_carry(&self.array, &other.array, false);
+            (FixedUInt::from_array(array), overflow)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingSub for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn overflowing_sub(self, other: Self) -> (FixedUInt<T, N, P>, bool) {
-            <FixedUInt<T, N, P> as OverflowingSub>::overflowing_sub(*self, *other)
+            let (array, borrow) = sub_with_borrow(&self.array, &other.array, false);
+            (FixedUInt::from_array(array), borrow)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingAdd for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn wrapping_add(self, other: Self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as WrappingAdd>::wrapping_add(*self, *other)
+            let (array, _carry) = add_with_carry(&self.array, &other.array, false);
+            FixedUInt::from_array(array)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingSub for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn wrapping_sub(self, other: Self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as WrappingSub>::wrapping_sub(*self, *other)
+            let (array, _borrow) = sub_with_borrow(&self.array, &other.array, false);
+            FixedUInt::from_array(array)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedAdd for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn checked_add(self, other: Self) -> Option<FixedUInt<T, N, P>> {
-            <FixedUInt<T, N, P> as CheckedAdd>::checked_add(*self, *other)
+            let (res, overflow) = <Self as OverflowingAdd>::overflowing_add(self, other);
+            if overflow { None } else { Some(res) }
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedSub for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn checked_sub(self, other: Self) -> Option<FixedUInt<T, N, P>> {
-            <FixedUInt<T, N, P> as CheckedSub>::checked_sub(*self, *other)
+            let (res, borrow) = <Self as OverflowingSub>::overflowing_sub(self, other);
+            if borrow { None } else { Some(res) }
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingAdd for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn saturating_add(self, other: Self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as SaturatingAdd>::saturating_add(*self, *other)
+            let (res, overflow) = <Self as OverflowingAdd>::overflowing_add(self, other);
+            if overflow {
+                <FixedUInt<T, N, P> as Bounded>::max_value()
+            } else {
+                res
+            }
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingSub for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn saturating_sub(self, other: Self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as SaturatingSub>::saturating_sub(*self, *other)
+            let (res, borrow) = <Self as OverflowingSub>::overflowing_sub(self, other);
+            if borrow {
+                <FixedUInt<T, N, P> as Zero>::zero()
+            } else {
+                res
+            }
         }
     }
 }

--- a/src/fixeduint/add_sub_impl.rs
+++ b/src/fixeduint/add_sub_impl.rs
@@ -10,6 +10,7 @@ use const_num_traits::{
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingAdd for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_add(self, other: Self) -> (Self, bool) {
             let mut ret = self;
             let overflow = add_impl(&mut ret.array, &other.array);
@@ -18,6 +19,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingSub for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_sub(self, other: Self) -> (Self, bool) {
             let mut ret = self;
             let overflow = sub_impl(&mut ret.array, &other.array);
@@ -26,18 +28,21 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingAdd for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_add(self, other: Self) -> Self {
             <Self as OverflowingAdd>::overflowing_add(self, other).0
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingSub for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_sub(self, other: Self) -> Self {
             <Self as OverflowingSub>::overflowing_sub(self, other).0
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedAdd for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_add(self, other: Self) -> Option<Self> {
             let (res, overflow) = <Self as OverflowingAdd>::overflowing_add(self, other);
             if overflow { None } else { Some(res) }
@@ -45,6 +50,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedSub for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_sub(self, other: Self) -> Option<Self> {
             let (res, overflow) = <Self as OverflowingSub>::overflowing_sub(self, other);
             if overflow { None } else { Some(res) }
@@ -52,6 +58,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingAdd for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn saturating_add(self, other: Self) -> Self {
             let (res, overflow) = <Self as OverflowingAdd>::overflowing_add(self, other);
             match P::TAG {
@@ -62,6 +69,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingSub for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn saturating_sub(self, other: Self) -> Self {
             let (res, overflow) = <Self as OverflowingSub>::overflowing_sub(self, other);
             match P::TAG {
@@ -189,48 +197,56 @@ c0nst::c0nst! {
     // &FixedUInt` impls above supply `Output = FixedUInt<T,N,P>`.
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingAdd for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_add(self, other: Self) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as OverflowingAdd>::overflowing_add(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingSub for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_sub(self, other: Self) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as OverflowingSub>::overflowing_sub(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingAdd for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_add(self, other: Self) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as WrappingAdd>::wrapping_add(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingSub for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_sub(self, other: Self) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as WrappingSub>::wrapping_sub(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedAdd for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_add(self, other: Self) -> Option<FixedUInt<T, N, P>> {
             <FixedUInt<T, N, P> as CheckedAdd>::checked_add(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedSub for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_sub(self, other: Self) -> Option<FixedUInt<T, N, P>> {
             <FixedUInt<T, N, P> as CheckedSub>::checked_sub(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingAdd for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn saturating_add(self, other: Self) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as SaturatingAdd>::saturating_add(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingSub for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn saturating_sub(self, other: Self) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as SaturatingSub>::saturating_sub(*self, *other)
         }

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -1184,13 +1184,7 @@ mod tests {
     fn test_unbounded_shift_polymorphic() {
         fn test_unbounded<T>(val: T, shift: u32, expected_shl: T, expected_shr: T)
         where
-            T: UnboundedShl<Output = T>
-                + UnboundedShr<Output = T>
-                + core::ops::Shl<u32, Output = T>
-                + core::ops::Shr<u32, Output = T>
-                + Eq
-                + core::fmt::Debug
-                + Copy,
+            T: UnboundedShl<Output = T> + UnboundedShr<Output = T> + Eq + core::fmt::Debug + Copy,
         {
             assert_eq!(UnboundedShl::unbounded_shl(val, shift), expected_shl);
             assert_eq!(UnboundedShr::unbounded_shr(val, shift), expected_shr);

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -224,56 +224,56 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Shl<usize> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: usize) -> Self::Output {
-            (*self).shl(bits)
+            FixedUInt::from_array(self.array).shl(bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Shr<usize> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: usize) -> Self::Output {
-            (*self).shr(bits)
+            FixedUInt::from_array(self.array).shr(bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Shl<u32> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: u32) -> Self::Output {
-            (*self).shl(bits)
+            FixedUInt::from_array(self.array).shl(bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Shr<u32> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: u32) -> Self::Output {
-            (*self).shr(bits)
+            FixedUInt::from_array(self.array).shr(bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Shl<&usize> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: &usize) -> Self::Output {
-            (*self).shl(*bits)
+            FixedUInt::from_array(self.array).shl(*bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Shr<&usize> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: &usize) -> Self::Output {
-            (*self).shr(*bits)
+            FixedUInt::from_array(self.array).shr(*bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Shl<&u32> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shl(self, bits: &u32) -> Self::Output {
-            (*self).shl(*bits)
+            FixedUInt::from_array(self.array).shl(*bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> core::ops::Shr<&u32> for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shr(self, bits: &u32) -> Self::Output {
-            (*self).shr(*bits)
+            FixedUInt::from_array(self.array).shr(*bits)
         }
     }
 
@@ -491,56 +491,56 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingShl for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn overflowing_shl(self, bits: u32) -> (FixedUInt<T, N, P>, bool) {
-            <FixedUInt<T, N, P> as OverflowingShl>::overflowing_shl(*self, bits)
+            <FixedUInt<T, N, P> as OverflowingShl>::overflowing_shl(FixedUInt::from_array(self.array), bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingShr for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn overflowing_shr(self, bits: u32) -> (FixedUInt<T, N, P>, bool) {
-            <FixedUInt<T, N, P> as OverflowingShr>::overflowing_shr(*self, bits)
+            <FixedUInt<T, N, P> as OverflowingShr>::overflowing_shr(FixedUInt::from_array(self.array), bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingShl for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn wrapping_shl(self, bits: u32) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as WrappingShl>::wrapping_shl(*self, bits)
+            <FixedUInt<T, N, P> as WrappingShl>::wrapping_shl(FixedUInt::from_array(self.array), bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingShr for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn wrapping_shr(self, bits: u32) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as WrappingShr>::wrapping_shr(*self, bits)
+            <FixedUInt<T, N, P> as WrappingShr>::wrapping_shr(FixedUInt::from_array(self.array), bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedShl for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn checked_shl(self, bits: u32) -> Option<FixedUInt<T, N, P>> {
-            <FixedUInt<T, N, P> as CheckedShl>::checked_shl(*self, bits)
+            <FixedUInt<T, N, P> as CheckedShl>::checked_shl(FixedUInt::from_array(self.array), bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedShr for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn checked_shr(self, bits: u32) -> Option<FixedUInt<T, N, P>> {
-            <FixedUInt<T, N, P> as CheckedShr>::checked_shr(*self, bits)
+            <FixedUInt<T, N, P> as CheckedShr>::checked_shr(FixedUInt::from_array(self.array), bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> UnboundedShl for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn unbounded_shl(self, rhs: u32) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as UnboundedShl>::unbounded_shl(*self, rhs)
+            <FixedUInt<T, N, P> as UnboundedShl>::unbounded_shl(FixedUInt::from_array(self.array), rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> UnboundedShr for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn unbounded_shr(self, rhs: u32) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as UnboundedShr>::unbounded_shr(*self, rhs)
+            <FixedUInt<T, N, P> as UnboundedShr>::unbounded_shr(FixedUInt::from_array(self.array), rhs)
         }
     }
 
@@ -581,13 +581,13 @@ c0nst::c0nst! {
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::HighestOne for &FixedUInt<T, N, P> {
         fn highest_one(self) -> Option<u32> {
-            <FixedUInt<T, N, P> as const_num_traits::HighestOne>::highest_one(*self)
+            <FixedUInt<T, N, P> as const_num_traits::HighestOne>::highest_one(FixedUInt::from_array(self.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::LowestOne for &FixedUInt<T, N, P> {
         fn lowest_one(self) -> Option<u32> {
-            <FixedUInt<T, N, P> as const_num_traits::LowestOne>::lowest_one(*self)
+            <FixedUInt<T, N, P> as const_num_traits::LowestOne>::lowest_one(FixedUInt::from_array(self.array))
         }
     }
 
@@ -604,7 +604,7 @@ c0nst::c0nst! {
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::BitWidth for &FixedUInt<T, N, P> {
         fn bit_width(self) -> u32 {
-            <FixedUInt<T, N, P> as const_num_traits::BitWidth>::bit_width(*self)
+            <FixedUInt<T, N, P> as const_num_traits::BitWidth>::bit_width(FixedUInt::from_array(self.array))
         }
     }
 
@@ -653,14 +653,14 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::IsolateHighestOne for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn isolate_highest_one(self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as const_num_traits::IsolateHighestOne>::isolate_highest_one(*self)
+            <FixedUInt<T, N, P> as const_num_traits::IsolateHighestOne>::isolate_highest_one(FixedUInt::from_array(self.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::IsolateLowestOne for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn isolate_lowest_one(self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as const_num_traits::IsolateLowestOne>::isolate_lowest_one(*self)
+            <FixedUInt<T, N, P> as const_num_traits::IsolateLowestOne>::isolate_lowest_one(FixedUInt::from_array(self.array))
         }
     }
 
@@ -705,14 +705,14 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::ShlExact for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shl_exact(self, rhs: u32) -> Option<FixedUInt<T, N, P>> {
-            <FixedUInt<T, N, P> as const_num_traits::ShlExact>::shl_exact(*self, rhs)
+            <FixedUInt<T, N, P> as const_num_traits::ShlExact>::shl_exact(FixedUInt::from_array(self.array), rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::ShrExact for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn shr_exact(self, rhs: u32) -> Option<FixedUInt<T, N, P>> {
-            <FixedUInt<T, N, P> as const_num_traits::ShrExact>::shr_exact(*self, rhs)
+            <FixedUInt<T, N, P> as const_num_traits::ShrExact>::shr_exact(FixedUInt::from_array(self.array), rhs)
         }
     }
 
@@ -754,14 +754,14 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::FunnelShl for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn funnel_shl(self, rhs: Self, n: u32) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as const_num_traits::FunnelShl>::funnel_shl(*self, *rhs, n)
+            <FixedUInt<T, N, P> as const_num_traits::FunnelShl>::funnel_shl(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array), n)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::FunnelShr for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn funnel_shr(self, rhs: Self, n: u32) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as const_num_traits::FunnelShr>::funnel_shr(*self, *rhs, n)
+            <FixedUInt<T, N, P> as const_num_traits::FunnelShr>::funnel_shr(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array), n)
         }
     }
 
@@ -824,14 +824,14 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> const_num_traits::DepositBits for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn deposit_bits(self, mask: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as const_num_traits::DepositBits>::deposit_bits(*self, *mask)
+            <FixedUInt<T, N, Nct> as const_num_traits::DepositBits>::deposit_bits(FixedUInt::from_array(self.array), FixedUInt::from_array(mask.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> const_num_traits::ExtractBits for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn extract_bits(self, mask: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as const_num_traits::ExtractBits>::extract_bits(*self, *mask)
+            <FixedUInt<T, N, Nct> as const_num_traits::ExtractBits>::extract_bits(FixedUInt::from_array(self.array), FixedUInt::from_array(mask.array))
         }
     }
 }
@@ -842,7 +842,7 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingShl
     for FixedUInt<T, N, P>
 {
     fn wrapping_shl(&self, bits: u32) -> Self {
-        WrappingShl::wrapping_shl(*self, bits)
+        <&Self as WrappingShl>::wrapping_shl(self, bits)
     }
 }
 
@@ -851,21 +851,21 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingShr
     for FixedUInt<T, N, P>
 {
     fn wrapping_shr(&self, bits: u32) -> Self {
-        WrappingShr::wrapping_shr(*self, bits)
+        <&Self as WrappingShr>::wrapping_shr(self, bits)
     }
 }
 
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedShl for FixedUInt<T, N, P> {
     fn checked_shl(&self, bits: u32) -> Option<Self> {
-        CheckedShl::checked_shl(*self, bits)
+        <&Self as CheckedShl>::checked_shl(self, bits)
     }
 }
 
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedShr for FixedUInt<T, N, P> {
     fn checked_shr(&self, bits: u32) -> Option<Self> {
-        CheckedShr::checked_shr(*self, bits)
+        <&Self as CheckedShr>::checked_shr(self, bits)
     }
 }
 

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -421,6 +421,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingShl for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_shl(self, bits: u32) -> (Self, bool) {
             let (shift, overflow) = normalize_shift_amount(bits, Self::BIT_SIZE);
             let res = core::ops::Shl::<usize>::shl(self, shift);
@@ -429,6 +430,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingShr for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_shr(self, bits: u32) -> (Self, bool) {
             let (shift, overflow) = normalize_shift_amount(bits, Self::BIT_SIZE);
             let res = core::ops::Shr::<usize>::shr(self, shift);
@@ -437,18 +439,21 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingShl for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_shl(self, bits: u32) -> Self {
             OverflowingShl::overflowing_shl(self, bits).0
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingShr for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_shr(self, bits: u32) -> Self {
             OverflowingShr::overflowing_shr(self, bits).0
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedShl for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_shl(self, bits: u32) -> Option<Self> {
             let (res, overflow) = OverflowingShl::overflowing_shl(self, bits);
             if overflow { None } else { Some(res) }
@@ -456,6 +461,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedShr for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_shr(self, bits: u32) -> Option<Self> {
             let (res, overflow) = OverflowingShr::overflowing_shr(self, bits);
             if overflow { None } else { Some(res) }
@@ -463,12 +469,14 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> UnboundedShl for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn unbounded_shl(self, rhs: u32) -> Self {
             const_unbounded_shl_u32(self, rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> UnboundedShr for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn unbounded_shr(self, rhs: u32) -> Self {
             const_unbounded_shr_u32(self, rhs)
         }
@@ -481,48 +489,56 @@ c0nst::c0nst! {
     // Output resolves to `FixedUInt<T,N,P>`.
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingShl for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_shl(self, bits: u32) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as OverflowingShl>::overflowing_shl(*self, bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingShr for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_shr(self, bits: u32) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as OverflowingShr>::overflowing_shr(*self, bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingShl for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_shl(self, bits: u32) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as WrappingShl>::wrapping_shl(*self, bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingShr for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_shr(self, bits: u32) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as WrappingShr>::wrapping_shr(*self, bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedShl for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_shl(self, bits: u32) -> Option<FixedUInt<T, N, P>> {
             <FixedUInt<T, N, P> as CheckedShl>::checked_shl(*self, bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedShr for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_shr(self, bits: u32) -> Option<FixedUInt<T, N, P>> {
             <FixedUInt<T, N, P> as CheckedShr>::checked_shr(*self, bits)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> UnboundedShl for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn unbounded_shl(self, rhs: u32) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as UnboundedShl>::unbounded_shl(*self, rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> UnboundedShr for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn unbounded_shr(self, rhs: u32) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as UnboundedShr>::unbounded_shr(*self, rhs)
         }
@@ -661,6 +677,7 @@ c0nst::c0nst! {
     // this trait or gate on their own precondition before calling.
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::ShlExact for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shl_exact(self, rhs: u32) -> Option<Self> {
             if (rhs as usize) < Self::BIT_SIZE
                 && rhs <= <Self as const_num_traits::PrimBits>::leading_zeros(self)
@@ -673,6 +690,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::ShrExact for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shr_exact(self, rhs: u32) -> Option<Self> {
             if (rhs as usize) < Self::BIT_SIZE
                 && rhs <= <Self as const_num_traits::PrimBits>::trailing_zeros(self)
@@ -685,12 +703,14 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::ShlExact for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shl_exact(self, rhs: u32) -> Option<FixedUInt<T, N, P>> {
             <FixedUInt<T, N, P> as const_num_traits::ShlExact>::shl_exact(*self, rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::ShrExact for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn shr_exact(self, rhs: u32) -> Option<FixedUInt<T, N, P>> {
             <FixedUInt<T, N, P> as const_num_traits::ShrExact>::shr_exact(*self, rhs)
         }

--- a/src/fixeduint/checked_pow_impl.rs
+++ b/src/fixeduint/checked_pow_impl.rs
@@ -21,6 +21,7 @@ use const_num_traits::{CheckedMul, CheckedPow, One};
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedPow for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn checked_pow(self, exp: u32) -> Option<Self> {
             if exp == 0 {
                 return Some(Self::one());
@@ -49,6 +50,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedPow for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn checked_pow(self, exp: u32) -> Option<FixedUInt<T, N, Nct>> {
             <FixedUInt<T, N, Nct> as CheckedPow>::checked_pow(*self, exp)
         }

--- a/src/fixeduint/checked_pow_impl.rs
+++ b/src/fixeduint/checked_pow_impl.rs
@@ -52,7 +52,7 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedPow for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn checked_pow(self, exp: u32) -> Option<FixedUInt<T, N, Nct>> {
-            <FixedUInt<T, N, Nct> as CheckedPow>::checked_pow(*self, exp)
+            <FixedUInt<T, N, Nct> as CheckedPow>::checked_pow(FixedUInt::from_array(self.array), exp)
         }
     }
 }

--- a/src/fixeduint/cios_row_ops_impl.rs
+++ b/src/fixeduint/cios_row_ops_impl.rs
@@ -27,7 +27,7 @@ use const_num_traits::{CarryingAdd, CarryingMul, ConstZero};
 
 impl<T, const N: usize, P: Personality> modmath_cios::CiosRowOps for FixedUInt<T, N, P>
 where
-    T: MachineWord + CarryingMul<Unsigned = T> + CarryingAdd,
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T> + CarryingAdd<Output = T>,
 {
     type Word = T;
 

--- a/src/fixeduint/div_ceil_impl.rs
+++ b/src/fixeduint/div_ceil_impl.rs
@@ -21,6 +21,7 @@ use const_num_traits::{CheckedAdd, DivCeil, One};
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> DivCeil for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn div_ceil(self, rhs: Self) -> Self {
             match checked_div_ceil_impl(self, rhs) {
                 Some(v) => v,
@@ -30,6 +31,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> DivCeil for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn div_ceil(self, rhs: Self) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as DivCeil>::div_ceil(*self, *rhs)
         }

--- a/src/fixeduint/div_ceil_impl.rs
+++ b/src/fixeduint/div_ceil_impl.rs
@@ -33,7 +33,7 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> DivCeil for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn div_ceil(self, rhs: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as DivCeil>::div_ceil(*self, *rhs)
+            <FixedUInt<T, N, Nct> as DivCeil>::div_ceil(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array))
         }
     }
 }

--- a/src/fixeduint/euclid.rs
+++ b/src/fixeduint/euclid.rs
@@ -5,6 +5,7 @@ use const_num_traits::{CheckedEuclid, Euclid, Zero};
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> Euclid for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn div_euclid(self, v: Self) -> Self {
             // For unsigned integers, Euclidean division is the same as regular division
             self / v
@@ -47,6 +48,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> Euclid for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn div_euclid(self, v: Self) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as Euclid>::div_euclid(*self, *v)
         }

--- a/src/fixeduint/euclid.rs
+++ b/src/fixeduint/euclid.rs
@@ -50,25 +50,25 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> Euclid for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn div_euclid(self, v: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as Euclid>::div_euclid(*self, *v)
+            <FixedUInt<T, N, Nct> as Euclid>::div_euclid(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
         fn rem_euclid(self, v: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as Euclid>::rem_euclid(*self, *v)
+            <FixedUInt<T, N, Nct> as Euclid>::rem_euclid(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
         fn div_rem_euclid(self, v: Self) -> (FixedUInt<T, N, Nct>, FixedUInt<T, N, Nct>) {
-            <FixedUInt<T, N, Nct> as Euclid>::div_rem_euclid(*self, *v)
+            <FixedUInt<T, N, Nct> as Euclid>::div_rem_euclid(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedEuclid for &FixedUInt<T, N, Nct> {
         fn checked_div_euclid(self, v: Self) -> Option<FixedUInt<T, N, Nct>> {
-            <FixedUInt<T, N, Nct> as CheckedEuclid>::checked_div_euclid(*self, *v)
+            <FixedUInt<T, N, Nct> as CheckedEuclid>::checked_div_euclid(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
         fn checked_rem_euclid(self, v: Self) -> Option<FixedUInt<T, N, Nct>> {
-            <FixedUInt<T, N, Nct> as CheckedEuclid>::checked_rem_euclid(*self, *v)
+            <FixedUInt<T, N, Nct> as CheckedEuclid>::checked_rem_euclid(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
         fn checked_div_rem_euclid(self, v: Self) -> Option<(FixedUInt<T, N, Nct>, FixedUInt<T, N, Nct>)> {
-            <FixedUInt<T, N, Nct> as CheckedEuclid>::checked_div_rem_euclid(*self, *v)
+            <FixedUInt<T, N, Nct> as CheckedEuclid>::checked_div_rem_euclid(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
     }
 }

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -24,6 +24,7 @@ use const_num_traits::{Personality, PersonalityTag};
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + MachineWord, const N: usize, P: Personality> CarryingAdd for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn carrying_add(self, rhs: Self, carry: bool) -> (Self, bool) {
             let (array, carry_out) = add_with_carry(&self.array, &rhs.array, carry);
             (Self::from_array(array), carry_out)
@@ -31,6 +32,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality> BorrowingSub for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn borrowing_sub(self, rhs: Self, borrow: bool) -> (Self, bool) {
             let (array, borrow_out) = sub_with_borrow(&self.array, &rhs.array, borrow);
             (Self::from_array(array), borrow_out)
@@ -147,6 +149,7 @@ c0nst::c0nst! {
             + [c0nst] core::ops::Shr<usize, Output = <T as ConstMachineWord>::ConstDoubleWord>,
     {
         type Unsigned = Self;
+        type Output = FixedUInt<T, N, P>;
         fn carrying_mul(self, rhs: Self, carry: Self) -> (Self, Self) {
             // Full product + add carry to low half, propagate to high.
             let (lo, hi) = schoolbook_mul(self, rhs);
@@ -177,12 +180,14 @@ c0nst::c0nst! {
     // --- Reference-receiver bigint-helper impls -----------------------------
 
     c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + MachineWord, const N: usize, P: Personality> CarryingAdd for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn carrying_add(self, rhs: Self, carry: bool) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as CarryingAdd>::carrying_add(*self, *rhs, carry)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality> BorrowingSub for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn borrowing_sub(self, rhs: Self, borrow: bool) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as BorrowingSub>::borrowing_sub(*self, *rhs, borrow)
         }
@@ -196,6 +201,7 @@ c0nst::c0nst! {
             + [c0nst] core::ops::Shr<usize, Output = <T as ConstMachineWord>::ConstDoubleWord>,
     {
         type Unsigned = FixedUInt<T, N, P>;
+        type Output = FixedUInt<T, N, P>;
         fn carrying_mul(self, rhs: Self, carry: Self) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
             <FixedUInt<T, N, P> as CarryingMul>::carrying_mul(*self, *rhs, *carry)
         }
@@ -461,7 +467,7 @@ mod tests {
         // Generic test function following crate pattern
         fn test_widening<T>(a: T, b: T, expected_lo: T, expected_hi: T)
         where
-            T: CarryingMul<Unsigned = T>
+            T: CarryingMul<Unsigned = T, Output = T>
                 + core::ops::Mul<T, Output = T>
                 + CarryingAdd
                 + BorrowingSub
@@ -514,7 +520,7 @@ mod tests {
     fn test_carrying_mul_add_polymorphic() {
         fn test_cma<T>(a: T, b: T, addend: T, carry: T, expected_lo: T, expected_hi: T)
         where
-            T: CarryingMul<Unsigned = T>
+            T: CarryingMul<Unsigned = T, Output = T>
                 + core::ops::Mul<T, Output = T>
                 + Eq
                 + core::fmt::Debug

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -19,8 +19,9 @@
 
 use super::{FixedUInt, MachineWord, add_with_carry, sub_with_borrow};
 use crate::machineword::ConstMachineWord;
-use const_num_traits::{BorrowingSub, Bounded, CarryingAdd, CarryingMul, Zero};
-use const_num_traits::{Personality, PersonalityTag};
+use const_num_traits::{
+    BorrowingSub, Bounded, CarryingAdd, CarryingMul, Personality, PersonalityTag, PrimInt, Zero,
+};
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CarryingAdd for FixedUInt<T, N, P> {
@@ -70,10 +71,7 @@ c0nst::c0nst! {
         a: FixedUInt<T, N, P>, b: FixedUInt<T, N, P>,
     ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>)
     where
-        <T as ConstMachineWord>::ConstDoubleWord:
-            [c0nst] core::ops::Mul<Output = <T as ConstMachineWord>::ConstDoubleWord>
-            + [c0nst] core::ops::BitAnd<Output = <T as ConstMachineWord>::ConstDoubleWord>
-            + [c0nst] core::ops::Shr<usize, Output = <T as ConstMachineWord>::ConstDoubleWord>,
+        <T as ConstMachineWord>::ConstDoubleWord: [c0nst] PrimInt,
     {
         // External `WideningMul` on T returns a single wide-int
         // (`<u8 as WideningMul>::Wide = u16`), not a `(lo, hi)` tuple.
@@ -143,10 +141,7 @@ c0nst::c0nst! {
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CarryingMul for FixedUInt<T, N, P>
     where
-        <T as ConstMachineWord>::ConstDoubleWord:
-            [c0nst] core::ops::Mul<Output = <T as ConstMachineWord>::ConstDoubleWord>
-            + [c0nst] core::ops::BitAnd<Output = <T as ConstMachineWord>::ConstDoubleWord>
-            + [c0nst] core::ops::Shr<usize, Output = <T as ConstMachineWord>::ConstDoubleWord>,
+        <T as ConstMachineWord>::ConstDoubleWord: [c0nst] PrimInt,
     {
         type Unsigned = Self;
         type Output = FixedUInt<T, N, P>;
@@ -195,10 +190,7 @@ c0nst::c0nst! {
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CarryingMul for &FixedUInt<T, N, P>
     where
-        <T as ConstMachineWord>::ConstDoubleWord:
-            [c0nst] core::ops::Mul<Output = <T as ConstMachineWord>::ConstDoubleWord>
-            + [c0nst] core::ops::BitAnd<Output = <T as ConstMachineWord>::ConstDoubleWord>
-            + [c0nst] core::ops::Shr<usize, Output = <T as ConstMachineWord>::ConstDoubleWord>,
+        <T as ConstMachineWord>::ConstDoubleWord: [c0nst] PrimInt,
     {
         type Unsigned = FixedUInt<T, N, P>;
         type Output = FixedUInt<T, N, P>;
@@ -242,10 +234,7 @@ mod tests {
             b: FixedUInt<T, N, P>,
         ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>)
         where
-            <T as ConstMachineWord>::ConstDoubleWord:
-                [c0nst] core::ops::Mul<Output = <T as ConstMachineWord>::ConstDoubleWord>
-                + [c0nst] core::ops::BitAnd<Output = <T as ConstMachineWord>::ConstDoubleWord>
-                + [c0nst] core::ops::Shr<usize, Output = <T as ConstMachineWord>::ConstDoubleWord>,
+            <T as ConstMachineWord>::ConstDoubleWord: [c0nst] PrimInt,
         {
             CarryingMul::carrying_mul(a, b, <FixedUInt<T, N, P> as Zero>::zero())
         }
@@ -256,10 +245,7 @@ mod tests {
             carry: FixedUInt<T, N, P>,
         ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>)
         where
-            <T as ConstMachineWord>::ConstDoubleWord:
-                [c0nst] core::ops::Mul<Output = <T as ConstMachineWord>::ConstDoubleWord>
-                + [c0nst] core::ops::BitAnd<Output = <T as ConstMachineWord>::ConstDoubleWord>
-                + [c0nst] core::ops::Shr<usize, Output = <T as ConstMachineWord>::ConstDoubleWord>,
+            <T as ConstMachineWord>::ConstDoubleWord: [c0nst] PrimInt,
         {
             CarryingMul::carrying_mul(a, b, carry)
         }
@@ -271,10 +257,7 @@ mod tests {
             carry: FixedUInt<T, N, P>,
         ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>)
         where
-            <T as ConstMachineWord>::ConstDoubleWord:
-                [c0nst] core::ops::Mul<Output = <T as ConstMachineWord>::ConstDoubleWord>
-                + [c0nst] core::ops::BitAnd<Output = <T as ConstMachineWord>::ConstDoubleWord>
-                + [c0nst] core::ops::Shr<usize, Output = <T as ConstMachineWord>::ConstDoubleWord>,
+            <T as ConstMachineWord>::ConstDoubleWord: [c0nst] PrimInt,
         {
             CarryingMul::carrying_mul_add(a, b, addend, carry)
         }

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -177,14 +177,14 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CarryingAdd for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn carrying_add(self, rhs: Self, carry: bool) -> (FixedUInt<T, N, P>, bool) {
-            <FixedUInt<T, N, P> as CarryingAdd>::carrying_add(*self, *rhs, carry)
+            <FixedUInt<T, N, P> as CarryingAdd>::carrying_add(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array), carry)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> BorrowingSub for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn borrowing_sub(self, rhs: Self, borrow: bool) -> (FixedUInt<T, N, P>, bool) {
-            <FixedUInt<T, N, P> as BorrowingSub>::borrowing_sub(*self, *rhs, borrow)
+            <FixedUInt<T, N, P> as BorrowingSub>::borrowing_sub(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array), borrow)
         }
     }
 
@@ -195,10 +195,10 @@ c0nst::c0nst! {
         type Unsigned = FixedUInt<T, N, P>;
         type Output = FixedUInt<T, N, P>;
         fn carrying_mul(self, rhs: Self, carry: Self) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
-            <FixedUInt<T, N, P> as CarryingMul>::carrying_mul(*self, *rhs, *carry)
+            <FixedUInt<T, N, P> as CarryingMul>::carrying_mul(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array), FixedUInt::from_array(carry.array))
         }
         fn carrying_mul_add(self, rhs: Self, addend: Self, carry: Self) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>) {
-            <FixedUInt<T, N, P> as CarryingMul>::carrying_mul_add(*self, *rhs, *addend, *carry)
+            <FixedUInt<T, N, P> as CarryingMul>::carrying_mul_add(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array), FixedUInt::from_array(addend.array), FixedUInt::from_array(carry.array))
         }
     }
 }

--- a/src/fixeduint/extended_precision_impl.rs
+++ b/src/fixeduint/extended_precision_impl.rs
@@ -23,7 +23,7 @@ use const_num_traits::{BorrowingSub, Bounded, CarryingAdd, CarryingMul, Zero};
 use const_num_traits::{Personality, PersonalityTag};
 
 c0nst::c0nst! {
-    c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + MachineWord, const N: usize, P: Personality> CarryingAdd for FixedUInt<T, N, P> {
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CarryingAdd for FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn carrying_add(self, rhs: Self, carry: bool) -> (Self, bool) {
             let (array, carry_out) = add_with_carry(&self.array, &rhs.array, carry);
@@ -31,7 +31,7 @@ c0nst::c0nst! {
         }
     }
 
-    c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality> BorrowingSub for FixedUInt<T, N, P> {
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> BorrowingSub for FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn borrowing_sub(self, rhs: Self, borrow: bool) -> (Self, bool) {
             let (array, borrow_out) = sub_with_borrow(&self.array, &rhs.array, borrow);
@@ -64,7 +64,7 @@ c0nst::c0nst! {
     /// split into two N-word halves `(low, high)`. Private helper shared
     /// between `CarryingMul::carrying_mul` and `carrying_mul_add`.
     c0nst fn schoolbook_mul<
-        T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + MachineWord,
+        T: [c0nst] ConstMachineWord + MachineWord,
         const N: usize, P: Personality,
     >(
         a: FixedUInt<T, N, P>, b: FixedUInt<T, N, P>,
@@ -141,7 +141,7 @@ c0nst::c0nst! {
         (FixedUInt::from_array(result_low), FixedUInt::from_array(result_high))
     }
 
-    c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality> CarryingMul for FixedUInt<T, N, P>
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CarryingMul for FixedUInt<T, N, P>
     where
         <T as ConstMachineWord>::ConstDoubleWord:
             [c0nst] core::ops::Mul<Output = <T as ConstMachineWord>::ConstDoubleWord>
@@ -179,21 +179,21 @@ c0nst::c0nst! {
 
     // --- Reference-receiver bigint-helper impls -----------------------------
 
-    c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + MachineWord, const N: usize, P: Personality> CarryingAdd for &FixedUInt<T, N, P> {
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CarryingAdd for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn carrying_add(self, rhs: Self, carry: bool) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as CarryingAdd>::carrying_add(*self, *rhs, carry)
         }
     }
 
-    c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality> BorrowingSub for &FixedUInt<T, N, P> {
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> BorrowingSub for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn borrowing_sub(self, rhs: Self, borrow: bool) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as BorrowingSub>::borrowing_sub(*self, *rhs, borrow)
         }
     }
 
-    c0nst impl<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality> CarryingMul for &FixedUInt<T, N, P>
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CarryingMul for &FixedUInt<T, N, P>
     where
         <T as ConstMachineWord>::ConstDoubleWord:
             [c0nst] core::ops::Mul<Output = <T as ConstMachineWord>::ConstDoubleWord>
@@ -219,7 +219,7 @@ mod tests {
     type U32 = FixedUInt<u8, 4>;
 
     c0nst::c0nst! {
-        pub c0nst fn const_carrying_add<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality>(
+        pub c0nst fn const_carrying_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
             a: FixedUInt<T, N, P>,
             b: FixedUInt<T, N, P>,
             carry: bool,
@@ -227,7 +227,7 @@ mod tests {
             CarryingAdd::carrying_add(a, b, carry)
         }
 
-        pub c0nst fn const_borrowing_sub<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality>(
+        pub c0nst fn const_borrowing_sub<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
             a: FixedUInt<T, N, P>,
             b: FixedUInt<T, N, P>,
             borrow: bool,
@@ -237,7 +237,7 @@ mod tests {
 
         /// Full `(low, high)` product via `CarryingMul` with a zero
         /// carry — `FixedUInt` doesn't implement `WideningMul`.
-        pub c0nst fn const_widening_mul<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality>(
+        pub c0nst fn const_widening_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
             a: FixedUInt<T, N, P>,
             b: FixedUInt<T, N, P>,
         ) -> (FixedUInt<T, N, P>, FixedUInt<T, N, P>)
@@ -250,7 +250,7 @@ mod tests {
             CarryingMul::carrying_mul(a, b, <FixedUInt<T, N, P> as Zero>::zero())
         }
 
-        pub c0nst fn const_carrying_mul<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality>(
+        pub c0nst fn const_carrying_mul<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
             a: FixedUInt<T, N, P>,
             b: FixedUInt<T, N, P>,
             carry: FixedUInt<T, N, P>,
@@ -264,7 +264,7 @@ mod tests {
             CarryingMul::carrying_mul(a, b, carry)
         }
 
-        pub c0nst fn const_carrying_mul_add<T: [c0nst] ConstMachineWord + [c0nst] CarryingAdd + [c0nst] BorrowingSub + MachineWord, const N: usize, P: Personality>(
+        pub c0nst fn const_carrying_mul_add<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
             a: FixedUInt<T, N, P>,
             b: FixedUInt<T, N, P>,
             addend: FixedUInt<T, N, P>,
@@ -468,7 +468,6 @@ mod tests {
         fn test_widening<T>(a: T, b: T, expected_lo: T, expected_hi: T)
         where
             T: CarryingMul<Unsigned = T, Output = T>
-                + core::ops::Mul<T, Output = T>
                 + CarryingAdd
                 + BorrowingSub
                 + Eq
@@ -520,11 +519,7 @@ mod tests {
     fn test_carrying_mul_add_polymorphic() {
         fn test_cma<T>(a: T, b: T, addend: T, carry: T, expected_lo: T, expected_hi: T)
         where
-            T: CarryingMul<Unsigned = T, Output = T>
-                + core::ops::Mul<T, Output = T>
-                + Eq
-                + core::fmt::Debug
-                + Copy,
+            T: CarryingMul<Unsigned = T, Output = T> + Eq + core::fmt::Debug + Copy,
         {
             let (lo, hi) = CarryingMul::carrying_mul_add(a, b, addend, carry);
             assert_eq!(lo, expected_lo, "lo mismatch");

--- a/src/fixeduint/ilog_impl.rs
+++ b/src/fixeduint/ilog_impl.rs
@@ -91,28 +91,28 @@ c0nst::c0nst! {
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> Ilog2 for &FixedUInt<T, N, Nct> {
         fn ilog2(self) -> u32 {
-            <FixedUInt<T, N, Nct> as Ilog2>::ilog2(*self)
+            <FixedUInt<T, N, Nct> as Ilog2>::ilog2(FixedUInt::from_array(self.array))
         }
         fn checked_ilog2(self) -> Option<u32> {
-            <FixedUInt<T, N, Nct> as Ilog2>::checked_ilog2(*self)
+            <FixedUInt<T, N, Nct> as Ilog2>::checked_ilog2(FixedUInt::from_array(self.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> Ilog10 for &FixedUInt<T, N, Nct> {
         fn ilog10(self) -> u32 {
-            <FixedUInt<T, N, Nct> as Ilog10>::ilog10(*self)
+            <FixedUInt<T, N, Nct> as Ilog10>::ilog10(FixedUInt::from_array(self.array))
         }
         fn checked_ilog10(self) -> Option<u32> {
-            <FixedUInt<T, N, Nct> as Ilog10>::checked_ilog10(*self)
+            <FixedUInt<T, N, Nct> as Ilog10>::checked_ilog10(FixedUInt::from_array(self.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> Ilog for &FixedUInt<T, N, Nct> {
         fn ilog(self, base: Self) -> u32 {
-            <FixedUInt<T, N, Nct> as Ilog>::ilog(*self, *base)
+            <FixedUInt<T, N, Nct> as Ilog>::ilog(FixedUInt::from_array(self.array), FixedUInt::from_array(base.array))
         }
         fn checked_ilog(self, base: Self) -> Option<u32> {
-            <FixedUInt<T, N, Nct> as Ilog>::checked_ilog(*self, *base)
+            <FixedUInt<T, N, Nct> as Ilog>::checked_ilog(FixedUInt::from_array(self.array), FixedUInt::from_array(base.array))
         }
     }
 }

--- a/src/fixeduint/isqrt_impl.rs
+++ b/src/fixeduint/isqrt_impl.rs
@@ -55,7 +55,7 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> Isqrt for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn isqrt(self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as Isqrt>::isqrt(*self)
+            <FixedUInt<T, N, Nct> as Isqrt>::isqrt(FixedUInt::from_array(self.array))
         }
     }
 }

--- a/src/fixeduint/midpoint_impl.rs
+++ b/src/fixeduint/midpoint_impl.rs
@@ -31,7 +31,7 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> Midpoint for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn midpoint(self, rhs: Self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as Midpoint>::midpoint(*self, *rhs)
+            <FixedUInt<T, N, P> as Midpoint>::midpoint(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array))
         }
     }
 }

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -12,7 +12,7 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::overflowin
     for FixedUInt<T, N, P>
 {
     fn overflowing_mul(&self, other: &Self) -> (Self, bool) {
-        <Self as OverflowingMul>::overflowing_mul(*self, *other)
+        <&Self as OverflowingMul>::overflowing_mul(self, other)
     }
 }
 
@@ -176,14 +176,14 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::WrappingMul
     for FixedUInt<T, N, P>
 {
     fn wrapping_mul(&self, other: &Self) -> Self {
-        <Self as WrappingMul>::wrapping_mul(*self, *other)
+        <&Self as WrappingMul>::wrapping_mul(self, other)
     }
 }
 
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize, P: Personality> num_traits::CheckedMul for FixedUInt<T, N, P> {
     fn checked_mul(&self, other: &Self) -> Option<Self> {
-        <Self as CheckedMul>::checked_mul(*self, *other)
+        <&Self as CheckedMul>::checked_mul(self, other)
     }
 }
 
@@ -192,7 +192,7 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::saturating
     for FixedUInt<T, N, P>
 {
     fn saturating_mul(&self, other: &Self) -> Self {
-        <Self as SaturatingMul>::saturating_mul(*self, *other)
+        <&Self as SaturatingMul>::saturating_mul(self, other)
     }
 }
 
@@ -253,7 +253,7 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedDiv for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn checked_div(self, other: Self) -> Option<FixedUInt<T, N, Nct>> {
-            <FixedUInt<T, N, Nct> as CheckedDiv>::checked_div(*self, *other)
+            <FixedUInt<T, N, Nct> as CheckedDiv>::checked_div(FixedUInt::from_array(self.array), FixedUInt::from_array(other.array))
         }
     }
 }
@@ -261,7 +261,7 @@ c0nst::c0nst! {
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize> num_traits::CheckedDiv for FixedUInt<T, N, Nct> {
     fn checked_div(&self, other: &Self) -> Option<Self> {
-        <Self as CheckedDiv>::checked_div(*self, *other)
+        <&Self as CheckedDiv>::checked_div(self, other)
     }
 }
 
@@ -322,7 +322,7 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedRem for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn checked_rem(self, other: Self) -> Option<FixedUInt<T, N, Nct>> {
-            <FixedUInt<T, N, Nct> as CheckedRem>::checked_rem(*self, *other)
+            <FixedUInt<T, N, Nct> as CheckedRem>::checked_rem(FixedUInt::from_array(self.array), FixedUInt::from_array(other.array))
         }
     }
 }
@@ -330,7 +330,7 @@ c0nst::c0nst! {
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const N: usize> num_traits::CheckedRem for FixedUInt<T, N, Nct> {
     fn checked_rem(&self, other: &Self) -> Option<Self> {
-        <Self as CheckedRem>::checked_rem(*self, *other)
+        <&Self as CheckedRem>::checked_rem(self, other)
     }
 }
 
@@ -392,7 +392,7 @@ where
     T: MachineWord,
 {
     fn ct_checked_mul(&self, v: &Self) -> subtle::CtOption<Self> {
-        let (val, overflow) = <Self as OverflowingMul>::overflowing_mul(*self, *v);
+        let (val, overflow) = <&Self as OverflowingMul>::overflowing_mul(self, v);
         subtle::CtOption::new(val, subtle::Choice::from(!overflow as u8))
     }
 }

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -18,6 +18,7 @@ impl<T: MachineWord, const N: usize, P: Personality> num_traits::ops::overflowin
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingMul for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_mul(self, other: Self) -> (Self, bool) {
             let (array, overflow) = const_mul::<T, N, true, P>(&self.array, &other.array, Self::WORD_BITS);
             (Self::from_array(array), overflow)
@@ -25,6 +26,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingMul for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_mul(self, other: Self) -> Self {
             let (array, _) = const_mul::<T, N, false, P>(&self.array, &other.array, Self::WORD_BITS);
             Self::from_array(array)
@@ -32,6 +34,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedMul for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_mul(self, other: Self) -> Option<Self> {
             let (res, overflow) = <Self as OverflowingMul>::overflowing_mul(self, other);
             if overflow { None } else { Some(res) }
@@ -39,6 +42,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingMul for FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn saturating_mul(self, other: Self) -> Self {
             let (res, overflow) = <Self as OverflowingMul>::overflowing_mul(self, other);
             match P::TAG {
@@ -51,24 +55,28 @@ c0nst::c0nst! {
     // --- Reference-receiver mul impls (see add_sub_impl.rs for rationale) ---
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingMul for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn overflowing_mul(self, other: Self) -> (FixedUInt<T, N, P>, bool) {
             <FixedUInt<T, N, P> as OverflowingMul>::overflowing_mul(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingMul for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn wrapping_mul(self, other: Self) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as WrappingMul>::wrapping_mul(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedMul for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn checked_mul(self, other: Self) -> Option<FixedUInt<T, N, P>> {
             <FixedUInt<T, N, P> as CheckedMul>::checked_mul(*self, *other)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingMul for &FixedUInt<T, N, P> {
+        type Output = FixedUInt<T, N, P>;
         fn saturating_mul(self, other: Self) -> FixedUInt<T, N, P> {
             <FixedUInt<T, N, P> as SaturatingMul>::saturating_mul(*self, *other)
         }
@@ -208,6 +216,7 @@ c0nst::c0nst! {
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedDiv for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn checked_div(self, other: Self) -> Option<Self> {
             if <Self as Zero>::is_zero(&other) {
                 None
@@ -218,6 +227,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedDiv for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn checked_div(self, other: Self) -> Option<FixedUInt<T, N, Nct>> {
             <FixedUInt<T, N, Nct> as CheckedDiv>::checked_div(*self, *other)
         }
@@ -275,6 +285,7 @@ c0nst::c0nst! {
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedRem for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn checked_rem(self, other: Self) -> Option<Self> {
             if <Self as Zero>::is_zero(&other) {
                 None
@@ -285,6 +296,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> CheckedRem for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn checked_rem(self, other: Self) -> Option<FixedUInt<T, N, Nct>> {
             <FixedUInt<T, N, Nct> as CheckedRem>::checked_rem(*self, *other)
         }

--- a/src/fixeduint/mul_div_impl.rs
+++ b/src/fixeduint/mul_div_impl.rs
@@ -52,33 +52,57 @@ c0nst::c0nst! {
         }
     }
 
-    // --- Reference-receiver mul impls (see add_sub_impl.rs for rationale) ---
+    // --- Reference-receiver mul impls -------------------------------------
+    //
+    // Read-through-ref primitives. See add_sub_impl.rs for the CT rationale
+    // — bodies must NOT deref-copy the operand `FixedUInt` onto the stack
+    // (that defeats the whole reason `&T` is used, e.g. `Zeroizing<T>` on
+    // ed25519's CT sign path). `const_mul` reads `&[T; N]` slices and
+    // returns a fresh `[T; N]`. The `Checked` and `Saturating` mirrors
+    // delegate to the primitives above so they inherit the read-through
+    // behaviour.
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> OverflowingMul for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn overflowing_mul(self, other: Self) -> (FixedUInt<T, N, P>, bool) {
-            <FixedUInt<T, N, P> as OverflowingMul>::overflowing_mul(*self, *other)
+            let (array, overflow) = const_mul::<T, N, true, P>(
+                &self.array,
+                &other.array,
+                FixedUInt::<T, N, P>::WORD_BITS,
+            );
+            (FixedUInt::from_array(array), overflow)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> WrappingMul for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn wrapping_mul(self, other: Self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as WrappingMul>::wrapping_mul(*self, *other)
+            let (array, _overflow) = const_mul::<T, N, false, P>(
+                &self.array,
+                &other.array,
+                FixedUInt::<T, N, P>::WORD_BITS,
+            );
+            FixedUInt::from_array(array)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> CheckedMul for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn checked_mul(self, other: Self) -> Option<FixedUInt<T, N, P>> {
-            <FixedUInt<T, N, P> as CheckedMul>::checked_mul(*self, *other)
+            let (res, overflow) = <Self as OverflowingMul>::overflowing_mul(self, other);
+            if overflow { None } else { Some(res) }
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> SaturatingMul for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn saturating_mul(self, other: Self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as SaturatingMul>::saturating_mul(*self, *other)
+            let (res, overflow) = <Self as OverflowingMul>::overflowing_mul(self, other);
+            if overflow {
+                <FixedUInt<T, N, P> as Bounded>::max_value()
+            } else {
+                res
+            }
         }
     }
 }

--- a/src/fixeduint/multiple_impl.rs
+++ b/src/fixeduint/multiple_impl.rs
@@ -31,6 +31,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> NextMultipleOf for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn next_multiple_of(self, rhs: Self) -> Self {
             match self.checked_next_multiple_of(rhs) {
                 Some(v) => v,
@@ -60,6 +61,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> NextMultipleOf for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn next_multiple_of(self, rhs: Self) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as NextMultipleOf>::next_multiple_of(*self, *rhs)
         }

--- a/src/fixeduint/multiple_impl.rs
+++ b/src/fixeduint/multiple_impl.rs
@@ -56,17 +56,17 @@ c0nst::c0nst! {
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> MultipleOf for &FixedUInt<T, N, Nct> {
         fn is_multiple_of(self, rhs: Self) -> bool {
-            <FixedUInt<T, N, Nct> as MultipleOf>::is_multiple_of(*self, *rhs)
+            <FixedUInt<T, N, Nct> as MultipleOf>::is_multiple_of(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> NextMultipleOf for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn next_multiple_of(self, rhs: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as NextMultipleOf>::next_multiple_of(*self, *rhs)
+            <FixedUInt<T, N, Nct> as NextMultipleOf>::next_multiple_of(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array))
         }
         fn checked_next_multiple_of(self, rhs: Self) -> Option<FixedUInt<T, N, Nct>> {
-            <FixedUInt<T, N, Nct> as NextMultipleOf>::checked_next_multiple_of(*self, *rhs)
+            <FixedUInt<T, N, Nct> as NextMultipleOf>::checked_next_multiple_of(FixedUInt::from_array(self.array), FixedUInt::from_array(rhs.array))
         }
     }
 }

--- a/src/fixeduint/num_integer_impl.rs
+++ b/src/fixeduint/num_integer_impl.rs
@@ -44,13 +44,13 @@ impl<T: MachineWord, const N: usize> num_integer::Integer for FixedUInt<T, N, Nc
             return Self::zero();
         }
         let gcd = self.gcd(other);
-        *self * (*other / gcd)
+        self * (other / gcd)
     }
     fn divides(&self, other: &Self) -> bool {
         self.is_multiple_of(other)
     }
     fn is_multiple_of(&self, other: &Self) -> bool {
-        (*self) % *other == Self::zero()
+        self % other == Self::zero()
     }
     fn is_even(&self) -> bool {
         // O(1): only check LSB of first word, not full-width AND + compare

--- a/src/fixeduint/power_of_two_impl.rs
+++ b/src/fixeduint/power_of_two_impl.rs
@@ -129,20 +129,20 @@ c0nst::c0nst! {
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> IsPowerOfTwo for &FixedUInt<T, N, P> {
         fn is_power_of_two(self) -> bool {
-            <FixedUInt<T, N, P> as IsPowerOfTwo>::is_power_of_two(*self)
+            <FixedUInt<T, N, P> as IsPowerOfTwo>::is_power_of_two(FixedUInt::from_array(self.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> NextPowerOfTwo for &FixedUInt<T, N, P> {
         type Output = FixedUInt<T, N, P>;
         fn next_power_of_two(self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as NextPowerOfTwo>::next_power_of_two(*self)
+            <FixedUInt<T, N, P> as NextPowerOfTwo>::next_power_of_two(FixedUInt::from_array(self.array))
         }
         fn checked_next_power_of_two(self) -> Option<FixedUInt<T, N, P>> {
-            <FixedUInt<T, N, P> as NextPowerOfTwo>::checked_next_power_of_two(*self)
+            <FixedUInt<T, N, P> as NextPowerOfTwo>::checked_next_power_of_two(FixedUInt::from_array(self.array))
         }
         fn wrapping_next_power_of_two(self) -> FixedUInt<T, N, P> {
-            <FixedUInt<T, N, P> as NextPowerOfTwo>::wrapping_next_power_of_two(*self)
+            <FixedUInt<T, N, P> as NextPowerOfTwo>::wrapping_next_power_of_two(FixedUInt::from_array(self.array))
         }
     }
 }
@@ -161,7 +161,10 @@ where
         use const_num_traits::ops::ct::CtIsZero;
         let nonzero = !self.ct_is_zero();
         let one = <Self as ConstOne>::ONE;
-        let masked = *self & <Self as WrappingSub>::wrapping_sub(*self, one);
+        // Route through the by-ref `WrappingSub` so `self` isn't
+        // deref-copied onto the stack — matters on Ct paths where
+        // `self` may point into a `Zeroizing<T>` nonce.
+        let masked = self & <&Self as WrappingSub>::wrapping_sub(self, &one);
         let pow2 = masked.ct_is_zero();
         nonzero & pow2
     }
@@ -272,7 +275,7 @@ mod tests {
         pub c0nst fn const_is_power_of_two<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(
             v: &FixedUInt<T, N, P>,
         ) -> bool {
-            IsPowerOfTwo::is_power_of_two(*v)
+            IsPowerOfTwo::is_power_of_two(FixedUInt::<T, N, P>::from_array(v.array))
         }
 
         pub c0nst fn const_next_power_of_two<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality>(

--- a/src/fixeduint/strict_impl.rs
+++ b/src/fixeduint/strict_impl.rs
@@ -115,56 +115,56 @@ c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictAdd for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn strict_add(self, v: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as StrictAdd>::strict_add(*self, *v)
+            <FixedUInt<T, N, Nct> as StrictAdd>::strict_add(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictSub for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn strict_sub(self, v: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as StrictSub>::strict_sub(*self, *v)
+            <FixedUInt<T, N, Nct> as StrictSub>::strict_sub(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictMul for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn strict_mul(self, v: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as StrictMul>::strict_mul(*self, *v)
+            <FixedUInt<T, N, Nct> as StrictMul>::strict_mul(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictDiv for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn strict_div(self, v: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as StrictDiv>::strict_div(*self, *v)
+            <FixedUInt<T, N, Nct> as StrictDiv>::strict_div(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictRem for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn strict_rem(self, v: Self) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as StrictRem>::strict_rem(*self, *v)
+            <FixedUInt<T, N, Nct> as StrictRem>::strict_rem(FixedUInt::from_array(self.array), FixedUInt::from_array(v.array))
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictShl for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn strict_shl(self, rhs: u32) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as StrictShl>::strict_shl(*self, rhs)
+            <FixedUInt<T, N, Nct> as StrictShl>::strict_shl(FixedUInt::from_array(self.array), rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictShr for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn strict_shr(self, rhs: u32) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as StrictShr>::strict_shr(*self, rhs)
+            <FixedUInt<T, N, Nct> as StrictShr>::strict_shr(FixedUInt::from_array(self.array), rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictPow for &FixedUInt<T, N, Nct> {
         type Output = FixedUInt<T, N, Nct>;
         fn strict_pow(self, exp: u32) -> FixedUInt<T, N, Nct> {
-            <FixedUInt<T, N, Nct> as StrictPow>::strict_pow(*self, exp)
+            <FixedUInt<T, N, Nct> as StrictPow>::strict_pow(FixedUInt::from_array(self.array), exp)
         }
     }
 }

--- a/src/fixeduint/strict_impl.rs
+++ b/src/fixeduint/strict_impl.rs
@@ -30,6 +30,7 @@ use const_num_traits::{
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictAdd for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_add(self, v: Self) -> Self {
             let (res, overflow) = <Self as OverflowingAdd>::overflowing_add(self, v);
             if overflow {
@@ -40,6 +41,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictSub for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_sub(self, v: Self) -> Self {
             let (res, overflow) = <Self as OverflowingSub>::overflowing_sub(self, v);
             if overflow {
@@ -50,6 +52,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictMul for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_mul(self, v: Self) -> Self {
             let (res, overflow) = <Self as OverflowingMul>::overflowing_mul(self, v);
             if overflow {
@@ -60,6 +63,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictDiv for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_div(self, v: Self) -> Self {
             // For unsigned `MIN / -1` is N/A; the only overflow mode is `v == 0`,
             // which `Div<Self>` already panics on. Delegate.
@@ -68,12 +72,14 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictRem for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_rem(self, v: Self) -> Self {
             self % v
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictShl for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_shl(self, rhs: u32) -> Self {
             let shift = rhs as usize;
             if shift >= Self::BIT_SIZE {
@@ -84,6 +90,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictShr for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_shr(self, rhs: u32) -> Self {
             let shift = rhs as usize;
             if shift >= Self::BIT_SIZE {
@@ -94,6 +101,7 @@ c0nst::c0nst! {
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictPow for FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_pow(self, exp: u32) -> Self {
             match <Self as CheckedPow>::checked_pow(self, exp) {
                 Some(v) => v,
@@ -105,48 +113,56 @@ c0nst::c0nst! {
     // --- Reference-receiver mirrors -----------------------------------------
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictAdd for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_add(self, v: Self) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as StrictAdd>::strict_add(*self, *v)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictSub for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_sub(self, v: Self) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as StrictSub>::strict_sub(*self, *v)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictMul for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_mul(self, v: Self) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as StrictMul>::strict_mul(*self, *v)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictDiv for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_div(self, v: Self) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as StrictDiv>::strict_div(*self, *v)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictRem for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_rem(self, v: Self) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as StrictRem>::strict_rem(*self, *v)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictShl for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_shl(self, rhs: u32) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as StrictShl>::strict_shl(*self, rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictShr for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_shr(self, rhs: u32) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as StrictShr>::strict_shr(*self, rhs)
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize> StrictPow for &FixedUInt<T, N, Nct> {
+        type Output = FixedUInt<T, N, Nct>;
         fn strict_pow(self, exp: u32) -> FixedUInt<T, N, Nct> {
             <FixedUInt<T, N, Nct> as StrictPow>::strict_pow(*self, exp)
         }

--- a/src/machineword.rs
+++ b/src/machineword.rs
@@ -13,44 +13,38 @@
 // limitations under the License.
 
 pub use const_num_traits::PrimInt;
-use const_num_traits::{
-    BorrowingSub, CarryingAdd, OverflowingAdd, OverflowingSub, ToBytes, WideningMul,
-};
+use const_num_traits::{BorrowingSub, CarryingAdd, OverflowingSub, ToBytes};
 
 c0nst::c0nst! {
     /// Const-friendly aggregate trait bundling the arithmetic, bit,
     /// shift, and byte-conversion capabilities every limb type has to
     /// carry to serve as a `FixedUInt`'s `T`.
     ///
-    /// `*Assign` bounds are added explicitly: external `PrimBits` /
-    /// `PrimInt` cover the by-value bit/shift ops (the CT-friendly
-    /// core) but not their `*Assign` counterparts, which we rely on
-    /// in `fixeduint.rs` (the per-limb loops use `|=` / `^=` / `<<=`
-    /// / `>>=` / `&=` etc. on `T`).
+    /// The bit/shift `*Assign` supertraits are added explicitly:
+    /// `PrimBits`/`PrimInt` provide the by-value bit/shift ops but
+    /// not the `*Assign` counterparts, which the per-limb loops in
+    /// `fixeduint.rs`/`bit_ops_impl.rs` use (`|=` / `^=` / `<<=` /
+    /// `>>=` / `&=` on `T`). Arithmetic `*Assign` and `WideningMul`
+    /// are intentionally NOT here — no limb-loop uses `T += T` /
+    /// `T -= T`, and the crate doesn't call `T::widening_mul`
+    /// anywhere (the CarryingMul impls route through the
+    /// `ConstDoubleWord` associated type).
     pub c0nst trait ConstMachineWord:
         [c0nst] PrimInt +
-        [c0nst] OverflowingAdd<Output = Self> +
         [c0nst] OverflowingSub<Output = Self> +
         [c0nst] CarryingAdd<Output = Self> +
         [c0nst] BorrowingSub<Output = Self> +
         [c0nst] ToBytes +
-        [c0nst] WideningMul +
         [c0nst] core::ops::BitAndAssign +
         [c0nst] core::ops::BitOrAssign +
         [c0nst] core::ops::BitXorAssign +
         [c0nst] core::ops::ShlAssign<usize> +
         [c0nst] core::ops::ShrAssign<usize> +
-        [c0nst] core::ops::AddAssign +
-        [c0nst] core::ops::SubAssign +
         [c0nst] From<u8>
     {
         type ConstDoubleWord: [c0nst] PrimInt
             + [c0nst] core::ops::BitAndAssign
-            + [c0nst] core::ops::BitOrAssign
-            + [c0nst] core::ops::AddAssign
-            + [c0nst] core::ops::Mul<Output = Self::ConstDoubleWord>
-            + [c0nst] core::ops::BitAnd<Output = Self::ConstDoubleWord>
-            + [c0nst] core::ops::Shr<usize, Output = Self::ConstDoubleWord>;
+            + [c0nst] core::ops::AddAssign;
         fn to_double(self) -> Self::ConstDoubleWord;
         fn from_double(word: Self::ConstDoubleWord) -> Self;
     }

--- a/src/machineword.rs
+++ b/src/machineword.rs
@@ -29,10 +29,10 @@ c0nst::c0nst! {
     /// / `>>=` / `&=` etc. on `T`).
     pub c0nst trait ConstMachineWord:
         [c0nst] PrimInt +
-        [c0nst] OverflowingAdd +
-        [c0nst] OverflowingSub +
-        [c0nst] CarryingAdd +
-        [c0nst] BorrowingSub +
+        [c0nst] OverflowingAdd<Output = Self> +
+        [c0nst] OverflowingSub<Output = Self> +
+        [c0nst] CarryingAdd<Output = Self> +
+        [c0nst] BorrowingSub<Output = Self> +
         [c0nst] ToBytes +
         [c0nst] WideningMul +
         [c0nst] core::ops::BitAndAssign +

--- a/tests/bit_shift.rs
+++ b/tests/bit_shift.rs
@@ -165,8 +165,8 @@ fn test_sh_variants() {
         INT: num_traits::PrimInt
             + core::fmt::Debug
             + core::convert::From<T>
-            + OverflowingShl
-            + OverflowingShr
+            + OverflowingShl<Output = INT>
+            + OverflowingShr<Output = INT>
             + num_traits::WrappingShl
             + num_traits::WrappingShr
             + num_traits::CheckedShl


### PR DESCRIPTION
## Summary

Integrates the breaking change from `const-num-traits 0.2.0-alpha.1`: each `checked/wrapping/saturating/overflowing/strict/euclid/rounding/carrying/borrowing/{ShlExact,ShrExact,UnboundedShl,UnboundedShr,DivCeil,DivFloor,DivExact,NextPowerOfTwo,PowerOfTwoOps,IsolateHighestOne,IsolateLowestOne,Isqrt,MulAdd,Maximum,Minimum,ClampMagnitude,AbsDiff,Midpoint,Inv,FunnelShl,FunnelShr,DepositBits,ExtractBits,Algebraic,...}` trait now carries its own `type Output` and no longer supertraits `core::ops::*`. Consumers bounded on `T: WrappingAdd + Add<Output=T>` switch to `T: WrappingAdd<Output=T>`; impls declare `type Output = Self` (or the equivalent).

- ~70 in-tree impls of the affected traits gain `type Output = FixedUInt<T, N, P>;`.
- `CarryingMul` impls gain `type Output` alongside the existing `type Unsigned` (the trait now carries both).
- `ConstMachineWord` supertraits pinned:
  ```
  [c0nst] OverflowingAdd<Output = Self>
  [c0nst] OverflowingSub<Output = Self>
  [c0nst] CarryingAdd<Output = Self>
  [c0nst] BorrowingSub<Output = Self>
  ```
  Lifts the same bound off every arithmetic free function (`add_impl`, `sub_impl`, `add_with_carry`, `sub_with_borrow`) instead of repeating it per callsite.
- `CiosRowOps` bound tightened to `CarryingMul<Unsigned = T, Output = T> + CarryingAdd<Output = T>`.
- `tests/bit_shift.rs::test_shifts` generic bounds get `OverflowingShl<Output = INT>` / `OverflowingShr<Output = INT>`.
- Extended-precision polymorphic tests get `CarryingMul<Unsigned = T, Output = T>`.

**Not touched**:
- `num_traits::CheckedShl/Shr` impls (the num-traits crate, not const-num-traits) — that trait has no `Output` associated type in either version; the two wrongly-auto-added lines were removed.
- `CheckedEuclid` impls — CheckedEuclid inherits `Output` from `Euclid` via `<Self as Euclid>::Output`; own-declaration would be a compile error. Auto-additions removed.

Migration went 89 initial errors → 0.

## Cargo state

Three manifests (root + `ct-verify/ct-fixtures` + `ct-verify/panic-free-audit`) point at the `v0.2.0-alpha.1` git tag via direct git dep (no `[patch.crates-io]` block — same shape as the alignment PR merged last cycle so downstream consumers transitively get the tag). Reverts to `version = "0.2"` (crates.io) once released.

Version bumped to `0.4.2`. Tagged `v0.4.2-alpha.1` for downstream (`rsa/new_reduce`, `ed25519_heapless`) to test against.

## Test plan

- [ ] Prototype `rsa/new_reduce` against `v0.4.2-alpha.1` — confirm its `FixedWidthUnsignedInt` blanket, which bounds `PrimBits + ToBytes + FromBytes + FromByteSlice`, still resolves after the operator-supertrait split (nothing on that consumer bounds operator supertraits directly, but worth verifying).
- [ ] Prototype `ed25519_heapless` against `v0.4.2-alpha.1` — verify the CT nonce path (`&FixedUInt: ToBytes`) still compiles and no new bounds are needed.
- [ ] Confirm the `const-num-traits 0.2` crates.io release resolves via a one-line dep-shape flip once available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public constant-time widening multiplication operation.
  * Expanded arithmetic trait compatibility across addition, subtraction, multiplication, division, shifting, powers, and strict operations.
  * Broadened availability of constant-time checked arithmetic for supported integer types.

* **Improvements**
  * Improved borrowed-value arithmetic handling, reducing unnecessary value copying.
  * Simplified generic requirements for custom machine-word types.
  * Updated the library to version 0.5.0 with enhanced const-generic arithmetic support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->