### PR TITLE
Fix panic-freeness of holder_be/holder_le under NumToBytes at -Oz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -118,26 +118,17 @@ impl<T: MachineWord, const N: usize, P: Personality> FixedUInt<T, N, P>
 where
     T: core::fmt::Debug,
 {
-    // Zero-init (`BytesHolder::default()`) rather than
-    // `BytesHolder::from_array(self.array)`. On the `&FixedUInt` path
-    // the latter would materialise the secret limb array on the stack
-    // as a Copy of the referenced `[T; N]` before the serialisation
-    // step overwrites it — defeating the CT/Zeroize goal of the
-    // by-reference impl. Zero-init writes serialised bytes through
-    // the reference directly. Also removes a wasted Copy on the
-    // owned path.
+    // Zero-init NOT `BytesHolder::from_array(self.array)` — the latter
+    // Copy-materialises the referenced `[T; N]` on the stack before
+    // serialisation overwrites it, defeating the point of the by-ref
+    // impl (CT / Zeroize wrapper leaks).
     //
-    // Serialisation body is inlined `chunks_exact_mut(WORD_SIZE)` per
-    // `to_{be,le}_bytes_fixed` in `byte_conversion_panic_free.rs`, NOT
-    // via the fallible `self.to_be_bytes(&mut [u8]) -> Result` path.
-    // The fallible variant does a runtime `output_buffer.len() <
-    // total_bytes` guard that fails to DCE at `opt-level = z`, leaving
-    // a `panic_fmt` in the linked binary for every downstream that
-    // reaches `NumToBytes::to_be_bytes` via this helper. `chunks_exact_mut`
-    // iterates exactly `N` times over `ret.as_byte_slice_mut()`'s
-    // `N * size_of::<T>()` bytes (known at monomorphisation); each
-    // `copy_from_slice` pairs an equal-length chunk and word slice,
-    // provable no-panic under LTO.
+    // Body inlines `chunks_exact_mut(WORD_SIZE)` (see
+    // `byte_conversion_panic_free.rs`) rather than `self.to_be_bytes(&mut
+    // [u8]) -> Result`: the fallible path's runtime length check fails
+    // to DCE at `-Oz`, leaving `panic_fmt` in the binary for every
+    // `NumToBytes` consumer. The inlined variant pairs equal-length
+    // chunks + words; no runtime check.
     #[inline]
     fn holder_be(&self) -> BytesHolder<T, N> {
         let mut ret = BytesHolder::default();

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -126,17 +126,43 @@ where
     // by-reference impl. Zero-init writes serialised bytes through
     // the reference directly. Also removes a wasted Copy on the
     // owned path.
+    //
+    // Serialisation body is inlined `chunks_exact_mut(WORD_SIZE)` per
+    // `to_{be,le}_bytes_fixed` in `byte_conversion_panic_free.rs`, NOT
+    // via the fallible `self.to_be_bytes(&mut [u8]) -> Result` path.
+    // The fallible variant does a runtime `output_buffer.len() <
+    // total_bytes` guard that fails to DCE at `opt-level = z`, leaving
+    // a `panic_fmt` in the linked binary for every downstream that
+    // reaches `NumToBytes::to_be_bytes` via this helper. `chunks_exact_mut`
+    // iterates exactly `N` times over `ret.as_byte_slice_mut()`'s
+    // `N * size_of::<T>()` bytes (known at monomorphisation); each
+    // `copy_from_slice` pairs an equal-length chunk and word slice,
+    // provable no-panic under LTO.
     #[inline]
     fn holder_be(&self) -> BytesHolder<T, N> {
         let mut ret = BytesHolder::default();
-        let _ = self.to_be_bytes(ret.as_byte_slice_mut());
+        let word_size = core::mem::size_of::<T>();
+        for (chunk, word) in ret
+            .as_byte_slice_mut()
+            .chunks_exact_mut(word_size)
+            .zip(self.array.iter().rev())
+        {
+            chunk.copy_from_slice(word.to_be_bytes().as_ref());
+        }
         ret
     }
 
     #[inline]
     fn holder_le(&self) -> BytesHolder<T, N> {
         let mut ret = BytesHolder::default();
-        let _ = self.to_le_bytes(ret.as_byte_slice_mut());
+        let word_size = core::mem::size_of::<T>();
+        for (chunk, word) in ret
+            .as_byte_slice_mut()
+            .chunks_exact_mut(word_size)
+            .zip(self.array.iter())
+        {
+            chunk.copy_from_slice(word.to_le_bytes().as_ref());
+        }
         ret
     }
 }

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -133,6 +133,11 @@ where
     fn holder_be(&self) -> BytesHolder<T, N> {
         let mut ret = BytesHolder::default();
         let word_size = core::mem::size_of::<T>();
+        // Zip-truncation guard: if a future edit desynced
+        // `as_byte_slice_mut`'s length from `N * size_of::<T>()`, `zip`
+        // would silently drop the tail words and produce a wrong-length
+        // serialisation. Compiles out in release.
+        debug_assert_eq!(ret.as_byte_slice_mut().len(), N * word_size);
         for (chunk, word) in ret
             .as_byte_slice_mut()
             .chunks_exact_mut(word_size)
@@ -147,6 +152,7 @@ where
     fn holder_le(&self) -> BytesHolder<T, N> {
         let mut ret = BytesHolder::default();
         let word_size = core::mem::size_of::<T>();
+        debug_assert_eq!(ret.as_byte_slice_mut().len(), N * word_size);
         for (chunk, word) in ret
             .as_byte_slice_mut()
             .chunks_exact_mut(word_size)


### PR DESCRIPTION
## Summary

`num_traits::ToBytes::to_be_bytes(&FixedUInt)` currently routes through `holder_be` / `holder_le`, which call the fallible slice-based `to_be_bytes(&mut [u8]) -> Result<&[u8], bool>`. That path's runtime `output_buffer.len() < total_bytes` guard fails to DCE at `-Oz` + LTO on multi-byte limbs, leaving a reachable `panic_fmt` symbol in the linked binary for every downstream `NumToBytes` consumer.

Fix: inline the `chunks_exact_mut(WORD_SIZE)` pattern from `to_be_bytes_fixed` / `to_le_bytes_fixed` in `byte_conversion_panic_free.rs` directly into `holder_be` / `holder_le`. The outer slice comes from `BytesHolder::as_byte_slice_mut()`, whose length (`N * size_of::<T>()`) is compile-time-known via monomorphization. No `Result` guard, no runtime length check. Every `copy_from_slice(word.to_be_bytes().as_ref())` pairs an equal-length chunk and word slice, provable no-panic under LTO.

Reported by the RSA panic-freeness audit downstream. Zero API surface change. Bumps to `0.5.1`.

## Test plan

- [ ] Confirm downstream RSA panic-freeness audit no longer surfaces `panic_fmt` traced back to `NumToBytes::to_be_bytes` / `to_le_bytes` on FixedUInt.
- [ ] `cargo nm` on a downstream `.a` built at `-Oz` + LTO shows the previously-flagged symbols gone (or reachable only from unrelated paths).
- [ ] Existing fixed-bigint tests remain green (200 stable + 213 nightly + 8 integration, feature sweep clean — verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure FixedUInt big-endian and little-endian NumToBytes conversions remain panic-free under size-optimised builds by inlining a compile-time-sized byte-chunking loop instead of routing through the fallible slice-based helpers, and bump the crate patch version to 0.5.1 to publish the fix.

Bug Fixes:
- Remove reliance on the fallible slice-based to_be_bytes/to_le_bytes path in FixedUInt NumToBytes conversions that could retain a panic guard at -Oz + LTO, restoring panic-freeness.

Enhancements:
- Inline a fixed-size chunks_exact_mut-based serialization loop into holder_be/holder_le to make the byte conversion implementation more predictable and optimisation-friendly.

Build:
- Bump the fixed-bigint crate version from 0.5.0 to 0.5.1 for publishing the panic-freeness fix.