### PR TITLE
Add HeaplessBigInt: a fixed-capacity, runtime-length unsigned integer (0.6.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 Cargo.lock
 *~
 notes/
-# Local working notes, kept out of the repo and the published crate.
-/CLAUDE.md
-/CT_VERIFY.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 Cargo.lock
 *~
 notes/
+# Local working notes, kept out of the repo and the published crate.
+/CLAUDE.md
+/CT_VERIFY.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,4 +89,6 @@ use-unsafe = []
 nightly = ["c0nst/nightly", "const-num-traits/nightly"]
 cios = ["dep:modmath-cios"]
 num-traits = ["dep:num-traits", "dep:num-integer"]
+# Parked sketch: fixed-capacity, runtime-length bignum. Off by default.
+heapless-runtime-len = []
 default = ["num-traits"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ version = "2.6"
 default-features = false
 
 [dependencies.modmath-cios]
-version = "0.1"
+version = "0.1.2"
 optional = true
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,6 @@ optional = true
 default-features = false
 
 [dependencies.const-num-traits]
-# crates.io release. 0.2.1 carries BitsPrecision + WithPrecision
-# (width-establishing constructors) with bits_precision(&self). The whole
-# dependency chain (modmath/rsa/krabitls) resolves to this one version.
 version = "0.2.1"
 default-features = false
 features = ["ct"]
@@ -92,12 +89,5 @@ use-unsafe = []
 nightly = ["c0nst/nightly", "const-num-traits/nightly"]
 cios = ["dep:modmath-cios"]
 num-traits = ["dep:num-traits", "dep:num-integer"]
-# Explicit (`dep:`) so this is a visible feature rather than the implicit
-# one an optional dependency auto-creates — enabling `zeroize` is what
-# brings in the `Zeroize`/`DefaultIsZeroes` impls, and a downstream that
-# drops it from a pin table should see the feature it lost, not a bound
-# error three crates away.
 zeroize = ["dep:zeroize"]
-# Parked sketch: fixed-capacity, runtime-length bignum. Off by default.
-heapless-runtime-len = []
 default = ["num-traits"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,12 +51,13 @@ default-features = false
 
 [dependencies.const-num-traits]
 # Alpha-validation chain: pinned to the git tag (not crates.io) so the
-# whole dependency chain resolves via alpha tags. 0.2.1-alpha.2 carries
-# BitsPrecision + WithPrecision (width-establishing constructors).
+# whole dependency chain resolves via alpha tags. 0.2.1-alpha.3 carries
+# BitsPrecision + WithPrecision (width-establishing constructors), with
+# bits_precision(&self) so non-Copy carriers seed from a borrowed witness.
 # Downstream (modmath/rsa/krabitls) must pin the same tag so cargo
 # unifies to one const-num-traits.
 git = "https://github.com/kaidokert/num-traits.git"
-tag = "v0.2.1-alpha.2"
+tag = "v0.2.1-alpha.3"
 default-features = false
 features = ["ct"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.5.2"
+version = "0.6.0-alpha.1"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,12 @@ optional = true
 default-features = false
 
 [dependencies.const-num-traits]
-version = "0.2"
+# Alpha-validation chain: pinned to the git tag (not crates.io) so the
+# whole dependency chain resolves via alpha tags. 0.2.1-alpha.1 carries
+# BitsPrecision. Downstream (modmath/rsa/krabitls) must pin the same tag
+# so cargo unifies to one const-num-traits.
+git = "https://github.com/kaidokert/num-traits.git"
+tag = "v0.2.1-alpha.1"
 default-features = false
 features = ["ct"]
 
@@ -92,9 +97,3 @@ num-traits = ["dep:num-traits", "dep:num-integer"]
 # Parked sketch: fixed-capacity, runtime-length bignum. Off by default.
 heapless-runtime-len = []
 default = ["num-traits"]
-
-# TEMPORARY dev-pin: const-num-traits 0.2.1 (BitsPrecision) is tagged
-# v0.2.1-alpha.0 but not yet on crates.io. Drop this patch once 0.2.1
-# publishes; `version = "0.2"` above then resolves it normally.
-[patch.crates-io]
-const-num-traits = { path = "../num-traits" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,10 @@ optional = true
 default-features = false
 
 [dependencies.const-num-traits]
-# Alpha-validation chain: pinned to the git tag (not crates.io) so the
-# whole dependency chain resolves via alpha tags. 0.2.1-alpha.3 carries
-# BitsPrecision + WithPrecision (width-establishing constructors), with
-# bits_precision(&self) so non-Copy carriers seed from a borrowed witness.
-# Downstream (modmath/rsa/krabitls) must pin the same tag so cargo
-# unifies to one const-num-traits.
-git = "https://github.com/kaidokert/num-traits.git"
-tag = "v0.2.1-alpha.3"
+# crates.io release. 0.2.1 carries BitsPrecision + WithPrecision
+# (width-establishing constructors) with bits_precision(&self). The whole
+# dependency chain (modmath/rsa/krabitls) resolves to this one version.
+version = "0.2.1"
 default-features = false
 features = ["ct"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.6.0-alpha.1"
+version = "0.6.0"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,12 @@ default-features = false
 
 [dependencies.const-num-traits]
 # Alpha-validation chain: pinned to the git tag (not crates.io) so the
-# whole dependency chain resolves via alpha tags. 0.2.1-alpha.1 carries
-# BitsPrecision. Downstream (modmath/rsa/krabitls) must pin the same tag
-# so cargo unifies to one const-num-traits.
+# whole dependency chain resolves via alpha tags. 0.2.1-alpha.2 carries
+# BitsPrecision + WithPrecision (width-establishing constructors).
+# Downstream (modmath/rsa/krabitls) must pin the same tag so cargo
+# unifies to one const-num-traits.
 git = "https://github.com/kaidokert/num-traits.git"
-tag = "v0.2.1-alpha.1"
+tag = "v0.2.1-alpha.2"
 default-features = false
 features = ["ct"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,12 @@ use-unsafe = []
 nightly = ["c0nst/nightly", "const-num-traits/nightly"]
 cios = ["dep:modmath-cios"]
 num-traits = ["dep:num-traits", "dep:num-integer"]
+# Explicit (`dep:`) so this is a visible feature rather than the implicit
+# one an optional dependency auto-creates — enabling `zeroize` is what
+# brings in the `Zeroize`/`DefaultIsZeroes` impls, and a downstream that
+# drops it from a pin table should see the feature it lost, not a bound
+# error three crates away.
+zeroize = ["dep:zeroize"]
 # Parked sketch: fixed-capacity, runtime-length bignum. Off by default.
 heapless-runtime-len = []
 default = ["num-traits"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,9 @@ num-traits = ["dep:num-traits", "dep:num-integer"]
 # Parked sketch: fixed-capacity, runtime-length bignum. Off by default.
 heapless-runtime-len = []
 default = ["num-traits"]
+
+# TEMPORARY dev-pin: const-num-traits 0.2.1 (BitsPrecision) is tagged
+# v0.2.1-alpha.0 but not yet on crates.io. Drop this patch once 0.2.1
+# publishes; `version = "0.2"` above then resolves it normally.
+[patch.crates-io]
+const-num-traits = { path = "../num-traits" }

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,7 +22,7 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.1", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,7 +22,7 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.1", default-features = false, features = ["ct"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.2", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,7 +22,7 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.2", default-features = false, features = ["ct"] }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.3", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -22,7 +22,7 @@ panic-handler = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.3", default-features = false, features = ["ct"] }
+const-num-traits = { version = "0.2.1", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }
 

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib"]
 # impl for `FixedUInt`). Without it, the trait-path fixtures below
 # can't reach the code under test.
 fixed-bigint = { path = "../..", features = ["use-unsafe"] }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.1", default-features = false }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.2", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib"]
 # impl for `FixedUInt`). Without it, the trait-path fixtures below
 # can't reach the code under test.
 fixed-bigint = { path = "../..", features = ["use-unsafe"] }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.3", default-features = false }
+const-num-traits = { version = "0.2.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib"]
 # impl for `FixedUInt`). Without it, the trait-path fixtures below
 # can't reach the code under test.
 fixed-bigint = { path = "../..", features = ["use-unsafe"] }
-const-num-traits = { version = "0.2", default-features = false }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.1", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,

--- a/ct-verify/panic-free-audit/Cargo.toml
+++ b/ct-verify/panic-free-audit/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib"]
 # impl for `FixedUInt`). Without it, the trait-path fixtures below
 # can't reach the code under test.
 fixed-bigint = { path = "../..", features = ["use-unsafe"] }
-const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.2", default-features = false }
+const-num-traits = { git = "https://github.com/kaidokert/num-traits.git", tag = "v0.2.1-alpha.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 
 # Workspace `[profile.release]` (lto=fat, codegen-units=1, opt-level=z,

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -67,6 +67,11 @@ mod const_to_from_bytes;
 #[cfg(any(feature = "nightly", feature = "use-unsafe"))]
 mod to_from_bytes;
 
+// Re-exported crate-internally so the `heapless` module can reuse the
+// same `BytesHolder` as its `ToBytes`/`FromBytes` associated type.
+#[cfg(any(feature = "nightly", feature = "use-unsafe"))]
+pub(crate) use to_from_bytes::BytesHolder;
+
 pub use has_nonzero_impl::NonZeroFixedUInt;
 
 use const_num_traits::{Ct, Nct, Personality, PersonalityMarker, PersonalityTag};

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -608,6 +608,24 @@ c0nst::c0nst! {
         }
     }
 
+    // --- BitsPrecision -----------------------------------------------------
+    //
+    // Operating width: for a fixed carrier this is `BIT_SIZE` (= N·word_bits),
+    // value-independent — width == capacity for FixedUInt. Contrast BitWidth
+    // (bit-length, per-value).
+
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::BitsPrecision for FixedUInt<T, N, P> {
+        fn bits_precision(self) -> u32 {
+            Self::BIT_SIZE as u32
+        }
+    }
+
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::BitsPrecision for &FixedUInt<T, N, P> {
+        fn bits_precision(self) -> u32 {
+            FixedUInt::<T, N, P>::BIT_SIZE as u32
+        }
+    }
+
     // --- IsolateHighestOne / IsolateLowestOne ------------------------------
     //
     // Mask the value down to just its highest / lowest set bit.
@@ -1221,6 +1239,18 @@ mod tests {
         assert_eq!(BitWidth::bit_width(U16::from(255u8)), 8);
         assert_eq!(BitWidth::bit_width(U16::from(256u16)), 9);
         assert_eq!(BitWidth::bit_width(U16::from(0xFFFFu16)), 16);
+    }
+
+    #[test]
+    fn test_bits_precision() {
+        use const_num_traits::BitsPrecision;
+        // Fixed carrier: width == BIT_SIZE, value-independent (= capacity).
+        type U16 = FixedUInt<u8, 2>;
+        type U32 = FixedUInt<u32, 1>;
+        assert_eq!(BitsPrecision::bits_precision(U16::from(0u8)), 16);
+        assert_eq!(BitsPrecision::bits_precision(U16::from(0xFFFFu16)), 16);
+        assert_eq!(BitsPrecision::bits_precision(U32::from(0u8)), 32);
+        assert_eq!(BitsPrecision::bits_precision(&U32::from(7u8)), 32);
     }
 
     #[test]

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -626,6 +626,18 @@ c0nst::c0nst! {
         }
     }
 
+    // --- WithPrecision -----------------------------------------------------
+    //
+    // The operating width is the type (N words), so widening is the identity —
+    // same as the primitive impls. The zero/one/witness constructors default
+    // over this required method.
+
+    c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::WithPrecision for FixedUInt<T, N, P> {
+        fn widen_to_precision(self, _bits_precision: u32) -> Self {
+            self
+        }
+    }
+
     // --- IsolateHighestOne / IsolateLowestOne ------------------------------
     //
     // Mask the value down to just its highest / lowest set bit.

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -629,8 +629,7 @@ c0nst::c0nst! {
     // --- WithPrecision -----------------------------------------------------
     //
     // The operating width is the type (N words), so widening is the identity —
-    // same as the primitive impls. The zero/one/witness constructors default
-    // over this required method.
+    // same as the primitive impls.
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::WithPrecision for FixedUInt<T, N, P> {
         fn widen_to_precision(self, _bits_precision: u32) -> Self {

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -615,13 +615,13 @@ c0nst::c0nst! {
     // (bit-length, per-value).
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::BitsPrecision for FixedUInt<T, N, P> {
-        fn bits_precision(self) -> u32 {
+        fn bits_precision(&self) -> u32 {
             Self::BIT_SIZE as u32
         }
     }
 
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> const_num_traits::BitsPrecision for &FixedUInt<T, N, P> {
-        fn bits_precision(self) -> u32 {
+        fn bits_precision(&self) -> u32 {
             FixedUInt::<T, N, P>::BIT_SIZE as u32
         }
     }
@@ -1259,9 +1259,9 @@ mod tests {
         // Fixed carrier: width == BIT_SIZE, value-independent (= capacity).
         type U16 = FixedUInt<u8, 2>;
         type U32 = FixedUInt<u32, 1>;
-        assert_eq!(BitsPrecision::bits_precision(U16::from(0u8)), 16);
-        assert_eq!(BitsPrecision::bits_precision(U16::from(0xFFFFu16)), 16);
-        assert_eq!(BitsPrecision::bits_precision(U32::from(0u8)), 32);
+        assert_eq!(BitsPrecision::bits_precision(&U16::from(0u8)), 16);
+        assert_eq!(BitsPrecision::bits_precision(&U16::from(0xFFFFu16)), 16);
+        assert_eq!(BitsPrecision::bits_precision(&U32::from(0u8)), 32);
         assert_eq!(BitsPrecision::bits_precision(&U32::from(7u8)), 32);
     }
 

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -26,12 +26,11 @@
 //! itself enable the feature — `#![feature(generic_const_exprs)]` — or the
 //! compiler cannot finish the associated type's well-formedness check and
 //! reports the unhelpful `error[E0275]: overflow evaluating whether [...] is
-//! well-formed`. With the feature enabled downstream it compiles and works.
-//! (This is why the `num_traits` impls live in `to_from_bytes.rs` instead —
-//! they avoid propagating a `generic_const_exprs` bound to callers.)
+//! well-formed`. (This is why the `num_traits` impls live in
+//! `to_from_bytes.rs` instead — they avoid propagating a
+//! `generic_const_exprs` bound to callers.)
 //!
-//! The correct-usage doctest below (a doctest compiles as its own downstream
-//! crate) is the cross-crate coverage.
+//! The doctest below is the cross-crate coverage:
 //!
 //! ```
 //! # #![feature(generic_const_exprs)]

--- a/src/fixeduint/to_from_bytes.rs
+++ b/src/fixeduint/to_from_bytes.rs
@@ -35,8 +35,10 @@ impl<T: MachineWord, const N: usize> BytesHolder<T, N> {
     pub(crate) const fn from_array(array: [T; N]) -> Self {
         Self { array }
     }
-    // Converts internal storage to a mutable byte slice
-    fn as_byte_slice_mut(&mut self) -> &mut [u8] {
+    // Converts internal storage to a mutable byte slice.
+    // `pub(crate)` so the `heapless` module can build a holder from its
+    // own limb array with the same endianness discipline.
+    pub(crate) fn as_byte_slice_mut(&mut self) -> &mut [u8] {
         // SAFETY: This is safe because the size of the array is the same as the size of the slice
         unsafe {
             core::slice::from_raw_parts_mut(

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -12,7 +12,7 @@ use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
     BorrowingSub, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, Nct, OverflowingAdd,
-    OverflowingSub, Personality, PersonalityTag, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    OverflowingSub, Personality, PersonalityTag, WrappingAdd, WrappingMul, WrappingSub,
 };
 use core::marker::PhantomData;
 
@@ -94,15 +94,71 @@ pub(crate) fn mul_slice<T: MachineWord + CarryingMul<Unsigned = T, Output = T>>(
     }
 }
 
+/// Full product `a * b` split at the carrier capacity `CAP`: returns
+/// `(lo, hi)` where the true product is `hi·2^(CAP·word_bits) + lo`.
+///
+/// This is the *capacity* split, deliberately distinct from the public
+/// `CarryingMul`/`WideMul`, which splits at the operands' value width.
+/// `checked_mul` needs it to answer "does the true product fit in the
+/// carrier?" — a question about `CAP`, not value width — so it cannot
+/// reuse the value-width split (that would report overflow the moment
+/// the product exceeds `max(len)`, rejecting products that still fit in
+/// `CAP`, which is exactly what EEA intermediates rely on).
+#[inline]
+fn mul_full_cap_split<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize>(
+    a: &[T],
+    a_n: usize,
+    b: &[T],
+    b_n: usize,
+) -> ([T; CAP], [T; CAP]) {
+    let mut lo = [zero::<T>(); CAP];
+    let mut hi = [zero::<T>(); CAP];
+    let mut i = 0;
+    while i < a_n {
+        let mut c = zero::<T>();
+        let mut j = 0;
+        while j < b_n {
+            let pos = i + j;
+            let (t_lo, t_hi) = <T as CarryingMul>::carrying_mul(a[i], b[j], c);
+            let existing = if pos < CAP { lo[pos] } else { hi[pos - CAP] };
+            let (sum, c1) = <T as CarryingAdd>::carrying_add(existing, t_lo, false);
+            if pos < CAP {
+                lo[pos] = sum;
+            } else {
+                hi[pos - CAP] = sum;
+            }
+            let (new_c, _) = <T as CarryingAdd>::carrying_add(t_hi, zero::<T>(), c1);
+            c = new_c;
+            j += 1;
+        }
+        let tail = i + b_n;
+        if tail < CAP {
+            let (sum, _) = <T as CarryingAdd>::carrying_add(lo[tail], c, false);
+            lo[tail] = sum;
+        } else {
+            let (sum, _) = <T as CarryingAdd>::carrying_add(hi[tail - CAP], c, false);
+            hi[tail - CAP] = sum;
+        }
+        i += 1;
+    }
+    (lo, hi)
+}
+
 // ── Inherent methods on HeaplessBigInt ──
 
 impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
-    /// Wrapping addition. Output `len = min(max(a.len, b.len) + 1, CAP)`
-    /// per the spec. If the natural sum would need `CAP + 1` limbs, the
-    /// top carry-out is silently discarded (wrapping semantics).
+    /// Wrapping addition. Wraps at the operands' VALUE width: output
+    /// `len = max(a.len, b.len)`, and a carry out of that width is
+    /// discarded (`a.wrapping_add(b) mod 2^(max_len·word_bits)`). This
+    /// matches `FixedUInt<T, max_len>` and the primitive contract —
+    /// `wrapping_*` wraps at the type width, which for this carrier is
+    /// the value width `len·word_bits`, never `CAP`. It does NOT grow a
+    /// limb: a growing sum (up to `CAP`) is what `core::ops::+` /
+    /// `checked_add` provide. Growing here would make iterative modular
+    /// algorithms (Montgomery `n_prime` Newton, wide-REDC) drift width
+    /// and produce inconsistent results on sub-capacity fields.
     pub fn wrapping_add(&self, other: &Self) -> Self {
-        let max_len = core::cmp::max(self.len as usize, other.len as usize);
-        let out_len = core::cmp::min(max_len + 1, CAP);
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
         let mut out = Self::new_zero_with_len(out_len as u16);
         let _carry = add_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
         debug_assert!(zero_tail_ok(&out.limbs, out_len));
@@ -165,10 +221,18 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
 impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
     HeaplessBigInt<T, CAP, P>
 {
-    /// Wrapping multiplication. Output `len = min(a.len + b.len, CAP)`.
-    /// Products that would exceed `CAP` limbs are truncated.
+    /// Wrapping multiplication. Wraps at the operands' VALUE width:
+    /// output `len = max(a.len, b.len)`, keeping the low `max_len` words
+    /// (`a·b mod 2^(max_len·word_bits)`). This matches
+    /// `FixedUInt<T, max_len>` and the primitive contract — `wrapping_*`
+    /// wraps at the type width (value width here), never `CAP`. The full
+    /// growing product (up to `CAP`) is `core::ops::*` / `checked_mul` /
+    /// `WideMul`; keeping the low half here is what Montgomery's
+    /// `t_lo.wrapping_mul(n_prime) mod R` needs, and prevents the width
+    /// drift that broke sub-capacity fields when this grew to
+    /// `a.len + b.len`.
     pub fn wrapping_mul(&self, other: &Self) -> Self {
-        let out_len = core::cmp::min(self.len as usize + other.len as usize, CAP);
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
         let mut out = Self::new_zero_with_len(out_len as u16);
         mul_slice(
             &self.limbs,
@@ -204,14 +268,16 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     /// Checked multiplication. `None` when the true product does not
     /// fit in `CAP` limbs.
     ///
-    /// **Nct**: value-aware. Computes the full 2·CAP-limb product via
-    /// [`CarryingMul`] and reports overflow iff the high half is
+    /// **Nct**: value-aware. Computes the full product split at the
+    /// carrier capacity `CAP` and reports overflow iff the high half is
     /// non-zero. Chained muls whose accumulated `len` sums exceed
     /// `CAP` but whose true value still fits (a common pattern in EEA
     /// intermediates) return `Some(product)` here; `overflowing_mul`'s
     /// shape-based check would falsely reject them. The returned
     /// value has its `len` trimmed to the highest non-zero limb — an
-    /// NCT-implicit content scan, sound because Nct.
+    /// NCT-implicit content scan, sound because Nct. The split is at
+    /// `CAP` (not the value width `WideMul` uses), because the question
+    /// is "does the true product fit in the carrier?".
     ///
     /// **Ct**: shape-based (`self.len + other.len > CAP` → `None`).
     /// Ct callers who need a value-derived answer are asking for a
@@ -219,10 +285,19 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     pub fn checked_mul(&self, other: &Self) -> Option<Self> {
         match P::TAG {
             PersonalityTag::Nct => {
-                let zero_v = <Self as Zero>::zero();
-                let (lo, hi) = <Self as CarryingMul>::carrying_mul(*self, *other, zero_v);
-                if <Self as Zero>::is_zero(&hi) {
-                    Some(trim_content(lo))
+                let (lo, hi) = mul_full_cap_split::<T, CAP>(
+                    &self.limbs,
+                    self.len as usize,
+                    &other.limbs,
+                    other.len as usize,
+                );
+                if hi.iter().all(is_zero) {
+                    let product = HeaplessBigInt {
+                        limbs: lo,
+                        len: CAP as u16,
+                        _p: PhantomData,
+                    };
+                    Some(trim_content(product))
                 } else {
                     None
                 }

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -10,7 +10,10 @@
 
 use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
-use const_num_traits::{BorrowingSub, CarryingAdd, CarryingMul, Personality};
+use const_num_traits::{
+    BorrowingSub, CarryingAdd, CarryingMul, OverflowingAdd, OverflowingSub, Personality,
+    WrappingAdd, WrappingSub,
+};
 
 // ── Free-function slice kernels ──
 //
@@ -229,6 +232,79 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
         let (res, overflow) = self.overflowing_mul(other);
         assert!(!overflow, "HeaplessBigInt::mul overflow");
         res
+    }
+}
+
+// ── const_num_traits Wrapping / Overflowing Add & Sub ──
+//
+// Delegate to the inherent methods; the traits take `self` by value,
+// the inherent methods take references. `HeaplessBigInt: Copy`, so
+// converting between the two is a no-op at runtime.
+
+impl<T: MachineWord, const CAP: usize, P: Personality> WrappingAdd for HeaplessBigInt<T, CAP, P> {
+    type Output = Self;
+    fn wrapping_add(self, v: Self) -> Self::Output {
+        Self::wrapping_add(&self, &v)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> WrappingSub for HeaplessBigInt<T, CAP, P> {
+    type Output = Self;
+    fn wrapping_sub(self, v: Self) -> Self::Output {
+        Self::wrapping_sub(&self, &v)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> OverflowingAdd
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn overflowing_add(self, v: Self) -> (Self::Output, bool) {
+        Self::overflowing_add(&self, &v)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> OverflowingSub
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn overflowing_sub(self, v: Self) -> (Self::Output, bool) {
+        Self::overflowing_sub(&self, &v)
+    }
+}
+
+// Reference-receiver variants mirror `FixedUInt`'s pattern (`add_sub_impl.rs`),
+// letting `&HeaplessBigInt` satisfy the same generic trait bound.
+
+impl<T: MachineWord, const CAP: usize, P: Personality> WrappingAdd for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn wrapping_add(self, v: Self) -> Self::Output {
+        HeaplessBigInt::wrapping_add(self, v)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> WrappingSub for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn wrapping_sub(self, v: Self) -> Self::Output {
+        HeaplessBigInt::wrapping_sub(self, v)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> OverflowingAdd
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn overflowing_add(self, v: Self) -> (Self::Output, bool) {
+        HeaplessBigInt::overflowing_add(self, v)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> OverflowingSub
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn overflowing_sub(self, v: Self) -> (Self::Output, bool) {
+        HeaplessBigInt::overflowing_sub(self, v)
     }
 }
 

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -16,9 +16,23 @@ use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
     BorrowingSub, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, Nct, OverflowingAdd,
-    OverflowingMul, OverflowingSub, Personality, WrappingAdd, WrappingMul, WrappingSub,
+    OverflowingMul, OverflowingSub, Personality, PersonalityTag, WrappingAdd, WrappingMul,
+    WrappingSub,
 };
 use core::marker::PhantomData;
+
+// The checked `+`/`-`/`*` operators panic on overflow at the operands'
+// width. That panic branches on a data-dependent overflow bit, so it
+// runs for `Nct` only; the `Ct` arm wraps silently (like `wrapping_*`),
+// keeping control flow value-independent. Mirrors `FixedUInt`'s
+// `maybe_panic_if::<P>`.
+#[inline]
+fn panic_on_overflow_if_nct<P: Personality>(overflow: bool, msg: &'static str) {
+    match P::TAG {
+        PersonalityTag::Nct => assert!(!overflow, "{}", msg),
+        PersonalityTag::Ct => {}
+    }
+}
 
 // ── Free-function slice kernels ──
 //
@@ -269,8 +283,8 @@ impl<T: MachineWord, const CAP: usize> HeaplessBigInt<T, CAP, Nct> {
 // ── core::ops::{Add, Sub, Mul} — panic on overflow at the operand width ──
 //
 // Same contract as the same-width `FixedUInt`: forward to the
-// `overflowing_*` op and panic if it flags. Callers wanting wrap or a
-// flag use `wrapping_*` / `overflowing_*` / `checked_*`.
+// `overflowing_*` op and panic (Nct) or wrap (Ct) if it flags. Callers
+// wanting wrap or a flag use `wrapping_*` / `overflowing_*` / `checked_*`.
 
 impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Add<&HeaplessBigInt<T, CAP, P>>
     for &HeaplessBigInt<T, CAP, P>
@@ -278,7 +292,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Add<&HeaplessB
     type Output = HeaplessBigInt<T, CAP, P>;
     fn add(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
         let (res, overflow) = self.overflowing_add(other);
-        assert!(!overflow, "HeaplessBigInt::add overflow");
+        panic_on_overflow_if_nct::<P>(overflow, "HeaplessBigInt::add overflow");
         res
     }
 }
@@ -289,7 +303,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Sub<&HeaplessB
     type Output = HeaplessBigInt<T, CAP, P>;
     fn sub(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
         let (res, borrow) = self.overflowing_sub(other);
-        assert!(!borrow, "HeaplessBigInt::sub underflow");
+        panic_on_overflow_if_nct::<P>(borrow, "HeaplessBigInt::sub underflow");
         res
     }
 }
@@ -300,7 +314,7 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     type Output = HeaplessBigInt<T, CAP, P>;
     fn mul(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
         let (res, overflow) = self.overflowing_mul(other);
-        assert!(!overflow, "HeaplessBigInt::mul overflow");
+        panic_on_overflow_if_nct::<P>(overflow, "HeaplessBigInt::mul overflow");
         res
     }
 }

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -1,25 +1,29 @@
 //! Add / Sub / Mul for `HeaplessBigInt`.
 //!
-//! Every op is written against public loop counts derived from operand
-//! `len`s (per § Length arithmetic under operations in the spec) and
-//! per-limb branchless primitives from `const_num_traits`. Iteration is
-//! CT-safe under the "len is public" invariant regardless of
-//! Personality, so the Nct and Ct arms share the same body for
-//! Add/Sub/Mul. Personality dispatch only enters when the output
-//! reporting shape differs (e.g. panic-on-overflow vs mask-select).
+//! Every op operates at the operands' width `max(a.len, b.len)` and
+//! returns bit-for-bit what the same-width `FixedUInt` returns: a value
+//! carried at `len = k` is a `k`-word integer, and the capacity beyond
+//! `len` does not exist as far as arithmetic is concerned. Wrapping,
+//! overflow, and carry/borrow all resolve at that width; `CAP` never
+//! enters an answer.
+//!
+//! Loop counts derive from the public `len`s and per-limb branchless
+//! primitives from `const_num_traits`, so iteration is CT-safe under the
+//! "len is public" invariant regardless of Personality — the Nct and Ct
+//! arms share one body.
 
 use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
     BorrowingSub, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, Nct, OverflowingAdd,
-    OverflowingSub, Personality, PersonalityTag, WrappingAdd, WrappingMul, WrappingSub,
+    OverflowingMul, OverflowingSub, Personality, WrappingAdd, WrappingMul, WrappingSub,
 };
 use core::marker::PhantomData;
 
 // ── Free-function slice kernels ──
 //
 // Take `&[T]` / `&mut [T]` so a future refactor can share them with
-// `fixed-bigint`'s existing algorithms (spec § Code sharing).
+// `fixed-bigint`'s existing fixed-width algorithms.
 
 /// `out[..n] = a[..n] + b[..n]`, returning the final carry-out.
 /// All three slices must have length ≥ `n`. `a` / `b` beyond their
@@ -53,9 +57,9 @@ pub(crate) fn sub_slice<T: MachineWord>(a: &[T], b: &[T], out: &mut [T], n: usiz
 }
 
 /// Schoolbook `out[..out_n] += a[..a_n] * b[..b_n]`. Assumes `out` is
-/// zero-initialised on entry. `out_n` is `min(a_n + b_n, CAP)`; a partial
-/// product that would overflow past `out_n` is silently truncated (used
-/// by wrapping-mul; overflow-detecting mul checks separately).
+/// zero-initialised on entry. A partial product past `out_n` is silently
+/// truncated; `wrapping_mul` passes `out_n = max(a_n, b_n)` to keep the
+/// low `width` words (the high half is dropped, as at a fixed width).
 ///
 /// `T: CarryingMul<Unsigned = T, Output = T>` is stated explicitly because
 /// `MachineWord`'s supertrait chain does not include `CarryingMul` — the
@@ -94,69 +98,14 @@ pub(crate) fn mul_slice<T: MachineWord + CarryingMul<Unsigned = T, Output = T>>(
     }
 }
 
-/// Full product `a * b` split at the carrier capacity `CAP`: returns
-/// `(lo, hi)` where the true product is `hi·2^(CAP·word_bits) + lo`.
-///
-/// This is the *capacity* split, deliberately distinct from the public
-/// `CarryingMul`/`WideMul`, which splits at the operands' value width.
-/// `checked_mul` needs it to answer "does the true product fit in the
-/// carrier?" — a question about `CAP`, not value width — so it cannot
-/// reuse the value-width split (that would report overflow the moment
-/// the product exceeds `max(len)`, rejecting products that still fit in
-/// `CAP`, which is exactly what EEA intermediates rely on).
-#[inline]
-fn mul_full_cap_split<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize>(
-    a: &[T],
-    a_n: usize,
-    b: &[T],
-    b_n: usize,
-) -> ([T; CAP], [T; CAP]) {
-    let mut lo = [zero::<T>(); CAP];
-    let mut hi = [zero::<T>(); CAP];
-    let mut i = 0;
-    while i < a_n {
-        let mut c = zero::<T>();
-        let mut j = 0;
-        while j < b_n {
-            let pos = i + j;
-            let (t_lo, t_hi) = <T as CarryingMul>::carrying_mul(a[i], b[j], c);
-            let existing = if pos < CAP { lo[pos] } else { hi[pos - CAP] };
-            let (sum, c1) = <T as CarryingAdd>::carrying_add(existing, t_lo, false);
-            if pos < CAP {
-                lo[pos] = sum;
-            } else {
-                hi[pos - CAP] = sum;
-            }
-            let (new_c, _) = <T as CarryingAdd>::carrying_add(t_hi, zero::<T>(), c1);
-            c = new_c;
-            j += 1;
-        }
-        let tail = i + b_n;
-        if tail < CAP {
-            let (sum, _) = <T as CarryingAdd>::carrying_add(lo[tail], c, false);
-            lo[tail] = sum;
-        } else {
-            let (sum, _) = <T as CarryingAdd>::carrying_add(hi[tail - CAP], c, false);
-            hi[tail - CAP] = sum;
-        }
-        i += 1;
-    }
-    (lo, hi)
-}
-
 // ── Inherent methods on HeaplessBigInt ──
 
 impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
-    /// Wrapping addition. Wraps at the operands' VALUE width: output
-    /// `len = max(a.len, b.len)`, and a carry out of that width is
-    /// discarded (`a.wrapping_add(b) mod 2^(max_len·word_bits)`). This
-    /// matches `FixedUInt<T, max_len>` and the primitive contract —
-    /// `wrapping_*` wraps at the type width, which for this carrier is
-    /// the value width `len·word_bits`, never `CAP`. It does NOT grow a
-    /// limb: a growing sum (up to `CAP`) is what `core::ops::+` /
-    /// `checked_add` provide. Growing here would make iterative modular
-    /// algorithms (Montgomery `n_prime` Newton, wide-REDC) drift width
-    /// and produce inconsistent results on sub-capacity fields.
+    /// Wrapping addition, at the operands' width `max(a.len, b.len)`.
+    /// A carry out of that width is discarded — `HeaplessBigInt` carried
+    /// at `len = k` is a `k`-word integer that behaves exactly like
+    /// `FixedUInt<T, k>`; the capacity beyond `len` does not exist as far
+    /// as arithmetic is concerned. `CAP` never enters.
     pub fn wrapping_add(&self, other: &Self) -> Self {
         let out_len = core::cmp::max(self.len as usize, other.len as usize);
         let mut out = Self::new_zero_with_len(out_len as u16);
@@ -165,19 +114,19 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         out
     }
 
-    /// Overflowing addition. Returns the wrapped result and the carry-out
-    /// beyond `out_len` limbs. Public overflow flag is a scalar; not
-    /// content-derived shape.
+    /// Overflowing addition, at the operands' width `max(a.len, b.len)`.
+    /// Returns `(sum mod 2^(width·word_bits), carry_out)` — the carry is
+    /// the bit beyond the width, reported as a flag, exactly as
+    /// `FixedUInt<T, width>::overflowing_add` does. Symmetric to
+    /// [`overflowing_sub`](Self::overflowing_sub). Does not grow a limb.
     pub fn overflowing_add(&self, other: &Self) -> (Self, bool) {
-        let max_len = core::cmp::max(self.len as usize, other.len as usize);
-        let out_len = core::cmp::min(max_len + 1, CAP);
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
         let mut out = Self::new_zero_with_len(out_len as u16);
-        let carry_full = add_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
-        let overflow = carry_full && out_len == CAP;
-        (out, overflow)
+        let carry = add_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
+        (out, carry)
     }
 
-    /// Checked addition. `None` on overflow.
+    /// Checked addition. `None` on overflow at the operands' width.
     pub fn checked_add(&self, other: &Self) -> Option<Self> {
         let (res, overflow) = self.overflowing_add(other);
         if overflow { None } else { Some(res) }
@@ -221,16 +170,11 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
 impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
     HeaplessBigInt<T, CAP, P>
 {
-    /// Wrapping multiplication. Wraps at the operands' VALUE width:
-    /// output `len = max(a.len, b.len)`, keeping the low `max_len` words
-    /// (`a·b mod 2^(max_len·word_bits)`). This matches
-    /// `FixedUInt<T, max_len>` and the primitive contract — `wrapping_*`
-    /// wraps at the type width (value width here), never `CAP`. The full
-    /// growing product (up to `CAP`) is `core::ops::*` / `checked_mul` /
-    /// `WideMul`; keeping the low half here is what Montgomery's
-    /// `t_lo.wrapping_mul(n_prime) mod R` needs, and prevents the width
-    /// drift that broke sub-capacity fields when this grew to
-    /// `a.len + b.len`.
+    /// Wrapping multiplication, at the operands' width `max(a.len, b.len)`:
+    /// keeps the low `width` words (`a·b mod 2^(width·word_bits)`),
+    /// exactly like `FixedUInt<T, width>::wrapping_mul`. The high half of
+    /// the product does not exist as far as this op is concerned — `CAP`
+    /// never enters. `WideMul` is the op that returns both halves.
     pub fn wrapping_mul(&self, other: &Self) -> Self {
         let out_len = core::cmp::max(self.len as usize, other.len as usize);
         let mut out = Self::new_zero_with_len(out_len as u16);
@@ -246,77 +190,36 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
         out
     }
 
-    /// Overflowing multiplication. Returns `(wrapped_result,
-    /// overflow_flag)`. Overflow is set if the natural product would need
-    /// more than `CAP` limbs.
+    /// Overflowing multiplication, at the operands' width
+    /// `w = max(a.len, b.len)`. Returns `(a·b mod 2^(w·word_bits),
+    /// overflow)`, where `overflow` is set iff the product does not fit
+    /// in `w` words — bit-identical to `FixedUInt<T, w>::overflowing_mul`.
+    /// The split is at the value width (via [`WideMul`]), so the high
+    /// half is the part beyond `w`; `CAP` is irrelevant.
     pub fn overflowing_mul(&self, other: &Self) -> (Self, bool) {
-        let natural_len = self.len as usize + other.len as usize;
-        let overflow = natural_len > CAP;
-        let out_len = core::cmp::min(natural_len, CAP);
-        let mut out = Self::new_zero_with_len(out_len as u16);
-        mul_slice(
-            &self.limbs,
-            self.len as usize,
-            &other.limbs,
-            other.len as usize,
-            &mut out.limbs,
-            out_len,
-        );
-        (out, overflow)
+        let zero_v = <Self as const_num_traits::Zero>::zero();
+        let (lo, hi) = <Self as CarryingMul>::carrying_mul(*self, *other, zero_v);
+        (lo, !<Self as const_num_traits::Zero>::is_zero(&hi))
     }
 
-    /// Checked multiplication. `None` when the true product does not
-    /// fit in `CAP` limbs.
-    ///
-    /// **Nct**: value-aware. Computes the full product split at the
-    /// carrier capacity `CAP` and reports overflow iff the high half is
-    /// non-zero. Chained muls whose accumulated `len` sums exceed
-    /// `CAP` but whose true value still fits (a common pattern in EEA
-    /// intermediates) return `Some(product)` here; `overflowing_mul`'s
-    /// shape-based check would falsely reject them. The returned
-    /// value has its `len` trimmed to the highest non-zero limb — an
-    /// NCT-implicit content scan, sound because Nct. The split is at
-    /// `CAP` (not the value width `WideMul` uses), because the question
-    /// is "does the true product fit in the carrier?".
-    ///
-    /// **Ct**: shape-based (`self.len + other.len > CAP` → `None`).
-    /// Ct callers who need a value-derived answer are asking for a
-    /// content-derived shape, which the spec forbids.
+    /// Checked multiplication. `None` when the product does not fit in the
+    /// operands' width `max(a.len, b.len)` — i.e. exactly when
+    /// `FixedUInt<T, width>::checked_mul` would return `None`. `CAP` does
+    /// not enter: the value is a `width`-word integer, and the words it
+    /// does not have do not exist.
     pub fn checked_mul(&self, other: &Self) -> Option<Self> {
-        match P::TAG {
-            PersonalityTag::Nct => {
-                let (lo, hi) = mul_full_cap_split::<T, CAP>(
-                    &self.limbs,
-                    self.len as usize,
-                    &other.limbs,
-                    other.len as usize,
-                );
-                if hi.iter().all(is_zero) {
-                    let product = HeaplessBigInt {
-                        limbs: lo,
-                        len: CAP as u16,
-                        _p: PhantomData,
-                    };
-                    Some(trim_content(product))
-                } else {
-                    None
-                }
-            }
-            PersonalityTag::Ct => {
-                let (res, overflow) = self.overflowing_mul(other);
-                if overflow { None } else { Some(res) }
-            }
-        }
+        let (res, overflow) = self.overflowing_mul(other);
+        if overflow { None } else { Some(res) }
     }
 }
 
 // ── const_num_traits CheckedAdd / CheckedMul (Nct only) ──
 //
-// The trait forms modmath's variable-time inv binds on. Nct-only: the
-// value-aware `checked_mul` (returns `Some` when the true product fits
-// even though the accumulated `len` shape overruns CAP) is an
-// NCT-implicit content scan, so exposing it through a trait is sound
-// only on the Nct carrier. `HeaplessBigInt: Copy`, so bridging the
+// The trait forms modmath's variable-time inv binds on. `checked_add` /
+// `checked_mul` return `None` on overflow at the operands' width, exactly
+// as the same-width `FixedUInt` would — the carrier at `len = k` is a
+// `k`-word integer, no capacity headroom. Trait exposure is kept Nct-only
+// to match the existing surface. `HeaplessBigInt: Copy`, so bridging the
 // by-value trait receiver to the by-reference inherent method is free.
 
 impl<T, const CAP: usize> CheckedAdd for HeaplessBigInt<T, CAP, Nct>
@@ -373,7 +276,11 @@ impl<T: MachineWord, const CAP: usize> HeaplessBigInt<T, CAP, Nct> {
     }
 }
 
-// ── core::ops::{Add, Sub, Mul} — panic on overflow, forward to wrapping ──
+// ── core::ops::{Add, Sub, Mul} — panic on overflow at the operand width ──
+//
+// Same contract as the same-width `FixedUInt`: forward to the
+// `overflowing_*` op and panic if it flags. Callers wanting wrap or a
+// flag use `wrapping_*` / `overflowing_*` / `checked_*`.
 
 impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Add<&HeaplessBigInt<T, CAP, P>>
     for &HeaplessBigInt<T, CAP, P>
@@ -567,8 +474,8 @@ impl<T: MachineWord, const CAP: usize, P: Personality> OverflowingSub
     }
 }
 
-// WrappingMul — the explicit method modmath's EEA should call instead
-// of `core::ops::Mul`, which has no defined overflow contract.
+// WrappingMul — explicit wrap-at-width multiply, for callers that want
+// the low half rather than `core::ops::Mul`'s panic-on-overflow.
 
 impl<T, const CAP: usize, P: Personality> WrappingMul for HeaplessBigInt<T, CAP, P>
 where
@@ -590,16 +497,36 @@ where
     }
 }
 
-// ── BorrowingSub at the bigint level ──
+// OverflowingMul — value-width overflow flag, matching FixedUInt.
+
+impl<T, const CAP: usize, P: Personality> OverflowingMul for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn overflowing_mul(self, v: Self) -> (Self::Output, bool) {
+        Self::overflowing_mul(&self, &v)
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> OverflowingMul for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn overflowing_mul(self, v: Self) -> (Self::Output, bool) {
+        HeaplessBigInt::overflowing_mul(self, v)
+    }
+}
+
+// ── CarryingAdd at the bigint level ──
 //
-// `self + rhs + carry_in` with carry_out, over the operands' value width
+// `self + rhs + carry_in` with carry_out, over the operands' width
 // (`max(self.len, rhs.len)`), not `CAP` — the symmetric partner of
-// `borrowing_sub` below. This is the value-width add-with-carry that
-// carry-propagating modular algorithms (wide-REDC) need: the carry-out
-// is the bit *beyond* the width, reported as a flag rather than grown
-// into a new limb. Distinct from `overflowing_add`, which grows a limb
-// (up to `CAP`) to hold the carry for the growing-bignum paths
-// (`core::ops::+`, `checked_add`) that modmath's EEA uses.
+// `borrowing_sub` below, same width rule as every other op. Same
+// value-width result as `overflowing_add`; the difference is the
+// `carry_in` input, which lets a multi-precision routine (wide-REDC)
+// chain carries across limbs the way `borrowing_sub` chains borrows.
 
 impl<T, const CAP: usize, P: Personality> CarryingAdd for HeaplessBigInt<T, CAP, P>
 where

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -1,0 +1,245 @@
+//! Add / Sub / Mul for `HeaplessBigInt`.
+//!
+//! Every op is written against public loop counts derived from operand
+//! `len`s (per § Length arithmetic under operations in the spec) and
+//! per-limb branchless primitives from `const_num_traits`. Iteration is
+//! CT-safe under the "len is public" invariant regardless of
+//! Personality, so the Nct and Ct arms share the same body for
+//! Add/Sub/Mul. Personality dispatch only enters when the output
+//! reporting shape differs (e.g. panic-on-overflow vs mask-select).
+
+use super::{HeaplessBigInt, is_zero, zero};
+use crate::MachineWord;
+use const_num_traits::{BorrowingSub, CarryingAdd, CarryingMul, Personality};
+
+// ── Free-function slice kernels ──
+//
+// Take `&[T]` / `&mut [T]` so a future refactor can share them with
+// `fixed-bigint`'s existing algorithms (spec § Code sharing).
+
+/// `out[..n] = a[..n] + b[..n]`, returning the final carry-out.
+/// All three slices must have length ≥ `n`. `a` / `b` beyond their
+/// respective logical `len`s must be zero (zero-tail invariant).
+#[inline]
+pub(crate) fn add_slice<T: MachineWord>(a: &[T], b: &[T], out: &mut [T], n: usize) -> bool {
+    let mut carry = false;
+    let mut i = 0;
+    while i < n {
+        let (sum, c) = <T as CarryingAdd>::carrying_add(a[i], b[i], carry);
+        out[i] = sum;
+        carry = c;
+        i += 1;
+    }
+    carry
+}
+
+/// `out[..n] = a[..n] - b[..n]`, returning the final borrow-out.
+/// Same length / zero-tail preconditions as [`add_slice`].
+#[inline]
+pub(crate) fn sub_slice<T: MachineWord>(a: &[T], b: &[T], out: &mut [T], n: usize) -> bool {
+    let mut borrow = false;
+    let mut i = 0;
+    while i < n {
+        let (diff, br) = <T as BorrowingSub>::borrowing_sub(a[i], b[i], borrow);
+        out[i] = diff;
+        borrow = br;
+        i += 1;
+    }
+    borrow
+}
+
+/// Schoolbook `out[..out_n] += a[..a_n] * b[..b_n]`. Assumes `out` is
+/// zero-initialised on entry. `out_n` is `min(a_n + b_n, CAP)`; a partial
+/// product that would overflow past `out_n` is silently truncated (used
+/// by wrapping-mul; overflow-detecting mul checks separately).
+///
+/// `T: CarryingMul<Unsigned = T, Output = T>` is stated explicitly because
+/// `MachineWord`'s supertrait chain does not include `CarryingMul` — the
+/// FixedUInt path routes multiplication through the `ConstDoubleWord`
+/// associated type rather than the `CarryingMul` primitive.
+#[inline]
+pub(crate) fn mul_slice<T: MachineWord + CarryingMul<Unsigned = T, Output = T>>(
+    a: &[T],
+    a_n: usize,
+    b: &[T],
+    b_n: usize,
+    out: &mut [T],
+    out_n: usize,
+) {
+    let mut i = 0;
+    while i < a_n {
+        let mut carry = zero::<T>();
+        let mut j = 0;
+        while j < b_n {
+            let pos = i + j;
+            if pos < out_n {
+                let (lo, hi) = <T as CarryingMul>::carrying_mul(a[i], b[j], carry);
+                let (sum, c1) = <T as CarryingAdd>::carrying_add(out[pos], lo, false);
+                out[pos] = sum;
+                let (new_carry, _) = <T as CarryingAdd>::carrying_add(hi, zero::<T>(), c1);
+                carry = new_carry;
+            }
+            j += 1;
+        }
+        let tail = i + b_n;
+        if tail < out_n {
+            let (sum, _) = <T as CarryingAdd>::carrying_add(out[tail], carry, false);
+            out[tail] = sum;
+        }
+        i += 1;
+    }
+}
+
+// ── Inherent methods on HeaplessBigInt ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
+    /// Wrapping addition. Output `len = min(max(a.len, b.len) + 1, CAP)`
+    /// per the spec. If the natural sum would need `CAP + 1` limbs, the
+    /// top carry-out is silently discarded (wrapping semantics).
+    pub fn wrapping_add(&self, other: &Self) -> Self {
+        let max_len = core::cmp::max(self.len as usize, other.len as usize);
+        let out_len = core::cmp::min(max_len + 1, CAP);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        let _carry = add_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
+        debug_assert!(zero_tail_ok(&out.limbs, out_len));
+        out
+    }
+
+    /// Overflowing addition. Returns the wrapped result and the carry-out
+    /// beyond `out_len` limbs. Public overflow flag is a scalar; not
+    /// content-derived shape.
+    pub fn overflowing_add(&self, other: &Self) -> (Self, bool) {
+        let max_len = core::cmp::max(self.len as usize, other.len as usize);
+        let out_len = core::cmp::min(max_len + 1, CAP);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        let carry_full = add_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
+        let overflow = carry_full && out_len == CAP;
+        (out, overflow)
+    }
+
+    /// Checked addition. `None` on overflow.
+    pub fn checked_add(&self, other: &Self) -> Option<Self> {
+        let (res, overflow) = self.overflowing_add(other);
+        if overflow { None } else { Some(res) }
+    }
+
+    /// Wrapping subtraction. Output `len = max(a.len, b.len)`.
+    /// If `self < other`, the value wraps modulo `2^(len * WORD_BITS)`.
+    pub fn wrapping_sub(&self, other: &Self) -> Self {
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        let _borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
+        debug_assert!(zero_tail_ok(&out.limbs, out_len));
+        out
+    }
+
+    /// Overflowing subtraction. Returns `(wrapped_result, borrow_out)`.
+    pub fn overflowing_sub(&self, other: &Self) -> (Self, bool) {
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        let borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
+        (out, borrow)
+    }
+
+    /// Checked subtraction. `None` on underflow.
+    pub fn checked_sub(&self, other: &Self) -> Option<Self> {
+        let (res, borrow) = self.overflowing_sub(other);
+        if borrow { None } else { Some(res) }
+    }
+}
+
+// Mul lives in its own impl block because `CarryingMul` is not part of
+// `MachineWord`'s supertrait chain — see `mul_slice`'s note.
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
+    HeaplessBigInt<T, CAP, P>
+{
+    /// Wrapping multiplication. Output `len = min(a.len + b.len, CAP)`.
+    /// Products that would exceed `CAP` limbs are truncated.
+    pub fn wrapping_mul(&self, other: &Self) -> Self {
+        let out_len = core::cmp::min(self.len as usize + other.len as usize, CAP);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        mul_slice(
+            &self.limbs,
+            self.len as usize,
+            &other.limbs,
+            other.len as usize,
+            &mut out.limbs,
+            out_len,
+        );
+        debug_assert!(zero_tail_ok(&out.limbs, out_len));
+        out
+    }
+
+    /// Overflowing multiplication. Returns `(wrapped_result,
+    /// overflow_flag)`. Overflow is set if the natural product would need
+    /// more than `CAP` limbs.
+    pub fn overflowing_mul(&self, other: &Self) -> (Self, bool) {
+        let natural_len = self.len as usize + other.len as usize;
+        let overflow = natural_len > CAP;
+        let out_len = core::cmp::min(natural_len, CAP);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        mul_slice(
+            &self.limbs,
+            self.len as usize,
+            &other.limbs,
+            other.len as usize,
+            &mut out.limbs,
+            out_len,
+        );
+        (out, overflow)
+    }
+
+    /// Checked multiplication. `None` on overflow.
+    pub fn checked_mul(&self, other: &Self) -> Option<Self> {
+        let (res, overflow) = self.overflowing_mul(other);
+        if overflow { None } else { Some(res) }
+    }
+}
+
+// ── core::ops::{Add, Sub, Mul} — panic on overflow, forward to wrapping ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Add<&HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn add(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        let (res, overflow) = self.overflowing_add(other);
+        assert!(!overflow, "HeaplessBigInt::add overflow");
+        res
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Sub<&HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn sub(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        let (res, borrow) = self.overflowing_sub(other);
+        assert!(!borrow, "HeaplessBigInt::sub underflow");
+        res
+    }
+}
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
+    core::ops::Mul<&HeaplessBigInt<T, CAP, P>> for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn mul(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        let (res, overflow) = self.overflowing_mul(other);
+        assert!(!overflow, "HeaplessBigInt::mul overflow");
+        res
+    }
+}
+
+#[inline]
+pub(crate) fn zero_tail_ok<T: MachineWord>(limbs: &[T], used: usize) -> bool {
+    let mut i = used;
+    while i < limbs.len() {
+        if !is_zero(&limbs[i]) {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -592,6 +592,42 @@ where
 
 // ── BorrowingSub at the bigint level ──
 //
+// `self + rhs + carry_in` with carry_out, over the operands' value width
+// (`max(self.len, rhs.len)`), not `CAP` — the symmetric partner of
+// `borrowing_sub` below. This is the value-width add-with-carry that
+// carry-propagating modular algorithms (wide-REDC) need: the carry-out
+// is the bit *beyond* the width, reported as a flag rather than grown
+// into a new limb. Distinct from `overflowing_add`, which grows a limb
+// (up to `CAP`) to hold the carry for the growing-bignum paths
+// (`core::ops::+`, `checked_add`) that modmath's EEA uses.
+
+impl<T, const CAP: usize, P: Personality> CarryingAdd for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    type Output = Self;
+    fn carrying_add(self, rhs: Self, carry_in: bool) -> (Self::Output, bool) {
+        let out_len = core::cmp::max(self.len as usize, rhs.len as usize);
+        let mut out_limbs = [zero::<T>(); CAP];
+        let mut carry = carry_in;
+        let mut i = 0;
+        while i < out_len {
+            let (sum, c) = <T as CarryingAdd>::carrying_add(self.limbs[i], rhs.limbs[i], carry);
+            out_limbs[i] = sum;
+            carry = c;
+            i += 1;
+        }
+        (
+            HeaplessBigInt {
+                limbs: out_limbs,
+                len: out_len as u16,
+                _p: PhantomData,
+            },
+            carry,
+        )
+    }
+}
+
 // `self - rhs - borrow_in` with borrow_out, over the operands' width
 // (`max(self.len, rhs.len)`), not `CAP` — same width rule as
 // `wrapping_sub`, so underflow wraps at the value's width and `CAP`

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -127,26 +127,28 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         if overflow { None } else { Some(res) }
     }
 
-    /// Wrapping subtraction. On underflow the value wraps modulo
-    /// `2^(CAP * WORD_BITS)` — the full container width, matching
-    /// `FixedUInt<T, CAP>`. Iterating the full `CAP` (rather than
-    /// `max(a.len, b.len)`) makes the result a function of the operand
-    /// *values*, not how their `len` was carried: `wrapping_sub(5, 7)`
-    /// is the same whether 5 and 7 are held at len 1 or len CAP. Output
-    /// `len = CAP`.
+    /// Wrapping subtraction. Output `len = max(a.len, b.len)` — the
+    /// operands' width, per the bit-vocabulary model where a
+    /// `HeaplessBigInt`'s width is `len·word_bits`, not `CAP`. On
+    /// underflow the value wraps modulo `2^(max_len·WORD_BITS)`: a
+    /// value carried at a narrower width wraps at that narrower width
+    /// (like `u8` vs `u32`), which is the point of the variable-width
+    /// carrier — `CAP` never enters.
     pub fn wrapping_sub(&self, other: &Self) -> Self {
-        let mut out = Self::new_zero_with_len(CAP as u16);
-        let _borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, CAP);
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        let _borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
+        debug_assert!(zero_tail_ok(&out.limbs, out_len));
         out
     }
 
     /// Overflowing subtraction. Returns `(wrapped_result, borrow_out)`.
-    /// `borrow_out` is the true underflow flag (`self < other`); the
-    /// wrapped value is the CAP-width two's complement — see
-    /// [`wrapping_sub`](Self::wrapping_sub) on the width choice.
+    /// Same width choice as [`wrapping_sub`](Self::wrapping_sub);
+    /// `borrow_out` is the underflow flag (`self < other`).
     pub fn overflowing_sub(&self, other: &Self) -> (Self, bool) {
-        let mut out = Self::new_zero_with_len(CAP as u16);
-        let borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, CAP);
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        let borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
         (out, borrow)
     }
 
@@ -513,9 +515,10 @@ where
 
 // ── BorrowingSub at the bigint level ──
 //
-// Full-CAP `self - rhs - borrow_in` with borrow_out. Iteration is
-// 0..CAP (not `self.len`) because widening-primitive semantics require
-// the whole array range. Modmath's full CIOS driver fires from this.
+// `self - rhs - borrow_in` with borrow_out, over the operands' width
+// (`max(self.len, rhs.len)`), not `CAP` — same width rule as
+// `wrapping_sub`, so underflow wraps at the value's width and `CAP`
+// stays out of the algorithm. Modmath's CIOS driver fires from this.
 
 impl<T, const CAP: usize, P: Personality> BorrowingSub for HeaplessBigInt<T, CAP, P>
 where
@@ -523,10 +526,11 @@ where
 {
     type Output = Self;
     fn borrowing_sub(self, rhs: Self, borrow_in: bool) -> (Self::Output, bool) {
+        let out_len = core::cmp::max(self.len as usize, rhs.len as usize);
         let mut out_limbs = [zero::<T>(); CAP];
         let mut borrow = borrow_in;
         let mut i = 0;
-        while i < CAP {
+        while i < out_len {
             let (diff, br) =
                 <T as BorrowingSub>::borrowing_sub(self.limbs[i], rhs.limbs[i], borrow);
             out_limbs[i] = diff;
@@ -536,7 +540,7 @@ where
         (
             HeaplessBigInt {
                 limbs: out_limbs,
-                len: CAP as u16,
+                len: out_len as u16,
                 _p: PhantomData,
             },
             borrow,

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -11,8 +11,8 @@
 use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
-    BorrowingSub, CarryingAdd, CarryingMul, Nct, OverflowingAdd, OverflowingSub, Personality,
-    PersonalityTag, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    BorrowingSub, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, Nct, OverflowingAdd,
+    OverflowingSub, Personality, PersonalityTag, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use core::marker::PhantomData;
 
@@ -225,6 +225,35 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
                 if overflow { None } else { Some(res) }
             }
         }
+    }
+}
+
+// ── const_num_traits CheckedAdd / CheckedMul (Nct only) ──
+//
+// The trait forms modmath's variable-time inv binds on. Nct-only: the
+// value-aware `checked_mul` (returns `Some` when the true product fits
+// even though the accumulated `len` shape overruns CAP) is an
+// NCT-implicit content scan, so exposing it through a trait is sound
+// only on the Nct carrier. `HeaplessBigInt: Copy`, so bridging the
+// by-value trait receiver to the by-reference inherent method is free.
+
+impl<T, const CAP: usize> CheckedAdd for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = Self;
+    fn checked_add(self, v: Self) -> Option<Self> {
+        Self::checked_add(&self, &v)
+    }
+}
+
+impl<T, const CAP: usize> CheckedMul for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn checked_mul(self, v: Self) -> Option<Self> {
+        Self::checked_mul(&self, &v)
     }
 }
 

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -552,21 +552,21 @@ where
 
 // ── CarryingMul at the bigint level ──
 //
-// `(lo, hi) = self * rhs + carry (+ add)`, split at the carrier's fixed
-// width `CAP`: `lo` = low CAP words, `hi` = high CAP words. This is the
-// `WideMul` contract — it must behave like `FixedUInt<T, CAP>`, whose
-// double-width product splits at `N`, because modmath's wide-REDC
-// reconstructs `full = hi·2^(CAP·word_bits) + lo` against the *carrier*
-// width, not the operands' runtime width. Unlike the value-arithmetic
-// ops, a widening multiply is intrinsically defined over the carrier's
-// fixed width, so `CAP` legitimately appears here (the same boundary
-// `ToBytes`'s owned holder uses). Splitting at `max(operand len)`
-// instead — the earlier mistake — diverges from `FixedUInt` for
-// sub-width operands (e.g. `38 * 38` in Curve25519's `r2_mod_n` setup)
-// and misplaces `hi` in the REDC.
+// `(lo, hi) = self * rhs + carry (+ add)`, split at the operands' VALUE
+// width `W = max(len)` words: `lo` = low W words, `hi` = high W words,
+// reconstructing as `full = hi·2^(W·word_bits) + lo`. This matches
+// `bits_precision()` (= `len·word_bits`) and the primitive contract
+// (`200u8.wide_mul(200) = (64, 156)` splits at the type width) — and it
+// is what modmath's wide-REDC reads back, since it reconstructs against
+// the operand's `bits_precision`, not the carrier's capacity.
 //
-// Iterates the full `CAP` (not runtime len): matches `FixedUInt` and is
-// constant-time (fixed loop count) on the Ct carrier.
+// NOT `CAP`: for a sub-capacity field (`len < CAP`) — rsa with a modulus
+// narrower than the carrier — a CAP split would strand the high half in
+// `lo` (`hi = 0`) and the REDC would be off by limbs. `CAP` is invisible
+// here just like every other value-width op; the only fixed-width use of
+// capacity is `ToBytes`'s owned holder. (For a full-width field,
+// `len == CAP`, so the two coincide — which is why ed25519 was
+// insensitive to this and RSA is not.)
 
 impl<T, const CAP: usize, P: Personality> CarryingMul for HeaplessBigInt<T, CAP, P>
 where
@@ -581,51 +581,66 @@ where
     }
 
     fn carrying_mul_add(self, rhs: Self, carry: Self, add: Self) -> (Self::Unsigned, Self::Output) {
+        // Split point W = the operands' value width. `carry`/`add` are
+        // added into the low half, so W must also cover them.
+        let w = core::cmp::max(
+            core::cmp::max(self.len as usize, rhs.len as usize),
+            core::cmp::max(carry.len as usize, add.len as usize),
+        );
         let mut lo_limbs = [zero::<T>(); CAP];
         let mut hi_limbs = [zero::<T>(); CAP];
 
-        // Schoolbook self * rhs into positions [0, 2·CAP): pos < CAP → lo,
-        // else hi[pos - CAP].
+        // Schoolbook self * rhs into positions [0, 2W): pos < W → lo,
+        // else hi[pos - W]. Iterate the operands' word counts (public
+        // shape), not the array capacity.
+        let a_n = self.len as usize;
+        let b_n = rhs.len as usize;
         let mut i = 0;
-        while i < CAP {
+        while i < a_n {
             let mut c = zero::<T>();
             let mut j = 0;
-            while j < CAP {
+            while j < b_n {
                 let pos = i + j;
                 let (t_lo, t_hi) = <T as CarryingMul>::carrying_mul(self.limbs[i], rhs.limbs[j], c);
-                let existing = if pos < CAP {
+                let existing = if pos < w {
                     lo_limbs[pos]
                 } else {
-                    hi_limbs[pos - CAP]
+                    hi_limbs[pos - w]
                 };
                 let (sum, c1) = <T as CarryingAdd>::carrying_add(existing, t_lo, false);
-                if pos < CAP {
+                if pos < w {
                     lo_limbs[pos] = sum;
                 } else {
-                    hi_limbs[pos - CAP] = sum;
+                    hi_limbs[pos - w] = sum;
                 }
                 let (new_c, _) = <T as CarryingAdd>::carrying_add(t_hi, zero::<T>(), c1);
                 c = new_c;
                 j += 1;
             }
-            // Row-final carry lands at column i + CAP → hi[i].
-            let (sum, _) = <T as CarryingAdd>::carrying_add(hi_limbs[i], c, false);
-            hi_limbs[i] = sum;
+            // Row-final carry at column i + b_n.
+            let tail = i + b_n;
+            if tail < w {
+                let (sum, _) = <T as CarryingAdd>::carrying_add(lo_limbs[tail], c, false);
+                lo_limbs[tail] = sum;
+            } else {
+                let (sum, _) = <T as CarryingAdd>::carrying_add(hi_limbs[tail - w], c, false);
+                hi_limbs[tail - w] = sum;
+            }
             i += 1;
         }
 
-        // Fold carry, then add, into the low half [0, CAP); overflow into hi.
+        // Fold carry, then add, into the low half [0, W); overflow into hi.
         for src in [&carry, &add] {
             let mut cin = false;
             let mut i = 0;
-            while i < CAP {
+            while i < w {
                 let (sum, c) = <T as CarryingAdd>::carrying_add(lo_limbs[i], src.limbs[i], cin);
                 lo_limbs[i] = sum;
                 cin = c;
                 i += 1;
             }
             let mut i = 0;
-            while cin && i < CAP {
+            while cin && i < w {
                 let (sum, c) = <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
                 hi_limbs[i] = sum;
                 cin = c;
@@ -635,12 +650,12 @@ where
 
         let lo = HeaplessBigInt {
             limbs: lo_limbs,
-            len: CAP as u16,
+            len: w as u16,
             _p: PhantomData,
         };
         let hi = HeaplessBigInt {
             limbs: hi_limbs,
-            len: CAP as u16,
+            len: w as u16,
             _p: PhantomData,
         };
         (lo, hi)

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -235,6 +235,92 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     }
 }
 
+// Value + mixed-receiver variants — modmath's EEA `Signed<T>` arithmetic
+// wants owned-owned `+`/`-`/`*`, owned-ref `*`, and ref-owned `-`. Each
+// delegates to the `&Self op &Self` variant. `HeaplessBigInt: Copy` so
+// forwarding by-value operands to references is a no-op at runtime.
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Add
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        (&self).add(&other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Add<&HeaplessBigInt<T, CAP, P>>
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn add(self, other: &Self) -> Self {
+        (&self).add(other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Add<HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn add(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        self.add(&other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Sub
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        (&self).sub(&other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Sub<&HeaplessBigInt<T, CAP, P>>
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn sub(self, other: &Self) -> Self {
+        (&self).sub(other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Sub<HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn sub(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        self.sub(&other)
+    }
+}
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
+    core::ops::Mul for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn mul(self, other: Self) -> Self {
+        (&self).mul(&other)
+    }
+}
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
+    core::ops::Mul<&HeaplessBigInt<T, CAP, P>> for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn mul(self, other: &Self) -> Self {
+        (&self).mul(other)
+    }
+}
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
+    core::ops::Mul<HeaplessBigInt<T, CAP, P>> for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn mul(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        self.mul(&other)
+    }
+}
+
 // ── const_num_traits Wrapping / Overflowing Add & Sub ──
 //
 // Delegate to the inherent methods; the traits take `self` by value,

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -42,15 +42,16 @@ fn panic_on_overflow_if_nct<P: Personality>(overflow: bool, msg: &'static str) {
 /// `out[..n] = a[..n] + b[..n]`, returning the final carry-out.
 /// All three slices must have length ≥ `n`. `a` / `b` beyond their
 /// respective logical `len`s must be zero (zero-tail invariant).
+///
+/// Slicing to `..n` up front bounds-checks once; the zip loop then has no
+/// per-element indexing, so the body is panic-free.
 #[inline]
 pub(crate) fn add_slice<T: MachineWord>(a: &[T], b: &[T], out: &mut [T], n: usize) -> bool {
     let mut carry = false;
-    let mut i = 0;
-    while i < n {
-        let (sum, c) = <T as CarryingAdd>::carrying_add(a[i], b[i], carry);
-        out[i] = sum;
+    for ((&ai, &bi), oi) in a[..n].iter().zip(&b[..n]).zip(&mut out[..n]) {
+        let (sum, c) = <T as CarryingAdd>::carrying_add(ai, bi, carry);
+        *oi = sum;
         carry = c;
-        i += 1;
     }
     carry
 }
@@ -60,12 +61,10 @@ pub(crate) fn add_slice<T: MachineWord>(a: &[T], b: &[T], out: &mut [T], n: usiz
 #[inline]
 pub(crate) fn sub_slice<T: MachineWord>(a: &[T], b: &[T], out: &mut [T], n: usize) -> bool {
     let mut borrow = false;
-    let mut i = 0;
-    while i < n {
-        let (diff, br) = <T as BorrowingSub>::borrowing_sub(a[i], b[i], borrow);
-        out[i] = diff;
+    for ((&ai, &bi), oi) in a[..n].iter().zip(&b[..n]).zip(&mut out[..n]) {
+        let (diff, br) = <T as BorrowingSub>::borrowing_sub(ai, bi, borrow);
+        *oi = diff;
         borrow = br;
-        i += 1;
     }
     borrow
 }
@@ -88,6 +87,12 @@ pub(crate) fn mul_slice<T: MachineWord + CarryingMul<Unsigned = T, Output = T>>(
     out: &mut [T],
     out_n: usize,
 ) {
+    // Slice to the logical lengths up front: the `a[i]` / `b[j]` reads and
+    // the `out[pos]` writes are then provably in bounds, so LLVM drops the
+    // per-access bounds checks from the hot nested loop.
+    let a = &a[..a_n];
+    let b = &b[..b_n];
+    let out = &mut out[..out_n];
     let mut i = 0;
     while i < a_n {
         let mut carry = zero::<T>();

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -11,8 +11,8 @@
 use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
-    BorrowingSub, CarryingAdd, CarryingMul, OverflowingAdd, OverflowingSub, Personality,
-    WrappingAdd, WrappingMul, WrappingSub,
+    BorrowingSub, CarryingAdd, CarryingMul, Nct, OverflowingAdd, OverflowingSub, Personality,
+    PersonalityTag, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use core::marker::PhantomData;
 
@@ -194,10 +194,69 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
         (out, overflow)
     }
 
-    /// Checked multiplication. `None` on overflow.
+    /// Checked multiplication. `None` when the true product does not
+    /// fit in `CAP` limbs.
+    ///
+    /// **Nct**: value-aware. Computes the full 2·CAP-limb product via
+    /// [`CarryingMul`] and reports overflow iff the high half is
+    /// non-zero. Chained muls whose accumulated `len` sums exceed
+    /// `CAP` but whose true value still fits (a common pattern in EEA
+    /// intermediates) return `Some(product)` here; `overflowing_mul`'s
+    /// shape-based check would falsely reject them. The returned
+    /// value has its `len` trimmed to the highest non-zero limb — an
+    /// NCT-implicit content scan, sound because Nct.
+    ///
+    /// **Ct**: shape-based (`self.len + other.len > CAP` → `None`).
+    /// Ct callers who need a value-derived answer are asking for a
+    /// content-derived shape, which the spec forbids.
     pub fn checked_mul(&self, other: &Self) -> Option<Self> {
-        let (res, overflow) = self.overflowing_mul(other);
-        if overflow { None } else { Some(res) }
+        match P::TAG {
+            PersonalityTag::Nct => {
+                let zero_v = <Self as Zero>::zero();
+                let (lo, hi) = <Self as CarryingMul>::carrying_mul(*self, *other, zero_v);
+                if <Self as Zero>::is_zero(&hi) {
+                    Some(trim_content(lo))
+                } else {
+                    None
+                }
+            }
+            PersonalityTag::Ct => {
+                let (res, overflow) = self.overflowing_mul(other);
+                if overflow { None } else { Some(res) }
+            }
+        }
+    }
+}
+
+// Trim trailing-zero limbs — NCT-implicit content scan sets `len` to
+// `1 + index of highest non-zero limb` (or 0 for the mathematical zero).
+// Called only from Nct code paths; exposed as a public method on the
+// Nct-only impl block below.
+fn trim_content<T: MachineWord, const CAP: usize, P: Personality>(
+    mut v: HeaplessBigInt<T, CAP, P>,
+) -> HeaplessBigInt<T, CAP, P> {
+    let mut new_len: u16 = 0;
+    let mut i = 0;
+    while i < CAP {
+        if !is_zero(&v.limbs[i]) {
+            new_len = (i + 1) as u16;
+        }
+        i += 1;
+    }
+    v.len = new_len;
+    v
+}
+
+// Nct-only public trim: normalises `len` to match the actual value.
+// Reasonable to call on any Nct-shape output whose `len` was inflated
+// by upstream shape arithmetic (chained mul, add-with-CAP-headroom).
+
+impl<T: MachineWord, const CAP: usize> HeaplessBigInt<T, CAP, Nct> {
+    /// Trim `len` down to the highest non-zero limb + 1 (0 for zero).
+    /// NCT-implicit — inspects limb content, so Nct-only.
+    #[inline]
+    pub fn trim(self) -> Self {
+        trim_content(self)
     }
 }
 

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -552,14 +552,21 @@ where
 
 // ── CarryingMul at the bigint level ──
 //
-// `(lo, hi) = self * rhs + carry (+ add)`. The split between `lo` and
-// `hi` is the operands' **width** `W = max(len)` words — the
-// `R = 2^(W·word_bits)` boundary modmath's `WideMul`/wide-REDC
-// reconstructs against (`full = hi·2^(W·word_bits) + lo`), matching the
-// primitive contract (`200u8 * 200 → (64, 156)`, split at 8 bits). Both
-// halves get `len = W`; `CAP` (capacity) never enters — splitting there
-// would misalign the REDC. `W` also covers `carry`/`add`, which the
-// primitive contract keeps below one register (`< 2^W`).
+// `(lo, hi) = self * rhs + carry (+ add)`, split at the carrier's fixed
+// width `CAP`: `lo` = low CAP words, `hi` = high CAP words. This is the
+// `WideMul` contract — it must behave like `FixedUInt<T, CAP>`, whose
+// double-width product splits at `N`, because modmath's wide-REDC
+// reconstructs `full = hi·2^(CAP·word_bits) + lo` against the *carrier*
+// width, not the operands' runtime width. Unlike the value-arithmetic
+// ops, a widening multiply is intrinsically defined over the carrier's
+// fixed width, so `CAP` legitimately appears here (the same boundary
+// `ToBytes`'s owned holder uses). Splitting at `max(operand len)`
+// instead — the earlier mistake — diverges from `FixedUInt` for
+// sub-width operands (e.g. `38 * 38` in Curve25519's `r2_mod_n` setup)
+// and misplaces `hi` in the REDC.
+//
+// Iterates the full `CAP` (not runtime len): matches `FixedUInt` and is
+// constant-time (fixed loop count) on the Ct carrier.
 
 impl<T, const CAP: usize, P: Personality> CarryingMul for HeaplessBigInt<T, CAP, P>
 where
@@ -574,64 +581,51 @@ where
     }
 
     fn carrying_mul_add(self, rhs: Self, carry: Self, add: Self) -> (Self::Unsigned, Self::Output) {
-        let w = core::cmp::max(
-            core::cmp::max(self.len as usize, rhs.len as usize),
-            core::cmp::max(carry.len as usize, add.len as usize),
-        );
         let mut lo_limbs = [zero::<T>(); CAP];
         let mut hi_limbs = [zero::<T>(); CAP];
 
-        // Schoolbook self * rhs into positions [0, 2W): pos < W → lo,
-        // else hi[pos - W]. Iterate the operands' word counts (public
-        // shape), not the array capacity.
-        let a_n = self.len as usize;
-        let b_n = rhs.len as usize;
+        // Schoolbook self * rhs into positions [0, 2·CAP): pos < CAP → lo,
+        // else hi[pos - CAP].
         let mut i = 0;
-        while i < a_n {
+        while i < CAP {
             let mut c = zero::<T>();
             let mut j = 0;
-            while j < b_n {
+            while j < CAP {
                 let pos = i + j;
                 let (t_lo, t_hi) = <T as CarryingMul>::carrying_mul(self.limbs[i], rhs.limbs[j], c);
-                let existing = if pos < w {
+                let existing = if pos < CAP {
                     lo_limbs[pos]
                 } else {
-                    hi_limbs[pos - w]
+                    hi_limbs[pos - CAP]
                 };
                 let (sum, c1) = <T as CarryingAdd>::carrying_add(existing, t_lo, false);
-                if pos < w {
+                if pos < CAP {
                     lo_limbs[pos] = sum;
                 } else {
-                    hi_limbs[pos - w] = sum;
+                    hi_limbs[pos - CAP] = sum;
                 }
                 let (new_c, _) = <T as CarryingAdd>::carrying_add(t_hi, zero::<T>(), c1);
                 c = new_c;
                 j += 1;
             }
-            // Row-final carry at column i + b_n.
-            let tail = i + b_n;
-            if tail < w {
-                let (sum, _) = <T as CarryingAdd>::carrying_add(lo_limbs[tail], c, false);
-                lo_limbs[tail] = sum;
-            } else {
-                let (sum, _) = <T as CarryingAdd>::carrying_add(hi_limbs[tail - w], c, false);
-                hi_limbs[tail - w] = sum;
-            }
+            // Row-final carry lands at column i + CAP → hi[i].
+            let (sum, _) = <T as CarryingAdd>::carrying_add(hi_limbs[i], c, false);
+            hi_limbs[i] = sum;
             i += 1;
         }
 
-        // Fold carry, then add, into the low half [0, W); overflow into hi.
+        // Fold carry, then add, into the low half [0, CAP); overflow into hi.
         for src in [&carry, &add] {
             let mut cin = false;
             let mut i = 0;
-            while i < w {
+            while i < CAP {
                 let (sum, c) = <T as CarryingAdd>::carrying_add(lo_limbs[i], src.limbs[i], cin);
                 lo_limbs[i] = sum;
                 cin = c;
                 i += 1;
             }
             let mut i = 0;
-            while cin && i < w {
+            while cin && i < CAP {
                 let (sum, c) = <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
                 hi_limbs[i] = sum;
                 cin = c;
@@ -641,12 +635,12 @@ where
 
         let lo = HeaplessBigInt {
             limbs: lo_limbs,
-            len: w as u16,
+            len: CAP as u16,
             _p: PhantomData,
         };
         let hi = HeaplessBigInt {
             limbs: hi_limbs,
-            len: w as u16,
+            len: CAP as u16,
             _p: PhantomData,
         };
         (lo, hi)

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -127,21 +127,26 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         if overflow { None } else { Some(res) }
     }
 
-    /// Wrapping subtraction. Output `len = max(a.len, b.len)`.
-    /// If `self < other`, the value wraps modulo `2^(len * WORD_BITS)`.
+    /// Wrapping subtraction. On underflow the value wraps modulo
+    /// `2^(CAP * WORD_BITS)` — the full container width, matching
+    /// `FixedUInt<T, CAP>`. Iterating the full `CAP` (rather than
+    /// `max(a.len, b.len)`) makes the result a function of the operand
+    /// *values*, not how their `len` was carried: `wrapping_sub(5, 7)`
+    /// is the same whether 5 and 7 are held at len 1 or len CAP. Output
+    /// `len = CAP`.
     pub fn wrapping_sub(&self, other: &Self) -> Self {
-        let out_len = core::cmp::max(self.len as usize, other.len as usize);
-        let mut out = Self::new_zero_with_len(out_len as u16);
-        let _borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
-        debug_assert!(zero_tail_ok(&out.limbs, out_len));
+        let mut out = Self::new_zero_with_len(CAP as u16);
+        let _borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, CAP);
         out
     }
 
     /// Overflowing subtraction. Returns `(wrapped_result, borrow_out)`.
+    /// `borrow_out` is the true underflow flag (`self < other`); the
+    /// wrapped value is the CAP-width two's complement — see
+    /// [`wrapping_sub`](Self::wrapping_sub) on the width choice.
     pub fn overflowing_sub(&self, other: &Self) -> (Self, bool) {
-        let out_len = core::cmp::max(self.len as usize, other.len as usize);
-        let mut out = Self::new_zero_with_len(out_len as u16);
-        let borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
+        let mut out = Self::new_zero_with_len(CAP as u16);
+        let borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, CAP);
         (out, borrow)
     }
 

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -271,9 +271,11 @@ where
 fn trim_content<T: MachineWord, const CAP: usize, P: Personality>(
     mut v: HeaplessBigInt<T, CAP, P>,
 ) -> HeaplessBigInt<T, CAP, P> {
+    // Scan the value's own words (0..len); the zero-tail invariant means
+    // limbs beyond len are already zero, so CAP need not appear.
     let mut new_len: u16 = 0;
     let mut i = 0;
-    while i < CAP {
+    while i < v.len as usize {
         if !is_zero(&v.limbs[i]) {
             new_len = (i + 1) as u16;
         }
@@ -550,14 +552,14 @@ where
 
 // ── CarryingMul at the bigint level ──
 //
-// `(lo, hi) = self * rhs + carry`, splitting the 2·CAP-limb natural
-// product across two CAP-wide halves. Modmath's `WideMul` blanket
-// impl fires from this, unlocking the Montgomery driver.
-//
-// Both output halves get `len = CAP` — a public shape derived from the
-// type parameter, not from operand content. The full-CAP iteration
-// discipline is deliberate: widening semantics require the whole array
-// range, not the runtime-len subset.
+// `(lo, hi) = self * rhs + carry (+ add)`. The split between `lo` and
+// `hi` is the operands' **width** `W = max(len)` words — the
+// `R = 2^(W·word_bits)` boundary modmath's `WideMul`/wide-REDC
+// reconstructs against (`full = hi·2^(W·word_bits) + lo`), matching the
+// primitive contract (`200u8 * 200 → (64, 156)`, split at 8 bits). Both
+// halves get `len = W`; `CAP` (capacity) never enters — splitting there
+// would misalign the REDC. `W` also covers `carry`/`add`, which the
+// primitive contract keeps below one register (`< 2^W`).
 
 impl<T, const CAP: usize, P: Personality> CarryingMul for HeaplessBigInt<T, CAP, P>
 where
@@ -572,79 +574,79 @@ where
     }
 
     fn carrying_mul_add(self, rhs: Self, carry: Self, add: Self) -> (Self::Unsigned, Self::Output) {
+        let w = core::cmp::max(
+            core::cmp::max(self.len as usize, rhs.len as usize),
+            core::cmp::max(carry.len as usize, add.len as usize),
+        );
         let mut lo_limbs = [zero::<T>(); CAP];
         let mut hi_limbs = [zero::<T>(); CAP];
 
-        // Schoolbook self * rhs accumulating into positions [0, 2·CAP).
+        // Schoolbook self * rhs into positions [0, 2W): pos < W → lo,
+        // else hi[pos - W]. Iterate the operands' word counts (public
+        // shape), not the array capacity.
+        let a_n = self.len as usize;
+        let b_n = rhs.len as usize;
         let mut i = 0;
-        while i < CAP {
+        while i < a_n {
             let mut c = zero::<T>();
             let mut j = 0;
-            while j < CAP {
+            while j < b_n {
                 let pos = i + j;
                 let (t_lo, t_hi) = <T as CarryingMul>::carrying_mul(self.limbs[i], rhs.limbs[j], c);
-                let existing = if pos < CAP {
+                let existing = if pos < w {
                     lo_limbs[pos]
                 } else {
-                    hi_limbs[pos - CAP]
+                    hi_limbs[pos - w]
                 };
                 let (sum, c1) = <T as CarryingAdd>::carrying_add(existing, t_lo, false);
-                if pos < CAP {
+                if pos < w {
                     lo_limbs[pos] = sum;
                 } else {
-                    hi_limbs[pos - CAP] = sum;
+                    hi_limbs[pos - w] = sum;
                 }
                 let (new_c, _) = <T as CarryingAdd>::carrying_add(t_hi, zero::<T>(), c1);
                 c = new_c;
                 j += 1;
             }
-            let (sum, _) = <T as CarryingAdd>::carrying_add(hi_limbs[i], c, false);
-            hi_limbs[i] = sum;
+            // Row-final carry at column i + b_n.
+            let tail = i + b_n;
+            if tail < w {
+                let (sum, _) = <T as CarryingAdd>::carrying_add(lo_limbs[tail], c, false);
+                lo_limbs[tail] = sum;
+            } else {
+                let (sum, _) = <T as CarryingAdd>::carrying_add(hi_limbs[tail - w], c, false);
+                hi_limbs[tail - w] = sum;
+            }
             i += 1;
         }
 
-        // Fold `carry` into the low half, propagating overflow into hi.
-        let mut cin = false;
-        let mut i = 0;
-        while i < CAP {
-            let (sum, c) = <T as CarryingAdd>::carrying_add(lo_limbs[i], carry.limbs[i], cin);
-            lo_limbs[i] = sum;
-            cin = c;
-            i += 1;
-        }
-        let mut i = 0;
-        while cin && i < CAP {
-            let (sum, c) = <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
-            hi_limbs[i] = sum;
-            cin = c;
-            i += 1;
-        }
-
-        // Fold `add` into the low half the same way.
-        let mut cin = false;
-        let mut i = 0;
-        while i < CAP {
-            let (sum, c) = <T as CarryingAdd>::carrying_add(lo_limbs[i], add.limbs[i], cin);
-            lo_limbs[i] = sum;
-            cin = c;
-            i += 1;
-        }
-        let mut i = 0;
-        while cin && i < CAP {
-            let (sum, c) = <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
-            hi_limbs[i] = sum;
-            cin = c;
-            i += 1;
+        // Fold carry, then add, into the low half [0, W); overflow into hi.
+        for src in [&carry, &add] {
+            let mut cin = false;
+            let mut i = 0;
+            while i < w {
+                let (sum, c) = <T as CarryingAdd>::carrying_add(lo_limbs[i], src.limbs[i], cin);
+                lo_limbs[i] = sum;
+                cin = c;
+                i += 1;
+            }
+            let mut i = 0;
+            while cin && i < w {
+                let (sum, c) = <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
+                hi_limbs[i] = sum;
+                cin = c;
+                i += 1;
+            }
         }
 
         let lo = HeaplessBigInt {
             limbs: lo_limbs,
-            len: CAP as u16,
+            len: w as u16,
             _p: PhantomData,
         };
         let hi = HeaplessBigInt {
             limbs: hi_limbs,
-            len: CAP as u16,
+            len: w as u16,
             _p: PhantomData,
         };
         (lo, hi)

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -12,8 +12,9 @@ use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
     BorrowingSub, CarryingAdd, CarryingMul, OverflowingAdd, OverflowingSub, Personality,
-    WrappingAdd, WrappingSub,
+    WrappingAdd, WrappingMul, WrappingSub,
 };
+use core::marker::PhantomData;
 
 // ── Free-function slice kernels ──
 //
@@ -391,6 +392,165 @@ impl<T: MachineWord, const CAP: usize, P: Personality> OverflowingSub
     type Output = HeaplessBigInt<T, CAP, P>;
     fn overflowing_sub(self, v: Self) -> (Self::Output, bool) {
         HeaplessBigInt::overflowing_sub(self, v)
+    }
+}
+
+// WrappingMul — the explicit method modmath's EEA should call instead
+// of `core::ops::Mul`, which has no defined overflow contract.
+
+impl<T, const CAP: usize, P: Personality> WrappingMul for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn wrapping_mul(self, v: Self) -> Self::Output {
+        Self::wrapping_mul(&self, &v)
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> WrappingMul for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn wrapping_mul(self, v: Self) -> Self::Output {
+        HeaplessBigInt::wrapping_mul(self, v)
+    }
+}
+
+// ── BorrowingSub at the bigint level ──
+//
+// Full-CAP `self - rhs - borrow_in` with borrow_out. Iteration is
+// 0..CAP (not `self.len`) because widening-primitive semantics require
+// the whole array range. Modmath's full CIOS driver fires from this.
+
+impl<T, const CAP: usize, P: Personality> BorrowingSub for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    type Output = Self;
+    fn borrowing_sub(self, rhs: Self, borrow_in: bool) -> (Self::Output, bool) {
+        let mut out_limbs = [zero::<T>(); CAP];
+        let mut borrow = borrow_in;
+        let mut i = 0;
+        while i < CAP {
+            let (diff, br) =
+                <T as BorrowingSub>::borrowing_sub(self.limbs[i], rhs.limbs[i], borrow);
+            out_limbs[i] = diff;
+            borrow = br;
+            i += 1;
+        }
+        (
+            HeaplessBigInt {
+                limbs: out_limbs,
+                len: CAP as u16,
+                _p: PhantomData,
+            },
+            borrow,
+        )
+    }
+}
+
+// ── CarryingMul at the bigint level ──
+//
+// `(lo, hi) = self * rhs + carry`, splitting the 2·CAP-limb natural
+// product across two CAP-wide halves. Modmath's `WideMul` blanket
+// impl fires from this, unlocking the Montgomery driver.
+//
+// Both output halves get `len = CAP` — a public shape derived from the
+// type parameter, not from operand content. The full-CAP iteration
+// discipline is deliberate: widening semantics require the whole array
+// range, not the runtime-len subset.
+
+impl<T, const CAP: usize, P: Personality> CarryingMul for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Unsigned = Self;
+    type Output = Self;
+
+    fn carrying_mul(self, rhs: Self, carry: Self) -> (Self::Unsigned, Self::Output) {
+        let zero_v = <Self as const_num_traits::Zero>::zero();
+        self.carrying_mul_add(rhs, carry, zero_v)
+    }
+
+    fn carrying_mul_add(self, rhs: Self, carry: Self, add: Self) -> (Self::Unsigned, Self::Output) {
+        let mut lo_limbs = [zero::<T>(); CAP];
+        let mut hi_limbs = [zero::<T>(); CAP];
+
+        // Schoolbook self * rhs accumulating into positions [0, 2·CAP).
+        let mut i = 0;
+        while i < CAP {
+            let mut c = zero::<T>();
+            let mut j = 0;
+            while j < CAP {
+                let pos = i + j;
+                let (t_lo, t_hi) = <T as CarryingMul>::carrying_mul(self.limbs[i], rhs.limbs[j], c);
+                let existing = if pos < CAP {
+                    lo_limbs[pos]
+                } else {
+                    hi_limbs[pos - CAP]
+                };
+                let (sum, c1) = <T as CarryingAdd>::carrying_add(existing, t_lo, false);
+                if pos < CAP {
+                    lo_limbs[pos] = sum;
+                } else {
+                    hi_limbs[pos - CAP] = sum;
+                }
+                let (new_c, _) = <T as CarryingAdd>::carrying_add(t_hi, zero::<T>(), c1);
+                c = new_c;
+                j += 1;
+            }
+            let (sum, _) = <T as CarryingAdd>::carrying_add(hi_limbs[i], c, false);
+            hi_limbs[i] = sum;
+            i += 1;
+        }
+
+        // Fold `carry` into the low half, propagating overflow into hi.
+        let mut cin = false;
+        let mut i = 0;
+        while i < CAP {
+            let (sum, c) = <T as CarryingAdd>::carrying_add(lo_limbs[i], carry.limbs[i], cin);
+            lo_limbs[i] = sum;
+            cin = c;
+            i += 1;
+        }
+        let mut i = 0;
+        while cin && i < CAP {
+            let (sum, c) = <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
+            hi_limbs[i] = sum;
+            cin = c;
+            i += 1;
+        }
+
+        // Fold `add` into the low half the same way.
+        let mut cin = false;
+        let mut i = 0;
+        while i < CAP {
+            let (sum, c) = <T as CarryingAdd>::carrying_add(lo_limbs[i], add.limbs[i], cin);
+            lo_limbs[i] = sum;
+            cin = c;
+            i += 1;
+        }
+        let mut i = 0;
+        while cin && i < CAP {
+            let (sum, c) = <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
+            hi_limbs[i] = sum;
+            cin = c;
+            i += 1;
+        }
+
+        let lo = HeaplessBigInt {
+            limbs: lo_limbs,
+            len: CAP as u16,
+            _p: PhantomData,
+        };
+        let hi = HeaplessBigInt {
+            limbs: hi_limbs,
+            len: CAP as u16,
+            _p: PhantomData,
+        };
+        (lo, hi)
     }
 }
 

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -101,11 +101,8 @@ pub(crate) fn mul_slice<T: MachineWord + CarryingMul<Unsigned = T, Output = T>>(
 // ── Inherent methods on HeaplessBigInt ──
 
 impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
-    /// Wrapping addition, at the operands' width `max(a.len, b.len)`.
-    /// A carry out of that width is discarded — `HeaplessBigInt` carried
-    /// at `len = k` is a `k`-word integer that behaves exactly like
-    /// `FixedUInt<T, k>`; the capacity beyond `len` does not exist as far
-    /// as arithmetic is concerned. `CAP` never enters.
+    /// Wrapping addition at the operands' width `max(a.len, b.len)`; a
+    /// carry out of that width is discarded.
     pub fn wrapping_add(&self, other: &Self) -> Self {
         let out_len = core::cmp::max(self.len as usize, other.len as usize);
         let mut out = Self::new_zero_with_len(out_len as u16);
@@ -132,13 +129,9 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         if overflow { None } else { Some(res) }
     }
 
-    /// Wrapping subtraction. Output `len = max(a.len, b.len)` — the
-    /// operands' width, per the bit-vocabulary model where a
-    /// `HeaplessBigInt`'s width is `len·word_bits`, not `CAP`. On
-    /// underflow the value wraps modulo `2^(max_len·WORD_BITS)`: a
-    /// value carried at a narrower width wraps at that narrower width
-    /// (like `u8` vs `u32`), which is the point of the variable-width
-    /// carrier — `CAP` never enters.
+    /// Wrapping subtraction at the operands' width `max(a.len, b.len)`;
+    /// underflow wraps modulo `2^(max_len·WORD_BITS)`, so a value carried
+    /// at a narrower width wraps at that narrower width (like `u8` vs `u32`).
     pub fn wrapping_sub(&self, other: &Self) -> Self {
         let out_len = core::cmp::max(self.len as usize, other.len as usize);
         let mut out = Self::new_zero_with_len(out_len as u16);
@@ -170,11 +163,10 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
 impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
     HeaplessBigInt<T, CAP, P>
 {
-    /// Wrapping multiplication, at the operands' width `max(a.len, b.len)`:
+    /// Wrapping multiplication at the operands' width `max(a.len, b.len)`:
     /// keeps the low `width` words (`a·b mod 2^(width·word_bits)`),
-    /// exactly like `FixedUInt<T, width>::wrapping_mul`. The high half of
-    /// the product does not exist as far as this op is concerned — `CAP`
-    /// never enters. `WideMul` is the op that returns both halves.
+    /// exactly like `FixedUInt<T, width>::wrapping_mul`. [`WideMul`] returns
+    /// both halves.
     pub fn wrapping_mul(&self, other: &Self) -> Self {
         let out_len = core::cmp::max(self.len as usize, other.len as usize);
         let mut out = Self::new_zero_with_len(out_len as u16);
@@ -203,10 +195,8 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     }
 
     /// Checked multiplication. `None` when the product does not fit in the
-    /// operands' width `max(a.len, b.len)` — i.e. exactly when
-    /// `FixedUInt<T, width>::checked_mul` would return `None`. `CAP` does
-    /// not enter: the value is a `width`-word integer, and the words it
-    /// does not have do not exist.
+    /// operands' width `max(a.len, b.len)` — exactly when
+    /// `FixedUInt<T, width>::checked_mul` would return `None`.
     pub fn checked_mul(&self, other: &Self) -> Option<Self> {
         let (res, overflow) = self.overflowing_mul(other);
         if overflow { None } else { Some(res) }
@@ -215,12 +205,12 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
 
 // ── const_num_traits CheckedAdd / CheckedMul (Nct only) ──
 //
-// The trait forms modmath's variable-time inv binds on. `checked_add` /
-// `checked_mul` return `None` on overflow at the operands' width, exactly
-// as the same-width `FixedUInt` would — the carrier at `len = k` is a
-// `k`-word integer, no capacity headroom. Trait exposure is kept Nct-only
-// to match the existing surface. `HeaplessBigInt: Copy`, so bridging the
-// by-value trait receiver to the by-reference inherent method is free.
+// The trait forms a downstream variable-time modular-inverse consumer binds
+// on. `checked_add` / `checked_mul` return `None` on overflow at the
+// operands' width, exactly as the same-width `FixedUInt` would. Trait
+// exposure is kept Nct-only to match the existing surface.
+// `HeaplessBigInt: Copy`, so bridging the by-value trait receiver to the
+// by-reference inherent method is free.
 
 impl<T, const CAP: usize> CheckedAdd for HeaplessBigInt<T, CAP, Nct>
 where
@@ -315,10 +305,10 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     }
 }
 
-// Value + mixed-receiver variants — modmath's EEA `Signed<T>` arithmetic
-// wants owned-owned `+`/`-`/`*`, owned-ref `*`, and ref-owned `-`. Each
-// delegates to the `&Self op &Self` variant. `HeaplessBigInt: Copy` so
-// forwarding by-value operands to references is a no-op at runtime.
+// Value + mixed-receiver variants for callers that want by-value operators:
+// owned-owned `+`/`-`/`*`, owned-ref `*`, ref-owned `-`. Each delegates to
+// the `&Self op &Self` variant. `HeaplessBigInt: Copy`, so forwarding
+// by-value operands to references is a no-op at runtime.
 
 impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::Add
     for HeaplessBigInt<T, CAP, P>
@@ -556,9 +546,8 @@ where
 }
 
 // `self - rhs - borrow_in` with borrow_out, over the operands' width
-// (`max(self.len, rhs.len)`), not `CAP` — same width rule as
-// `wrapping_sub`, so underflow wraps at the value's width and `CAP`
-// stays out of the algorithm. Modmath's CIOS driver fires from this.
+// (`max(self.len, rhs.len)`) — same width rule as `wrapping_sub`, so
+// underflow wraps at the value's width. Used by multi-precision reduction.
 
 impl<T, const CAP: usize, P: Personality> BorrowingSub for HeaplessBigInt<T, CAP, P>
 where
@@ -595,16 +584,15 @@ where
 // reconstructing as `full = hi·2^(W·word_bits) + lo`. This matches
 // `bits_precision()` (= `len·word_bits`) and the primitive contract
 // (`200u8.wide_mul(200) = (64, 156)` splits at the type width) — and it
-// is what modmath's wide-REDC reads back, since it reconstructs against
-// the operand's `bits_precision`, not the carrier's capacity.
+// is what a wide Montgomery reduction reads back, since it reconstructs
+// against the operand's `bits_precision`, not the carrier's capacity.
 //
-// NOT `CAP`: for a sub-capacity field (`len < CAP`) — rsa with a modulus
-// narrower than the carrier — a CAP split would strand the high half in
+// NOT `CAP`: for a sub-capacity field (`len < CAP` — e.g. a modulus
+// narrower than the carrier) a CAP split would strand the high half in
 // `lo` (`hi = 0`) and the REDC would be off by limbs. `CAP` is invisible
 // here just like every other value-width op; the only fixed-width use of
-// capacity is `ToBytes`'s owned holder. (For a full-width field,
-// `len == CAP`, so the two coincide — which is why ed25519 was
-// insensitive to this and RSA is not.)
+// capacity is `ToBytes`'s owned holder. (For a full-width field
+// `len == CAP`, so the two coincide.)
 
 impl<T, const CAP: usize, P: Personality> CarryingMul for HeaplessBigInt<T, CAP, P>
 where

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -194,8 +194,8 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     /// `w = max(a.len, b.len)`. Returns `(a·b mod 2^(w·word_bits),
     /// overflow)`, where `overflow` is set iff the product does not fit
     /// in `w` words — bit-identical to `FixedUInt<T, w>::overflowing_mul`.
-    /// The split is at the value width (via [`WideMul`]), so the high
-    /// half is the part beyond `w`; `CAP` is irrelevant.
+    /// The split is at the value width (via the widening [`CarryingMul`]), so
+    /// the high half is the part beyond `w`; `CAP` is irrelevant.
     pub fn overflowing_mul(&self, other: &Self) -> (Self, bool) {
         let zero_v = <Self as const_num_traits::Zero>::zero();
         let (lo, hi) = <Self as CarryingMul>::carrying_mul(*self, *other, zero_v);

--- a/src/heapless/bits.rs
+++ b/src/heapless/bits.rs
@@ -1,8 +1,10 @@
 //! `bit_length` and `leading_zeros` for `HeaplessBigInt`.
 //!
-//! Both are NCT-implicit: they scan limb content to find the highest
-//! non-zero position. Ct callers that need a masked-return counterpart
-//! wire it through a separate primitive.
+//! Both dispatch on `P` like `FixedUInt`: `Nct` scans MSB-to-LSB and
+//! stops at the highest non-zero limb; `Ct` scans the full width with an
+//! `undecided` lock so the loop is value-independent (mirroring
+//! `const_leading_zeros_ct`). The returned count is the magnitude either
+//! way — a caller that must keep the magnitude secret does not call these.
 //!
 //! `bit_length` is the position of the highest set bit plus one, so
 //! `bit_length(0) == 0` and `bit_length(1) == 1`. `leading_zeros` is
@@ -13,34 +15,56 @@
 
 use super::HeaplessBigInt;
 use crate::MachineWord;
-use const_num_traits::Personality;
+use const_num_traits::{Personality, PersonalityTag};
 
 impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
     /// Number of bits needed to represent the value: `0` for zero,
     /// otherwise the position of the highest set bit plus one.
     pub fn bit_length(&self) -> usize {
-        let word_bits = core::mem::size_of::<T>() * 8;
-        // Walk MSB-to-LSB. First non-zero limb determines the answer;
-        // limbs beyond that are zero by the invariant so we don't need
-        // to inspect them.
-        let mut i = self.len as usize;
-        while i > 0 {
-            i -= 1;
-            let limb = self.limbs[i];
-            if !super::is_zero(&limb) {
-                let leading = limb.leading_zeros() as usize;
-                return i * word_bits + (word_bits - leading);
-            }
-        }
-        0
+        let width = self.len as usize * core::mem::size_of::<T>() * 8;
+        width - self.leading_zeros()
     }
 
     /// Leading zeros against the value's width (`len * word_bits`), so
     /// `leading_zeros + bit_length == bits_precision()`. A `len = 0`
     /// value has width 0, hence `leading_zeros() == 0`.
     pub fn leading_zeros(&self) -> usize {
-        let width = self.len as usize * core::mem::size_of::<T>() * 8;
-        width - self.bit_length()
+        let word_bits = core::mem::size_of::<T>() * 8;
+        match P::TAG {
+            // MSB-to-LSB; the first non-zero limb fixes the count and the
+            // invariant guarantees limbs above it are zero. Zero words above
+            // that limb contribute a full `word_bits` each.
+            PersonalityTag::Nct => {
+                let len = self.len as usize;
+                let mut i = len;
+                while i > 0 {
+                    i -= 1;
+                    let limb = self.limbs[i];
+                    if !super::is_zero(&limb) {
+                        return (len - 1 - i) * word_bits + limb.leading_zeros() as usize;
+                    }
+                }
+                len * word_bits
+            }
+            // Full scan: accumulate each limb's leading-zero contribution
+            // until a non-zero limb locks `decided`; later limbs add 0.
+            PersonalityTag::Ct => {
+                let mut total = 0usize;
+                let mut decided = 0usize;
+                let mut i = self.len as usize;
+                while i > 0 {
+                    i -= 1;
+                    let v = self.limbs[i];
+                    let v_lz = v.leading_zeros() as usize;
+                    let undecided = core::hint::black_box(!decided);
+                    total += undecided & v_lz;
+                    let v_nz_mask =
+                        core::hint::black_box(((!super::is_zero(&v)) as usize).wrapping_neg());
+                    decided |= v_nz_mask;
+                }
+                total
+            }
+        }
     }
 }
 

--- a/src/heapless/bits.rs
+++ b/src/heapless/bits.rs
@@ -72,7 +72,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitWidt
 impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitsPrecision
     for HeaplessBigInt<T, CAP, P>
 {
-    fn bits_precision(self) -> u32 {
+    fn bits_precision(&self) -> u32 {
         self.len as u32 * (core::mem::size_of::<T>() as u32 * 8)
     }
 }
@@ -80,7 +80,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitsPre
 impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitsPrecision
     for &HeaplessBigInt<T, CAP, P>
 {
-    fn bits_precision(self) -> u32 {
+    fn bits_precision(&self) -> u32 {
         self.len as u32 * (core::mem::size_of::<T>() as u32 * 8)
     }
 }

--- a/src/heapless/bits.rs
+++ b/src/heapless/bits.rs
@@ -41,3 +41,44 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         total_bits - self.bit_length()
     }
 }
+
+// ── const_num_traits::BitWidth (bit-length) / BitsPrecision (width) ──
+//
+// Two distinct quantities (bit-vocabulary canon): `bit_width` is the
+// significant-bit count (per-value magnitude); `bits_precision` is the
+// operating width, which for this variable-width carrier is the
+// constructed `len·word_bits` — NOT `CAP` (capacity stays out of any
+// trait answer). `bit_length <= bits_precision` always. Value receiver
+// per the traits; `&Self` mirrors (no reference blanket upstream).
+
+impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitWidth
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn bit_width(self) -> u32 {
+        self.bit_length() as u32
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitWidth
+    for &HeaplessBigInt<T, CAP, P>
+{
+    fn bit_width(self) -> u32 {
+        self.bit_length() as u32
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitsPrecision
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn bits_precision(self) -> u32 {
+        self.len as u32 * (core::mem::size_of::<T>() as u32 * 8)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitsPrecision
+    for &HeaplessBigInt<T, CAP, P>
+{
+    fn bits_precision(self) -> u32 {
+        self.len as u32 * (core::mem::size_of::<T>() as u32 * 8)
+    }
+}

--- a/src/heapless/bits.rs
+++ b/src/heapless/bits.rs
@@ -6,9 +6,10 @@
 //!
 //! `bit_length` is the position of the highest set bit plus one, so
 //! `bit_length(0) == 0` and `bit_length(1) == 1`. `leading_zeros` is
-//! taken against `CAP * word_bits` — the full container width, not the
-//! runtime `len` — so it composes cleanly with other bit-width-sized
-//! callers (Barrett reduction start, sliding-window scalar decomposition).
+//! taken against the value's **width** (`len * word_bits`), not capacity
+//! — so `bit_length + leading_zeros == bits_precision()` and `CAP` never
+//! enters. A caller that wants zeros relative to a wider window sizes it
+//! from that window's own `bits_precision`, not this value's capacity.
 
 use super::HeaplessBigInt;
 use crate::MachineWord;
@@ -34,11 +35,12 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         0
     }
 
-    /// Leading zeros against the full container width (`CAP * word_bits`).
-    /// `leading_zeros(0) == CAP * word_bits`.
+    /// Leading zeros against the value's width (`len * word_bits`), so
+    /// `leading_zeros + bit_length == bits_precision()`. A `len = 0`
+    /// value has width 0, hence `leading_zeros() == 0`.
     pub fn leading_zeros(&self) -> usize {
-        let total_bits = CAP * core::mem::size_of::<T>() * 8;
-        total_bits - self.bit_length()
+        let width = self.len as usize * core::mem::size_of::<T>() * 8;
+        width - self.bit_length()
     }
 }
 

--- a/src/heapless/bits.rs
+++ b/src/heapless/bits.rs
@@ -1,0 +1,43 @@
+//! `bit_length` and `leading_zeros` for `HeaplessBigInt`.
+//!
+//! Both are NCT-implicit: they scan limb content to find the highest
+//! non-zero position. Ct callers that need a masked-return counterpart
+//! wire it through a separate primitive.
+//!
+//! `bit_length` is the position of the highest set bit plus one, so
+//! `bit_length(0) == 0` and `bit_length(1) == 1`. `leading_zeros` is
+//! taken against `CAP * word_bits` — the full container width, not the
+//! runtime `len` — so it composes cleanly with other bit-width-sized
+//! callers (Barrett reduction start, sliding-window scalar decomposition).
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::Personality;
+
+impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
+    /// Number of bits needed to represent the value: `0` for zero,
+    /// otherwise the position of the highest set bit plus one.
+    pub fn bit_length(&self) -> usize {
+        let word_bits = core::mem::size_of::<T>() * 8;
+        // Walk MSB-to-LSB. First non-zero limb determines the answer;
+        // limbs beyond that are zero by the invariant so we don't need
+        // to inspect them.
+        let mut i = self.len as usize;
+        while i > 0 {
+            i -= 1;
+            let limb = self.limbs[i];
+            if !super::is_zero(&limb) {
+                let leading = limb.leading_zeros() as usize;
+                return i * word_bits + (word_bits - leading);
+            }
+        }
+        0
+    }
+
+    /// Leading zeros against the full container width (`CAP * word_bits`).
+    /// `leading_zeros(0) == CAP * word_bits`.
+    pub fn leading_zeros(&self) -> usize {
+        let total_bits = CAP * core::mem::size_of::<T>() * 8;
+        total_bits - self.bit_length()
+    }
+}

--- a/src/heapless/bits.rs
+++ b/src/heapless/bits.rs
@@ -84,3 +84,19 @@ impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::BitsPre
         self.len as u32 * (core::mem::size_of::<T>() as u32 * 8)
     }
 }
+
+// Establish a width from a witness. Grow-only, value-preserving: widen `self`
+// to the whole-word length covering `bits_precision` bits, never shrinking.
+// The zero/one/witness constructors (`zero_with_precision_of(&modulus)` etc.)
+// default over this, giving generic reducers a correctly-sized seed instead of
+// the minimal-width `zero()` that silently truncates. `CAP` is the ceiling:
+// `widened` panics if the requested width exceeds it.
+impl<T: MachineWord, const CAP: usize, P: Personality> const_num_traits::WithPrecision
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn widen_to_precision(self, bits_precision: u32) -> Self {
+        let word_bits = core::mem::size_of::<T>() as u32 * 8;
+        let target_len = bits_precision.div_ceil(word_bits) as u16;
+        self.widened(target_len.max(self.len()))
+    }
+}

--- a/src/heapless/bitwise.rs
+++ b/src/heapless/bitwise.rs
@@ -11,7 +11,7 @@
 //! Both lens are public shape parameters, so the body is identical for
 //! Nct and Ct. `BitAnd` serves Montgomery's `from_montgomery` mask;
 //! `BitOr` serves the sign path's blinding-inverse (`InvertCt`).
-//! `BitXor` is still unimplemented — no consumer needs it.
+//! `BitXor` is omitted — no consumer needs it.
 
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;

--- a/src/heapless/bitwise.rs
+++ b/src/heapless/bitwise.rs
@@ -1,0 +1,62 @@
+//! `BitAnd` for `HeaplessBigInt` (all four receiver forms).
+//!
+//! Limb-wise AND. Output `len = min(a.len, b.len)`: for any index at or
+//! above that bound, one operand is in its zero-tail, so the AND is
+//! zero — `min` is both value-tight and satisfies the zero-tail
+//! invariant. Both operand lens are public shape parameters, so `min`
+//! is public; the body is identical for Nct and Ct.
+//!
+//! Used by Montgomery `from_montgomery`'s reduction mask. `BitOr` /
+//! `BitXor` are not implemented — no current consumer needs them.
+
+use super::{HeaplessBigInt, zero};
+use crate::MachineWord;
+use const_num_traits::Personality;
+use core::marker::PhantomData;
+use core::ops::BitAnd;
+
+// Core: `&Self & &Self`. The value + mixed receiver forms delegate here.
+impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd<&HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn bitand(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        let out_len = core::cmp::min(self.len, other.len);
+        let mut limbs = [zero::<T>(); CAP];
+        let mut i = 0;
+        while i < out_len as usize {
+            limbs[i] = self.limbs[i] & other.limbs[i];
+            i += 1;
+        }
+        HeaplessBigInt {
+            limbs,
+            len: out_len,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd for HeaplessBigInt<T, CAP, P> {
+    type Output = Self;
+    fn bitand(self, other: Self) -> Self {
+        (&self).bitand(&other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd<&HeaplessBigInt<T, CAP, P>>
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn bitand(self, other: &Self) -> Self {
+        (&self).bitand(other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd<HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn bitand(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        self.bitand(&other)
+    }
+}

--- a/src/heapless/bitwise.rs
+++ b/src/heapless/bitwise.rs
@@ -1,19 +1,23 @@
-//! `BitAnd` for `HeaplessBigInt` (all four receiver forms).
+//! `BitAnd` / `BitOr` for `HeaplessBigInt` (all four receiver forms each).
 //!
-//! Limb-wise AND. Output `len = min(a.len, b.len)`: for any index at or
-//! above that bound, one operand is in its zero-tail, so the AND is
-//! zero — `min` is both value-tight and satisfies the zero-tail
-//! invariant. Both operand lens are public shape parameters, so `min`
-//! is public; the body is identical for Nct and Ct.
+//! Limb-wise, width-based, `CAP` never enters:
+//! - `BitAnd` → `len = min(a.len, b.len)`: at or above that bound one
+//!   operand is in its zero-tail, so the AND is zero — `min` is
+//!   value-tight and satisfies the zero-tail invariant.
+//! - `BitOr` → `len = max(a.len, b.len)`: OR *sets* bits, so the result
+//!   spans the wider operand; the shorter operand's zero-tail leaves the
+//!   wider operand's limbs unchanged there.
 //!
-//! Used by Montgomery `from_montgomery`'s reduction mask. `BitOr` /
-//! `BitXor` are not implemented — no current consumer needs them.
+//! Both lens are public shape parameters, so the body is identical for
+//! Nct and Ct. `BitAnd` serves Montgomery's `from_montgomery` mask;
+//! `BitOr` serves the sign path's blinding-inverse (`InvertCt`).
+//! `BitXor` is still unimplemented — no consumer needs it.
 
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
 use const_num_traits::Personality;
 use core::marker::PhantomData;
-use core::ops::BitAnd;
+use core::ops::{BitAnd, BitOr};
 
 // Core: `&Self & &Self`. The value + mixed receiver forms delegate here.
 impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd<&HeaplessBigInt<T, CAP, P>>
@@ -58,5 +62,51 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd<HeaplessBigInt<T, 
     type Output = HeaplessBigInt<T, CAP, P>;
     fn bitand(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
         self.bitand(&other)
+    }
+}
+
+// Core: `&Self | &Self`. The value + mixed receiver forms delegate here.
+impl<T: MachineWord, const CAP: usize, P: Personality> BitOr<&HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn bitor(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        let out_len = core::cmp::max(self.len, other.len);
+        let mut limbs = [zero::<T>(); CAP];
+        let mut i = 0;
+        while i < out_len as usize {
+            limbs[i] = self.limbs[i] | other.limbs[i];
+            i += 1;
+        }
+        HeaplessBigInt {
+            limbs,
+            len: out_len,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitOr for HeaplessBigInt<T, CAP, P> {
+    type Output = Self;
+    fn bitor(self, other: Self) -> Self {
+        (&self).bitor(&other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitOr<&HeaplessBigInt<T, CAP, P>>
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn bitor(self, other: &Self) -> Self {
+        (&self).bitor(other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitOr<HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn bitor(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        self.bitor(&other)
     }
 }

--- a/src/heapless/bytes.rs
+++ b/src/heapless/bytes.rs
@@ -1,0 +1,160 @@
+//! Byte serialization for `HeaplessBigInt`.
+//!
+//! The written byte count is `self.len * word_size` — public shape,
+//! derived from the public `len`. Callers own the output buffer; the
+//! methods panic if it is too small (checked at runtime, no `Result`).
+//!
+//! Layout matches `FixedUInt`'s slice-based conventions: BE writes the
+//! high-order word's high byte at index 0, LE writes the low-order
+//! word's low byte at index 0.
+//!
+//! The inner byte-copy is the zip byte-loop landed in fixed-bigint
+//! 0.5.2 — no `copy_from_slice` length assert to fold. Per-word reads
+//! are bit-shifted rather than `T::from_be_bytes`, so `T` needs only
+//! `MachineWord` (not a byte-conversion trait bound).
+
+use super::{HeaplessBigInt, zero};
+use crate::MachineWord;
+use const_num_traits::Personality;
+use core::marker::PhantomData;
+
+// Read up to `bytes.len()` MSB-first bytes into a T, zero-padding on the
+// high side if `bytes.len() < size_of::<T>()`. Skips the shift on the
+// first iteration because `T::BITS`-wide shift is UB — matters at
+// `size_of::<T>() == 1` (u8 backing) where the loop runs exactly once.
+#[inline]
+fn read_be_word<T: MachineWord>(bytes: &[u8]) -> T {
+    let mut val = zero::<T>();
+    let mut first = true;
+    for &b in bytes {
+        if !first {
+            val = val << 8;
+        }
+        val = val | <T as From<u8>>::from(b);
+        first = false;
+    }
+    val
+}
+
+// LE counterpart: byte `i` of the input contributes at bit position `i*8`.
+#[inline]
+fn read_le_word<T: MachineWord>(bytes: &[u8]) -> T {
+    let mut val = zero::<T>();
+    let mut shift = 0;
+    for &b in bytes {
+        val = val | (<T as From<u8>>::from(b) << shift);
+        shift += 8;
+    }
+    val
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
+    /// Serialize into `out` as big-endian bytes. Writes `self.len *
+    /// size_of::<T>()` bytes into `out[..byte_count]` and returns that
+    /// slice. Panics if `out.len() < byte_count`.
+    pub fn to_be_bytes<'a>(&self, out: &'a mut [u8]) -> &'a [u8] {
+        let word_size = core::mem::size_of::<T>();
+        let byte_count = self.len as usize * word_size;
+        assert!(
+            out.len() >= byte_count,
+            "HeaplessBigInt::to_be_bytes: out.len() < required ({byte_count} bytes)"
+        );
+        for (chunk, word) in out[..byte_count]
+            .chunks_exact_mut(word_size)
+            .zip(self.limbs[..self.len as usize].iter().rev())
+        {
+            let word_bytes = word.to_be_bytes();
+            for (dst, src) in chunk.iter_mut().zip(word_bytes.as_ref()) {
+                *dst = *src;
+            }
+        }
+        &out[..byte_count]
+    }
+
+    /// Serialize into `out` as little-endian bytes. Same size + panic
+    /// contract as [`to_be_bytes`](Self::to_be_bytes).
+    pub fn to_le_bytes<'a>(&self, out: &'a mut [u8]) -> &'a [u8] {
+        let word_size = core::mem::size_of::<T>();
+        let byte_count = self.len as usize * word_size;
+        assert!(
+            out.len() >= byte_count,
+            "HeaplessBigInt::to_le_bytes: out.len() < required ({byte_count} bytes)"
+        );
+        for (chunk, word) in out[..byte_count]
+            .chunks_exact_mut(word_size)
+            .zip(self.limbs[..self.len as usize].iter())
+        {
+            let word_bytes = word.to_le_bytes();
+            for (dst, src) in chunk.iter_mut().zip(word_bytes.as_ref()) {
+                *dst = *src;
+            }
+        }
+        &out[..byte_count]
+    }
+
+    /// Deserialize a big-endian byte slice. Output `len =
+    /// ceil(bytes.len() / word_size)`, capped at `CAP`. A partial top
+    /// word (input length not a multiple of `word_size`) leaves the
+    /// missing high bytes zero — matches the BE convention. Panics if
+    /// `bytes.len() > CAP * word_size`.
+    pub fn from_be_bytes(bytes: &[u8]) -> Self {
+        let word_size = core::mem::size_of::<T>();
+        let max_bytes = CAP * word_size;
+        assert!(
+            bytes.len() <= max_bytes,
+            "HeaplessBigInt::from_be_bytes: input {} bytes > CAP * word_size ({max_bytes})",
+            bytes.len()
+        );
+        let byte_count = bytes.len();
+        let out_len = byte_count.div_ceil(word_size);
+
+        let mut limbs = [zero::<T>(); CAP];
+        // Walk backwards through `bytes`: each word_size chunk (or
+        // partial chunk at the front) fills a limb starting from limb 0.
+        let mut hi = byte_count;
+        let mut word_idx = 0;
+        while hi > 0 {
+            let take = core::cmp::min(word_size, hi);
+            let lo = hi - take;
+            limbs[word_idx] = read_be_word::<T>(&bytes[lo..hi]);
+            word_idx += 1;
+            hi = lo;
+        }
+
+        Self {
+            limbs,
+            len: out_len as u16,
+            _p: PhantomData,
+        }
+    }
+
+    /// Deserialize a little-endian byte slice. Same size contract as
+    /// [`from_be_bytes`](Self::from_be_bytes).
+    pub fn from_le_bytes(bytes: &[u8]) -> Self {
+        let word_size = core::mem::size_of::<T>();
+        let max_bytes = CAP * word_size;
+        assert!(
+            bytes.len() <= max_bytes,
+            "HeaplessBigInt::from_le_bytes: input {} bytes > CAP * word_size ({max_bytes})",
+            bytes.len()
+        );
+        let byte_count = bytes.len();
+        let out_len = byte_count.div_ceil(word_size);
+
+        let mut limbs = [zero::<T>(); CAP];
+        let mut offset = 0;
+        let mut word_idx = 0;
+        while offset < byte_count {
+            let take = core::cmp::min(word_size, byte_count - offset);
+            limbs[word_idx] = read_le_word::<T>(&bytes[offset..offset + take]);
+            word_idx += 1;
+            offset += take;
+        }
+
+        Self {
+            limbs,
+            len: out_len as u16,
+            _p: PhantomData,
+        }
+    }
+}

--- a/src/heapless/bytes.rs
+++ b/src/heapless/bytes.rs
@@ -26,9 +26,9 @@ fn read_be_word<T: MachineWord>(bytes: &[u8]) -> T {
     let mut first = true;
     for &b in bytes {
         if !first {
-            val = val << 8;
+            val <<= 8;
         }
-        val = val | <T as From<u8>>::from(b);
+        val |= <T as From<u8>>::from(b);
         first = false;
     }
     val
@@ -40,7 +40,7 @@ fn read_le_word<T: MachineWord>(bytes: &[u8]) -> T {
     let mut val = zero::<T>();
     let mut shift = 0;
     for &b in bytes {
-        val = val | (<T as From<u8>>::from(b) << shift);
+        val |= <T as From<u8>>::from(b) << shift;
         shift += 8;
     }
     val

--- a/src/heapless/bytes.rs
+++ b/src/heapless/bytes.rs
@@ -15,7 +15,7 @@
 
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
-use const_num_traits::Personality;
+use const_num_traits::{ByteSliceError, ByteSliceErrorKind, FromByteSlice, Personality};
 use core::marker::PhantomData;
 
 // Read up to `bytes.len()` MSB-first bytes into a T, zero-padding on the
@@ -156,5 +156,41 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
             len: out_len as u16,
             _p: PhantomData,
         }
+    }
+}
+
+// ── const_num_traits::FromByteSlice ──
+//
+// Result-returning slice parse: empty → `Empty`, wider than the
+// container → `Overflow`, shorter → zero-extended. The inherent
+// `from_be_bytes`/`from_le_bytes` already zero-extend; the length
+// guard converts their panic-on-oversize into the `Overflow` error.
+
+impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
+    #[inline]
+    fn check_slice_len(len: usize) -> Result<(), ByteSliceError> {
+        if len == 0 {
+            return Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Empty,
+            });
+        }
+        if len > CAP * core::mem::size_of::<T>() {
+            return Err(ByteSliceError {
+                kind: ByteSliceErrorKind::Overflow,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> FromByteSlice for HeaplessBigInt<T, CAP, P> {
+    fn from_be_slice(bytes: &[u8]) -> Result<Self, ByteSliceError> {
+        Self::check_slice_len(bytes.len())?;
+        Ok(Self::from_be_bytes(bytes))
+    }
+
+    fn from_le_slice(bytes: &[u8]) -> Result<Self, ByteSliceError> {
+        Self::check_slice_len(bytes.len())?;
+        Ok(Self::from_le_bytes(bytes))
     }
 }

--- a/src/heapless/bytes.rs
+++ b/src/heapless/bytes.rs
@@ -8,20 +8,18 @@
 //! high-order word's high byte at index 0, LE writes the low-order
 //! word's low byte at index 0.
 //!
-//! The inner byte-copy is the zip byte-loop landed in fixed-bigint
-//! 0.5.2 — no `copy_from_slice` length assert to fold. Per-word reads
-//! are bit-shifted rather than `T::from_be_bytes`, so `T` needs only
-//! `MachineWord` (not a byte-conversion trait bound).
+//! Per-word reads are bit-shifted rather than `T::from_be_bytes`, so `T`
+//! needs only `MachineWord`, not a byte-conversion trait bound.
 
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
 use const_num_traits::{ByteSliceError, ByteSliceErrorKind, FromByteSlice, Personality};
 use core::marker::PhantomData;
 
-// Read up to `bytes.len()` MSB-first bytes into a T, zero-padding on the
-// high side if `bytes.len() < size_of::<T>()`. Skips the shift on the
-// first iteration because `T::BITS`-wide shift is UB — matters at
-// `size_of::<T>() == 1` (u8 backing) where the loop runs exactly once.
+// Read MSB-first bytes into a T, zero-padding the high side if
+// `bytes.len() < size_of::<T>()`. Skips the shift on the first iteration
+// because a `T::BITS`-wide shift is UB — matters at `size_of::<T>() == 1`
+// (u8 backing) where the loop runs exactly once.
 #[inline]
 fn read_be_word<T: MachineWord>(bytes: &[u8]) -> T {
     let mut val = zero::<T>();
@@ -109,8 +107,8 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         let out_len = byte_count.div_ceil(word_size);
 
         let mut limbs = [zero::<T>(); CAP];
-        // Walk backwards through `bytes`: each word_size chunk (or
-        // partial chunk at the front) fills a limb starting from limb 0.
+        // Fill limbs from limb 0, consuming `bytes` back-to-front (a
+        // partial chunk, if any, lands at the high end).
         let mut hi = byte_count;
         let mut word_idx = 0;
         while hi > 0 {

--- a/src/heapless/cios.rs
+++ b/src/heapless/cios.rs
@@ -1,0 +1,96 @@
+//! `modmath_cios::CiosRowOps` impl for `HeaplessBigInt`.
+//!
+//! CIOS Montgomery multiplication drives multi-limb integer operands
+//! through two row-op kernels: a plain multiply-accumulate and a
+//! multiply-accumulate-with-shift. Together with `word_count()` and a
+//! `cios_accumulator()` sized to match the operand width, they let the
+//! CIOS driver be generic over the carrier type.
+//!
+//! `cios_accumulator(&self)` is overridden so runtime-width operands
+//! hand back a zero-value carrier whose `len` matches `self.len`; the
+//! trait's `Default` body returns the mathematical zero at `len == 0`,
+//! which would give the driver `word_count(acc) == 0` and break the
+//! invariant.
+//!
+//! The row-op bodies mirror the `mul_slice` shape in `arith.rs`
+//! (`carrying_mul` + `carrying_add`), reusing the max-value analysis
+//! that shows carry propagation stays inside a single `T`.
+
+use super::{HeaplessBigInt, zero};
+use crate::MachineWord;
+use const_num_traits::{CarryingAdd, CarryingMul, ConstOne, Personality};
+
+impl<T, const CAP: usize, P: Personality> modmath_cios::CiosRowOps for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Word = T;
+
+    fn word_count(&self) -> usize {
+        self.len as usize
+    }
+
+    fn cios_accumulator(&self) -> Self {
+        Self::new_zero_with_len(self.len)
+    }
+
+    fn word(&self, i: usize) -> T {
+        self.limbs[i]
+    }
+
+    fn mul_acc_row(scalar: T, multiplicand: &Self, acc: &mut Self, carry_in: T) -> T {
+        // acc += scalar * multiplicand + carry_in. Each iteration adds
+        // one limb's worth. carry propagates through the loop; the
+        // final carry-out is returned.
+        let n = multiplicand.len as usize;
+        let mut carry = carry_in;
+        let mut i = 0;
+        while i < n {
+            let (t_lo, t_hi) =
+                <T as CarryingMul>::carrying_mul(scalar, multiplicand.limbs[i], carry);
+            let (sum, c) = <T as CarryingAdd>::carrying_add(acc.limbs[i], t_lo, false);
+            acc.limbs[i] = sum;
+            // t_hi + c never overflows T: when t_hi is maximal (2^b - 1)
+            // the corresponding t_lo is zero, so acc[i] + t_lo does not
+            // overflow and c == 0.
+            let (new_carry, _) = <T as CarryingAdd>::carrying_add(t_hi, zero(), c);
+            carry = new_carry;
+            i += 1;
+        }
+        carry
+    }
+
+    fn mul_acc_shift_row(scalar: T, multiplicand: &Self, acc: &mut Self, acc_hi: T) -> T {
+        let n = multiplicand.len as usize;
+        // Phase 1: acc += scalar * multiplicand, running carry.
+        let mut carry = zero::<T>();
+        let mut i = 0;
+        while i < n {
+            let (t_lo, t_hi) =
+                <T as CarryingMul>::carrying_mul(scalar, multiplicand.limbs[i], carry);
+            let (sum, c) = <T as CarryingAdd>::carrying_add(acc.limbs[i], t_lo, false);
+            acc.limbs[i] = sum;
+            let (new_carry, _) = <T as CarryingAdd>::carrying_add(t_hi, zero(), c);
+            carry = new_carry;
+            i += 1;
+        }
+        // Combine phase-1 carry with the incoming acc_hi at position W.
+        let (top_low, top_hi_bit) = <T as CarryingAdd>::carrying_add(carry, acc_hi, false);
+        // Shift right by one limb: drop acc[0] (which the CIOS
+        // invariant makes zero), shuffle limbs down, place top_low at
+        // the highest slot.
+        let mut i = 0;
+        while i + 1 < n {
+            acc.limbs[i] = acc.limbs[i + 1];
+            i += 1;
+        }
+        if n > 0 {
+            acc.limbs[n - 1] = top_low;
+        }
+        if top_hi_bit {
+            <T as ConstOne>::ONE
+        } else {
+            zero()
+        }
+    }
+}

--- a/src/heapless/cios.rs
+++ b/src/heapless/cios.rs
@@ -39,9 +39,7 @@ where
     }
 
     fn mul_acc_row(scalar: T, multiplicand: &Self, acc: &mut Self, carry_in: T) -> T {
-        // acc += scalar * multiplicand + carry_in. Each iteration adds
-        // one limb's worth. carry propagates through the loop; the
-        // final carry-out is returned.
+        // acc += scalar * multiplicand + carry_in; returns the carry-out.
         let n = multiplicand.len as usize;
         let mut carry = carry_in;
         let mut i = 0;
@@ -76,9 +74,8 @@ where
         }
         // Combine phase-1 carry with the incoming acc_hi at position W.
         let (top_low, top_hi_bit) = <T as CarryingAdd>::carrying_add(carry, acc_hi, false);
-        // Shift right by one limb: drop acc[0] (which the CIOS
-        // invariant makes zero), shuffle limbs down, place top_low at
-        // the highest slot.
+        // Shift right by one limb: drop acc[0] (zero by the CIOS
+        // invariant) and place top_low at the highest slot.
         let mut i = 0;
         while i + 1 < n {
             acc.limbs[i] = acc.limbs[i + 1];

--- a/src/heapless/cmp.rs
+++ b/src/heapless/cmp.rs
@@ -2,13 +2,15 @@
 //! `subtle::ConstantTimeEq` and `subtle::ConditionallySelectable` for
 //! the Ct paths.
 //!
-//! All value-based:
-//! - `Eq`: walks `max(a.len, b.len)` limbs. Under the zero-tail invariant,
-//!   `HeaplessBigInt<u32, N, _>` with `len = 0` compares equal to a
-//!   `zero_full_cap()` (len = CAP) — both represent mathematical zero.
-//! - `Ord`: walks MSB-to-LSB up to `max(a.len, b.len)`. Regular impl
-//!   branches on limb content (NCT-implicit); Ct callers use
-//!   `subtle::ConstantTimeGreater` / `ConstantTimeEq` separately.
+//! All value-based, each dispatching on `P` like `FixedUInt`:
+//! - `Eq`: walks `max(a.len, b.len)` limbs. `Nct` short-circuits at the
+//!   first differing limb; `Ct` XOR/OR-folds every limb so timing does
+//!   not reveal the first mismatch (the returned `bool` is still
+//!   branchable — Ct-secure equality routes through `ConstantTimeEq`).
+//!   Under the zero-tail invariant, `HeaplessBigInt<u32, N, _>` with
+//!   `len = 0` compares equal to a `zero_full_cap()` (len = CAP).
+//! - `Ord`: MSB-to-LSB up to `max(a.len, b.len)`. `Nct` short-circuits;
+//!   `Ct` scans the full width with an `undecided` lock (no early return).
 //! - `subtle::ConstantTimeEq`: XOR-fold across `max(a.len, b.len)`.
 //!   `black_box` guards against LLVM re-branchifying the fold.
 //! - `subtle::ConditionallySelectable`: per-limb branchless select via
@@ -22,9 +24,9 @@
 //!   scan up to `max(a.len, b.len)` with a running `undecided` bit —
 //!   the Montgomery conditional-subtract shape.
 
-use super::HeaplessBigInt;
+use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
-use const_num_traits::Personality;
+use const_num_traits::{Personality, PersonalityTag};
 use core::marker::PhantomData;
 
 // ── PartialEq / Eq (value-based) ──
@@ -32,20 +34,35 @@ use core::marker::PhantomData;
 impl<T: MachineWord, const CAP: usize, P: Personality> PartialEq for HeaplessBigInt<T, CAP, P> {
     fn eq(&self, other: &Self) -> bool {
         let n = core::cmp::max(self.len, other.len) as usize;
-        let mut i = 0;
-        while i < n {
-            if self.limbs[i] != other.limbs[i] {
-                return false;
+        match P::TAG {
+            PersonalityTag::Nct => {
+                let mut i = 0;
+                while i < n {
+                    if self.limbs[i] != other.limbs[i] {
+                        return false;
+                    }
+                    i += 1;
+                }
+                true
             }
-            i += 1;
+            // Fold every limb, no early return: timing is independent of
+            // where the first mismatch is.
+            PersonalityTag::Ct => {
+                let mut diff = zero::<T>();
+                let mut i = 0;
+                while i < n {
+                    diff |= self.limbs[i] ^ other.limbs[i];
+                    i += 1;
+                }
+                is_zero(&diff)
+            }
         }
-        true
     }
 }
 
 impl<T: MachineWord, const CAP: usize, P: Personality> Eq for HeaplessBigInt<T, CAP, P> {}
 
-// ── PartialOrd / Ord (value-based, NCT-implicit) ──
+// ── PartialOrd / Ord (value-based) ──
 
 impl<T: MachineWord, const CAP: usize, P: Personality> PartialOrd for HeaplessBigInt<T, CAP, P> {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
@@ -56,15 +73,42 @@ impl<T: MachineWord, const CAP: usize, P: Personality> PartialOrd for HeaplessBi
 impl<T: MachineWord, const CAP: usize, P: Personality> Ord for HeaplessBigInt<T, CAP, P> {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         let n = core::cmp::max(self.len, other.len) as usize;
-        let mut i = n;
-        while i > 0 {
-            i -= 1;
-            match self.limbs[i].cmp(&other.limbs[i]) {
-                core::cmp::Ordering::Equal => continue,
-                ord => return ord,
+        match P::TAG {
+            PersonalityTag::Nct => {
+                let mut i = n;
+                while i > 0 {
+                    i -= 1;
+                    match self.limbs[i].cmp(&other.limbs[i]) {
+                        core::cmp::Ordering::Equal => continue,
+                        ord => return ord,
+                    }
+                }
+                core::cmp::Ordering::Equal
+            }
+            // Full MSB-to-LSB scan; once a differing limb is seen the
+            // `decided` mask stops later limbs from overturning it. Mirrors
+            // `FixedUInt`'s `const_cmp_ct`. result: 2 = Greater, 1 = Less.
+            PersonalityTag::Ct => {
+                let mut result: u8 = 0;
+                let mut decided: u8 = 0;
+                let mut i = n;
+                while i > 0 {
+                    i -= 1;
+                    let gt = (self.limbs[i] > other.limbs[i]) as u8;
+                    let lt = (self.limbs[i] < other.limbs[i]) as u8;
+                    let here = (gt << 1) | lt;
+                    let undecided_mask = core::hint::black_box(!decided);
+                    result |= undecided_mask & here;
+                    let here_nz_mask = core::hint::black_box(((here != 0) as u8).wrapping_neg());
+                    decided |= here_nz_mask;
+                }
+                match result {
+                    2 => core::cmp::Ordering::Greater,
+                    1 => core::cmp::Ordering::Less,
+                    _ => core::cmp::Ordering::Equal,
+                }
             }
         }
-        core::cmp::Ordering::Equal
     }
 }
 

--- a/src/heapless/cmp.rs
+++ b/src/heapless/cmp.rs
@@ -74,12 +74,13 @@ impl<T: MachineWord + core::hash::Hash, const CAP: usize, P: Personality> core::
     for HeaplessBigInt<T, CAP, P>
 {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        // Hash up to the highest non-zero limb, ignoring both `len` and
-        // `CAP`, so `ConstZero::ZERO` and `zero_full_cap()` produce the
-        // same hash (value-based). NCT-implicit — this scans content.
+        // Hash up to the highest non-zero limb, ignoring `len` so equal
+        // values at different shapes hash alike (value-based). Scans
+        // `0..len`; limbs beyond `len` are zero by invariant, so `CAP`
+        // need not enter. NCT-implicit — this scans content.
         let mut top = 0usize;
         let mut i = 0;
-        while i < CAP {
+        while i < self.len as usize {
             if !super::is_zero(&self.limbs[i]) {
                 top = i + 1;
             }

--- a/src/heapless/cmp.rs
+++ b/src/heapless/cmp.rs
@@ -1,5 +1,6 @@
 //! `PartialEq` / `Eq` / `PartialOrd` / `Ord` for `HeaplessBigInt`, plus
-//! `subtle::ConstantTimeEq` for the Ct comparison path.
+//! `subtle::ConstantTimeEq` and `subtle::ConditionallySelectable` for
+//! the Ct paths.
 //!
 //! All value-based:
 //! - `Eq`: walks `max(a.len, b.len)` limbs. Under the zero-tail invariant,
@@ -10,10 +11,21 @@
 //!   `subtle::ConstantTimeGreater` / `ConstantTimeEq` separately.
 //! - `subtle::ConstantTimeEq`: XOR-fold across `max(a.len, b.len)`.
 //!   `black_box` guards against LLVM re-branchifying the fold.
+//! - `subtle::ConditionallySelectable`: per-limb branchless select via
+//!   `T`'s subtle impl, iterating up to `max(a.len, b.len)`. Output len
+//!   is that same `max`, a public shape derived from two public shape
+//!   parameters — never from `choice`.
+//! - `const_num_traits::CtIsZero`: AND-fold `T::ct_eq(&ZERO)` across
+//!   `0..self.len`. Limbs beyond `len` are zero by invariant so
+//!   skipping them preserves the answer.
+//! - `subtle::ConstantTimeGreater` / `ConstantTimeLess`: MSB-to-LSB
+//!   scan up to `max(a.len, b.len)` with a running `undecided` bit —
+//!   the Montgomery conditional-subtract shape.
 
 use super::HeaplessBigInt;
 use crate::MachineWord;
 use const_num_traits::Personality;
+use core::marker::PhantomData;
 
 // ── PartialEq / Eq (value-based) ──
 
@@ -102,4 +114,88 @@ where
         // FixedUInt's `const_ct_select`.
         subtle::Choice::from(core::hint::black_box(acc.unwrap_u8()))
     }
+}
+
+// ── subtle::ConditionallySelectable ──
+
+impl<T, const CAP: usize, P: Personality> subtle::ConditionallySelectable
+    for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    fn conditional_select(a: &Self, b: &Self, choice: subtle::Choice) -> Self {
+        // Output `len = max(a.len, b.len)`. Both operand lens are public
+        // shape parameters, so their `max` is public — never derived
+        // from `choice`. Per-limb select up to that bound; the tails
+        // beyond each operand's own len are zero (zero-tail invariant),
+        // so per-limb select on the tails yields zero regardless of
+        // `choice`, and the output's tail past `out_len` stays zero.
+        let out_len = core::cmp::max(a.len, b.len);
+        let mut limbs = [super::zero::<T>(); CAP];
+        let mut i = 0;
+        while i < out_len as usize {
+            limbs[i] = <T as subtle::ConditionallySelectable>::conditional_select(
+                &a.limbs[i],
+                &b.limbs[i],
+                choice,
+            );
+            i += 1;
+        }
+        Self {
+            limbs,
+            len: out_len,
+            _p: PhantomData,
+        }
+    }
+}
+
+// ── const_num_traits::CtIsZero ──
+
+impl<T, const CAP: usize, P: Personality> const_num_traits::ops::ct::CtIsZero
+    for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + subtle::ConstantTimeEq,
+{
+    fn ct_is_zero(&self) -> subtle::Choice {
+        let n = self.len as usize;
+        let mut acc = subtle::Choice::from(1u8);
+        let mut i = 0;
+        while i < n {
+            acc &= self.limbs[i].ct_eq(&<T as const_num_traits::ConstZero>::ZERO);
+            i += 1;
+        }
+        subtle::Choice::from(core::hint::black_box(acc.unwrap_u8()))
+    }
+}
+
+// ── subtle::ConstantTimeGreater / ConstantTimeLess ──
+
+impl<T, const CAP: usize, P: Personality> subtle::ConstantTimeGreater for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + subtle::ConstantTimeEq + subtle::ConstantTimeGreater,
+{
+    fn ct_gt(&self, other: &Self) -> subtle::Choice {
+        // MSB-to-LSB scan across `max(a.len, b.len)`. `undecided` locks
+        // the answer at the first differing limb without a data-dependent
+        // branch — every iteration always executes.
+        let n = core::cmp::max(self.len, other.len) as usize;
+        let mut gt = subtle::Choice::from(0u8);
+        let mut undecided = subtle::Choice::from(1u8);
+        let mut i = n;
+        while i > 0 {
+            i -= 1;
+            let gt_here = self.limbs[i].ct_gt(&other.limbs[i]);
+            let eq_here = self.limbs[i].ct_eq(&other.limbs[i]);
+            gt |= undecided & gt_here;
+            undecided &= eq_here;
+        }
+        gt
+    }
+}
+
+// `ConstantTimeLess` is derived from `ConstantTimeEq` + `ConstantTimeGreater`
+// via its default methods; the empty impl is enough to opt in.
+impl<T, const CAP: usize, P: Personality> subtle::ConstantTimeLess for HeaplessBigInt<T, CAP, P> where
+    T: MachineWord + subtle::ConstantTimeEq + subtle::ConstantTimeGreater
+{
 }

--- a/src/heapless/cmp.rs
+++ b/src/heapless/cmp.rs
@@ -1,0 +1,105 @@
+//! `PartialEq` / `Eq` / `PartialOrd` / `Ord` for `HeaplessBigInt`, plus
+//! `subtle::ConstantTimeEq` for the Ct comparison path.
+//!
+//! All value-based:
+//! - `Eq`: walks `max(a.len, b.len)` limbs. Under the zero-tail invariant,
+//!   `HeaplessBigInt<u32, N, _>` with `len = 0` compares equal to a
+//!   `zero_full_cap()` (len = CAP) — both represent mathematical zero.
+//! - `Ord`: walks MSB-to-LSB up to `max(a.len, b.len)`. Regular impl
+//!   branches on limb content (NCT-implicit); Ct callers use
+//!   `subtle::ConstantTimeGreater` / `ConstantTimeEq` separately.
+//! - `subtle::ConstantTimeEq`: XOR-fold across `max(a.len, b.len)`.
+//!   `black_box` guards against LLVM re-branchifying the fold.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::Personality;
+
+// ── PartialEq / Eq (value-based) ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> PartialEq for HeaplessBigInt<T, CAP, P> {
+    fn eq(&self, other: &Self) -> bool {
+        let n = core::cmp::max(self.len, other.len) as usize;
+        let mut i = 0;
+        while i < n {
+            if self.limbs[i] != other.limbs[i] {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Eq for HeaplessBigInt<T, CAP, P> {}
+
+// ── PartialOrd / Ord (value-based, NCT-implicit) ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> PartialOrd for HeaplessBigInt<T, CAP, P> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Ord for HeaplessBigInt<T, CAP, P> {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        let n = core::cmp::max(self.len, other.len) as usize;
+        let mut i = n;
+        while i > 0 {
+            i -= 1;
+            match self.limbs[i].cmp(&other.limbs[i]) {
+                core::cmp::Ordering::Equal => continue,
+                ord => return ord,
+            }
+        }
+        core::cmp::Ordering::Equal
+    }
+}
+
+// ── Hash (consistent with value-based Eq) ──
+
+impl<T: MachineWord + core::hash::Hash, const CAP: usize, P: Personality> core::hash::Hash
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        // Hash up to the highest non-zero limb, ignoring both `len` and
+        // `CAP`, so `ConstZero::ZERO` and `zero_full_cap()` produce the
+        // same hash (value-based). NCT-implicit — this scans content.
+        let mut top = 0usize;
+        let mut i = 0;
+        while i < CAP {
+            if !super::is_zero(&self.limbs[i]) {
+                top = i + 1;
+            }
+            i += 1;
+        }
+        state.write_usize(top);
+        for limb in &self.limbs[..top] {
+            limb.hash(state);
+        }
+    }
+}
+
+// ── subtle::ConstantTimeEq (Ct-safe equality) ──
+
+impl<T, const CAP: usize, P: Personality> subtle::ConstantTimeEq for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + subtle::ConstantTimeEq,
+{
+    fn ct_eq(&self, other: &Self) -> subtle::Choice {
+        // Iterate `max(len)` — a public shape parameter. Both operands
+        // walk the same public count regardless of value.
+        let n = core::cmp::max(self.len, other.len) as usize;
+        let mut acc = subtle::Choice::from(1u8);
+        let mut i = 0;
+        while i < n {
+            let per_limb = self.limbs[i].ct_eq(&other.limbs[i]);
+            acc &= per_limb;
+            i += 1;
+        }
+        // `black_box` on the accumulator so LLVM can't recognise the
+        // AND-fold as a short-circuit — same defence as
+        // FixedUInt's `const_ct_select`.
+        subtle::Choice::from(core::hint::black_box(acc.unwrap_u8()))
+    }
+}

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -29,12 +29,23 @@ where
         "HeaplessBigInt: divide by zero"
     );
 
+    // Both outputs are carried at the operands' width `max(len)`, the same
+    // as the general path below — the early returns must widen too, or
+    // `x / x` would come back at `len == 1` and later width-preserving ops
+    // would run narrower than the operands.
+    let work_len = core::cmp::max(dividend.len(), divisor.len());
+
     match dividend.cmp(divisor) {
-        Ordering::Less => return (<HeaplessBigInt<T, CAP, Nct> as Zero>::zero(), *dividend),
+        Ordering::Less => {
+            return (
+                <HeaplessBigInt<T, CAP, Nct> as Zero>::zero().widened(work_len),
+                dividend.widened(work_len),
+            );
+        }
         Ordering::Equal => {
             return (
-                <HeaplessBigInt<T, CAP, Nct> as One>::one(),
-                <HeaplessBigInt<T, CAP, Nct> as Zero>::zero(),
+                <HeaplessBigInt<T, CAP, Nct> as One>::one().widened(work_len),
+                <HeaplessBigInt<T, CAP, Nct> as Zero>::zero().widened(work_len),
             );
         }
         Ordering::Greater => {}
@@ -44,16 +55,14 @@ where
     let dv_bits = divisor.bit_length();
     let mut shift = d_bits - dv_bits;
 
-    // Work at a fixed width wide enough for every shifted value. `Shl` is
-    // width-preserving, so the divisor and the quotient-bit unit must be
-    // carried at this width for the up-shifts to have room. `shift <=
-    // d_bits - dv_bits`, so `divisor << shift <= dividend`, which fits in
-    // `dividend`'s words — `work_len` never needs to exceed the operands.
-    let work_len = core::cmp::max(dividend.len(), divisor.len());
+    // `Shl` is width-preserving, so the divisor and the quotient-bit unit
+    // must be carried at `work_len` for the up-shifts to have room. `shift
+    // <= d_bits - dv_bits`, so `divisor << shift <= dividend`, which fits
+    // in `dividend`'s words — `work_len` never needs to exceed the operands.
     let mut rem = dividend.widened(work_len);
     let wide_divisor = divisor.widened(work_len);
     let one = <HeaplessBigInt<T, CAP, Nct> as One>::one().widened(work_len);
-    let mut quotient = <HeaplessBigInt<T, CAP, Nct> as Zero>::zero();
+    let mut quotient = <HeaplessBigInt<T, CAP, Nct> as Zero>::zero().widened(work_len);
 
     loop {
         let shifted = wide_divisor << shift;

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -44,14 +44,22 @@ where
     let dv_bits = divisor.bit_length();
     let mut shift = d_bits - dv_bits;
 
-    let mut rem = *dividend;
+    // Work at a fixed width wide enough for every shifted value. `Shl` is
+    // width-preserving, so the divisor and the quotient-bit unit must be
+    // carried at this width for the up-shifts to have room. `shift <=
+    // d_bits - dv_bits`, so `divisor << shift <= dividend`, which fits in
+    // `dividend`'s words — `work_len` never needs to exceed the operands.
+    let work_len = core::cmp::max(dividend.len(), divisor.len());
+    let mut rem = dividend.widened(work_len);
+    let wide_divisor = divisor.widened(work_len);
+    let one = <HeaplessBigInt<T, CAP, Nct> as One>::one().widened(work_len);
     let mut quotient = <HeaplessBigInt<T, CAP, Nct> as Zero>::zero();
 
     loop {
-        let shifted = *divisor << shift;
+        let shifted = wide_divisor << shift;
         if rem >= shifted {
             rem = rem.wrapping_sub(&shifted);
-            let bit = <HeaplessBigInt<T, CAP, Nct> as One>::one() << shift;
+            let bit = one << shift;
             quotient = quotient.wrapping_add(&bit);
         }
         if shift == 0 {

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -1,0 +1,109 @@
+//! `core::ops::Div` / `Rem` for `HeaplessBigInt<T, CAP, Nct>`.
+//!
+//! Nct-only. Division is data-dependent (early-exits on shift, on
+//! `rem >= shifted`) — the personality rule mirrors `FixedUInt`, where
+//! `Div`/`Rem` are `Nct` only. Ct callers that need `x mod modulus` use
+//! Montgomery reduction via the CIOS driver, not this path.
+//!
+//! Algorithm is shift-and-subtract long division: shift the divisor to
+//! the highest bit position where it might fit into the remaining
+//! dividend, subtract when it does, set the corresponding quotient bit.
+//! Uses only ops HeaplessBigInt already exposes (`Shl<usize>`,
+//! `wrapping_sub`, `wrapping_add`, `cmp`, `bit_length`) — no direct
+//! limb access, no new bit-poke helpers.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{CarryingMul, Nct, One, Zero};
+
+fn div_rem_impl<T, const CAP: usize>(
+    dividend: &HeaplessBigInt<T, CAP, Nct>,
+    divisor: &HeaplessBigInt<T, CAP, Nct>,
+) -> (HeaplessBigInt<T, CAP, Nct>, HeaplessBigInt<T, CAP, Nct>)
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    use core::cmp::Ordering;
+    assert!(
+        !<HeaplessBigInt<T, CAP, Nct> as Zero>::is_zero(divisor),
+        "HeaplessBigInt: divide by zero"
+    );
+
+    match dividend.cmp(divisor) {
+        Ordering::Less => return (<HeaplessBigInt<T, CAP, Nct> as Zero>::zero(), *dividend),
+        Ordering::Equal => {
+            return (
+                <HeaplessBigInt<T, CAP, Nct> as One>::one(),
+                <HeaplessBigInt<T, CAP, Nct> as Zero>::zero(),
+            );
+        }
+        Ordering::Greater => {}
+    }
+
+    let d_bits = dividend.bit_length();
+    let dv_bits = divisor.bit_length();
+    let mut shift = d_bits - dv_bits;
+
+    let mut rem = *dividend;
+    let mut quotient = <HeaplessBigInt<T, CAP, Nct> as Zero>::zero();
+
+    loop {
+        let shifted = *divisor << shift;
+        if rem >= shifted {
+            rem = rem.wrapping_sub(&shifted);
+            let bit = <HeaplessBigInt<T, CAP, Nct> as One>::one() << shift;
+            quotient = quotient.wrapping_add(&bit);
+        }
+        if shift == 0 {
+            break;
+        }
+        shift -= 1;
+    }
+
+    (quotient, rem)
+}
+
+macro_rules! div_impls {
+    ($lhs:ty, $rhs:ty, $out:ty) => {
+        impl<T, const CAP: usize> core::ops::Div<$rhs> for $lhs
+        where
+            T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+        {
+            type Output = $out;
+            fn div(self, other: $rhs) -> Self::Output {
+                div_rem_impl::<T, CAP>(&self, &other).0
+            }
+        }
+
+        impl<T, const CAP: usize> core::ops::Rem<$rhs> for $lhs
+        where
+            T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+        {
+            type Output = $out;
+            fn rem(self, other: $rhs) -> Self::Output {
+                div_rem_impl::<T, CAP>(&self, &other).1
+            }
+        }
+    };
+}
+
+div_impls!(
+    HeaplessBigInt<T, CAP, Nct>,
+    HeaplessBigInt<T, CAP, Nct>,
+    HeaplessBigInt<T, CAP, Nct>
+);
+div_impls!(
+    HeaplessBigInt<T, CAP, Nct>,
+    &HeaplessBigInt<T, CAP, Nct>,
+    HeaplessBigInt<T, CAP, Nct>
+);
+div_impls!(
+    &HeaplessBigInt<T, CAP, Nct>,
+    HeaplessBigInt<T, CAP, Nct>,
+    HeaplessBigInt<T, CAP, Nct>
+);
+div_impls!(
+    &HeaplessBigInt<T, CAP, Nct>,
+    &HeaplessBigInt<T, CAP, Nct>,
+    HeaplessBigInt<T, CAP, Nct>
+);

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -107,3 +107,46 @@ div_impls!(
     &HeaplessBigInt<T, CAP, Nct>,
     HeaplessBigInt<T, CAP, Nct>
 );
+
+// ── DivAssign / RemAssign ──
+//
+// modmath's constrained flavor uses `%=`; `DivAssign` is added for
+// symmetry. Both delegate to the same long-division kernel.
+
+impl<T, const CAP: usize> core::ops::DivAssign for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn div_assign(&mut self, other: Self) {
+        *self = div_rem_impl::<T, CAP>(self, &other).0;
+    }
+}
+
+impl<T, const CAP: usize> core::ops::DivAssign<&HeaplessBigInt<T, CAP, Nct>>
+    for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn div_assign(&mut self, other: &Self) {
+        *self = div_rem_impl::<T, CAP>(self, other).0;
+    }
+}
+
+impl<T, const CAP: usize> core::ops::RemAssign for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn rem_assign(&mut self, other: Self) {
+        *self = div_rem_impl::<T, CAP>(self, &other).1;
+    }
+}
+
+impl<T, const CAP: usize> core::ops::RemAssign<&HeaplessBigInt<T, CAP, Nct>>
+    for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn rem_assign(&mut self, other: &Self) {
+        *self = div_rem_impl::<T, CAP>(self, other).1;
+    }
+}

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -118,8 +118,8 @@ div_impls!(
 
 // ── DivAssign / RemAssign ──
 //
-// modmath's constrained flavor uses `%=`; `DivAssign` is added for
-// symmetry. Both delegate to the same long-division kernel.
+// `RemAssign` is the used form; `DivAssign` is added for symmetry. Both
+// delegate to the same long-division kernel.
 
 impl<T, const CAP: usize> core::ops::DivAssign for HeaplessBigInt<T, CAP, Nct>
 where

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -64,16 +64,23 @@ where
     let one = <HeaplessBigInt<T, CAP, Nct> as One>::one().widened(work_len);
     let mut quotient = <HeaplessBigInt<T, CAP, Nct> as Zero>::zero().widened(work_len);
 
+    // Compute the top shift once, then walk down one bit per iteration. A
+    // fresh `wide_divisor << shift` each step would be an O(W·shift) shift;
+    // `>> 1` is O(W). `divisor << shift <= dividend` fits in `work_len`, so
+    // no significant bit is lost on the initial shift and `>> 1` faithfully
+    // reconstructs `<< (shift-k)`.
+    let mut shifted = wide_divisor << shift;
+    let mut bit = one << shift;
     loop {
-        let shifted = wide_divisor << shift;
         if rem >= shifted {
             rem = rem.wrapping_sub(&shifted);
-            let bit = one << shift;
             quotient = quotient.wrapping_add(&bit);
         }
         if shift == 0 {
             break;
         }
+        shifted >>= 1;
+        bit >>= 1;
         shift -= 1;
     }
 

--- a/src/heapless/from_prim.rs
+++ b/src/heapless/from_prim.rs
@@ -5,6 +5,12 @@
 //! the value — so the shape is public. Under-sized capacity (`CAP` too
 //! small to hold the source primitive) triggers `from_le_bytes`'s
 //! runtime assertion; matches `FixedUInt`'s implicit contract.
+//!
+//! This is the source-int width, which is likely narrower than the width
+//! a downstream computation needs — see the construction-width table in
+//! the [module docs](super). To carry the value at a chosen width, pin it
+//! with [`WithPrecision`](const_num_traits::WithPrecision) (e.g.
+//! `From::from(v).widen_to_precision_of(&modulus)`).
 
 use super::HeaplessBigInt;
 use crate::MachineWord;

--- a/src/heapless/from_prim.rs
+++ b/src/heapless/from_prim.rs
@@ -1,0 +1,29 @@
+//! `From<u8>` / `From<u16>` / `From<u32>` for `HeaplessBigInt`.
+//!
+//! Small-value constructors. Output `len` is fixed by the source
+//! primitive width (`ceil(size_of::<uN>() / size_of::<T>())`), not by
+//! the value — so the shape is public. Under-sized capacity (`CAP` too
+//! small to hold the source primitive) triggers `from_le_bytes`'s
+//! runtime assertion; matches `FixedUInt`'s implicit contract.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::Personality;
+
+impl<T: MachineWord, const CAP: usize, P: Personality> From<u8> for HeaplessBigInt<T, CAP, P> {
+    fn from(v: u8) -> Self {
+        Self::from_le_bytes(&v.to_le_bytes())
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> From<u16> for HeaplessBigInt<T, CAP, P> {
+    fn from(v: u16) -> Self {
+        Self::from_le_bytes(&v.to_le_bytes())
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> From<u32> for HeaplessBigInt<T, CAP, P> {
+    fn from(v: u32) -> Self {
+        Self::from_le_bytes(&v.to_le_bytes())
+    }
+}

--- a/src/heapless/has_personality.rs
+++ b/src/heapless/has_personality.rs
@@ -1,0 +1,16 @@
+//! `HasPersonality` projection for `HeaplessBigInt`.
+//!
+//! Mirrors `FixedUInt`'s `has_personality_impl.rs`: the carrier's
+//! declared personality is its type parameter, so downstream personality
+//! gates (`T: HasPersonality<P = Nct>`) resolve without naming the
+//! carrier. This is what modmath's `NonCt` blanket-impl gates on.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{HasPersonality, Personality};
+
+impl<T: MachineWord, const CAP: usize, P: Personality> HasPersonality
+    for HeaplessBigInt<T, CAP, P>
+{
+    type P = P;
+}

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -1,0 +1,125 @@
+//! `Zero`, `One`, `Default` for `HeaplessBigInt`.
+//!
+//! - `Zero`: mathematical zero, `len = 0`.
+//! - `One`: `len = 1`, `limbs[0] = T::ONE`.
+//! - `Default = Zero` (spec's landed shape after `modmath-cios 0.1.2`
+//!   introduced `cios_accumulator(&self)` — the CIOS full-CAP zero
+//!   is now a separate constructor, not `Default`).
+
+use super::{AssertCapFits, HeaplessBigInt, zero};
+use crate::MachineWord;
+use const_num_traits::{ConstOne, ConstZero, One, Personality, Zero};
+use core::marker::PhantomData;
+
+// ── const_num_traits::Zero / One ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Zero for HeaplessBigInt<T, CAP, P> {
+    #[inline]
+    fn zero() -> Self {
+        Self::new_zero_with_len(0)
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        // Value-based: any limb non-zero → non-zero. NCT-implicit (short-
+        // circuits on limb content). Ct callers use `CtIsZero::ct_is_zero`
+        // via a separate impl (added when needed).
+        let mut i = 0;
+        while i < self.len as usize {
+            if !super::is_zero(&self.limbs[i]) {
+                return false;
+            }
+            i += 1;
+        }
+        // Zero-tail invariant means limbs beyond len are zero regardless.
+        true
+    }
+
+    #[inline]
+    fn set_zero(&mut self) {
+        *self = <Self as Zero>::zero();
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> One for HeaplessBigInt<T, CAP, P> {
+    #[inline]
+    fn one() -> Self {
+        let _ = <Self as AssertCapFits>::CHECK;
+        assert!(CAP >= 1, "HeaplessBigInt::one requires CAP >= 1");
+        let mut limbs = [zero::<T>(); CAP];
+        limbs[0] = <T as ConstOne>::ONE;
+        Self {
+            limbs,
+            len: 1,
+            _p: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn set_one(&mut self) {
+        *self = <Self as One>::one();
+    }
+
+    #[inline]
+    fn is_one(&self) -> bool {
+        // NCT-implicit content scan.
+        if self.len == 0 {
+            return false;
+        }
+        if !<T as const_num_traits::One>::is_one(&self.limbs[0]) {
+            return false;
+        }
+        let mut i = 1;
+        while i < self.len as usize {
+            if !super::is_zero(&self.limbs[i]) {
+                return false;
+            }
+            i += 1;
+        }
+        true
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Default for HeaplessBigInt<T, CAP, P> {
+    #[inline]
+    fn default() -> Self {
+        <Self as Zero>::zero()
+    }
+}
+
+// ── const_num_traits::ConstZero / ConstOne ──
+//
+// Declared as `const` items so downstream can use them in const
+// expressions. `ConstOne::ONE` needs a mutable-array initialisation
+// step, which requires a helper `const fn` on stable.
+
+impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
+    #[inline]
+    const fn const_zero() -> Self {
+        Self {
+            limbs: [<T as ConstZero>::ZERO; CAP],
+            len: 0,
+            _p: PhantomData,
+        }
+    }
+
+    #[inline]
+    const fn const_one() -> Self {
+        assert!(CAP >= 1, "HeaplessBigInt::ONE requires CAP >= 1");
+        let mut limbs = [<T as ConstZero>::ZERO; CAP];
+        limbs[0] = <T as ConstOne>::ONE;
+        Self {
+            limbs,
+            len: 1,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> ConstZero for HeaplessBigInt<T, CAP, P> {
+    const ZERO: Self = Self::const_zero();
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> ConstOne for HeaplessBigInt<T, CAP, P> {
+    const ONE: Self = Self::const_one();
+}

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -15,7 +15,7 @@ use core::marker::PhantomData;
 impl<T: MachineWord, const CAP: usize, P: Personality> Zero for HeaplessBigInt<T, CAP, P> {
     #[inline]
     fn zero() -> Self {
-        Self::new_zero_with_len(0)
+        Self::const_zero()
     }
 
     #[inline]
@@ -59,14 +59,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> One for HeaplessBigInt<T,
     #[inline]
     fn one() -> Self {
         let () = <Self as AssertCapFits>::CHECK;
-        assert!(CAP >= 1, "HeaplessBigInt::one requires CAP >= 1");
-        let mut limbs = [zero::<T>(); CAP];
-        limbs[0] = <T as ConstOne>::ONE;
-        Self {
-            limbs,
-            len: 1,
-            _p: PhantomData,
-        }
+        Self::const_one()
     }
 
     #[inline]

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -2,9 +2,8 @@
 //!
 //! - `Zero`: mathematical zero, `len = 0`.
 //! - `One`: `len = 1`, `limbs[0] = T::ONE`.
-//! - `Default = Zero` (spec's landed shape after `modmath-cios 0.1.2`
-//!   introduced `cios_accumulator(&self)` — the CIOS full-CAP zero
-//!   is now a separate constructor, not `Default`).
+//! - `Default = Zero`. (The CIOS full-CAP zero is a separate constructor,
+//!   `cios_accumulator`, not `Default`.)
 
 use super::{AssertCapFits, HeaplessBigInt, zero};
 use crate::MachineWord;

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -58,7 +58,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Zero for HeaplessBigInt<T
 impl<T: MachineWord, const CAP: usize, P: Personality> One for HeaplessBigInt<T, CAP, P> {
     #[inline]
     fn one() -> Self {
-        let _ = <Self as AssertCapFits>::CHECK;
+        let () = <Self as AssertCapFits>::CHECK;
         assert!(CAP >= 1, "HeaplessBigInt::one requires CAP >= 1");
         let mut limbs = [zero::<T>(); CAP];
         limbs[0] = <T as ConstOne>::ONE;

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -7,7 +7,7 @@
 
 use super::{AssertCapFits, HeaplessBigInt, zero};
 use crate::MachineWord;
-use const_num_traits::{ConstOne, ConstZero, One, Personality, Zero};
+use const_num_traits::{ConstOne, ConstZero, One, Personality, PersonalityTag, Zero};
 use core::marker::PhantomData;
 
 // ── const_num_traits::Zero / One ──
@@ -20,18 +20,33 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Zero for HeaplessBigInt<T
 
     #[inline]
     fn is_zero(&self) -> bool {
-        // Value-based: any limb non-zero → non-zero. NCT-implicit (short-
-        // circuits on limb content). Ct callers use `CtIsZero::ct_is_zero`
-        // via a separate impl (added when needed).
-        let mut i = 0;
-        while i < self.len as usize {
-            if !super::is_zero(&self.limbs[i]) {
-                return false;
+        // Any limb non-zero → non-zero. `Nct` short-circuits; `Ct`
+        // OR-folds every limb so timing is value-independent (the returned
+        // `bool` is still branchable — see `CtIsZero::ct_is_zero` for the
+        // `Choice`-returning form). Limbs beyond `len` are zero by the
+        // zero-tail invariant, so scanning `0..len` suffices.
+        let n = self.len as usize;
+        match P::TAG {
+            PersonalityTag::Nct => {
+                let mut i = 0;
+                while i < n {
+                    if !super::is_zero(&self.limbs[i]) {
+                        return false;
+                    }
+                    i += 1;
+                }
+                true
             }
-            i += 1;
+            PersonalityTag::Ct => {
+                let mut acc = zero::<T>();
+                let mut i = 0;
+                while i < n {
+                    acc |= self.limbs[i];
+                    i += 1;
+                }
+                super::is_zero(&acc)
+            }
         }
-        // Zero-tail invariant means limbs beyond len are zero regardless.
-        true
     }
 
     #[inline]
@@ -61,21 +76,37 @@ impl<T: MachineWord, const CAP: usize, P: Personality> One for HeaplessBigInt<T,
 
     #[inline]
     fn is_one(&self) -> bool {
-        // NCT-implicit content scan.
-        if self.len == 0 {
+        // `len` is a public shape parameter, so branching on it is fine in
+        // both personalities. `Nct` short-circuits the limb scan; `Ct`
+        // folds `(limbs[0] ^ 1) | limbs[1] | …` with no early return.
+        let n = self.len as usize;
+        if n == 0 {
             return false;
         }
-        if !<T as const_num_traits::One>::is_one(&self.limbs[0]) {
-            return false;
-        }
-        let mut i = 1;
-        while i < self.len as usize {
-            if !super::is_zero(&self.limbs[i]) {
-                return false;
+        match P::TAG {
+            PersonalityTag::Nct => {
+                if !<T as const_num_traits::One>::is_one(&self.limbs[0]) {
+                    return false;
+                }
+                let mut i = 1;
+                while i < n {
+                    if !super::is_zero(&self.limbs[i]) {
+                        return false;
+                    }
+                    i += 1;
+                }
+                true
             }
-            i += 1;
+            PersonalityTag::Ct => {
+                let mut acc = self.limbs[0] ^ <T as ConstOne>::ONE;
+                let mut i = 1;
+                while i < n {
+                    acc |= self.limbs[i];
+                    i += 1;
+                }
+                super::is_zero(&acc)
+            }
         }
-        true
     }
 }
 

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -29,6 +29,8 @@ mod has_personality;
 mod identities;
 mod parity;
 mod shift;
+#[cfg(feature = "zeroize")]
+mod zeroize_impl;
 
 /// Fixed-capacity, runtime-length unsigned bignum.
 ///

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -60,7 +60,7 @@
 //! Behind the off-by-default `heapless-runtime-len` feature.
 
 use crate::MachineWord;
-use const_num_traits::{Nct, Personality};
+use const_num_traits::{Ct, Nct, Personality};
 use core::marker::PhantomData;
 
 mod arith;
@@ -145,21 +145,23 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
 
     /// Construct from a limb array + explicit `len`. Panics if `len > CAP`
     /// or if any limb at index `>= len` is non-zero (invariant check).
+    ///
+    /// The tail check runs in every build, not just under `debug_assertions`:
+    /// downstream arithmetic, equality, and `widened` all assume the tail is
+    /// zero, so a release build that skipped it would silently promote a
+    /// hidden limb into the value.
     #[inline]
     pub fn from_limbs(limbs: [T; CAP], len: u16) -> Self {
         let _ = <Self as AssertCapFits>::CHECK;
         assert!((len as usize) <= CAP);
-        #[cfg(debug_assertions)]
-        {
-            let mut i = len as usize;
-            while i < CAP {
-                assert!(
-                    is_zero(&limbs[i]),
-                    "HeaplessBigInt::from_limbs: zero-tail invariant violated at index {}",
-                    i
-                );
-                i += 1;
-            }
+        let mut i = len as usize;
+        while i < CAP {
+            assert!(
+                is_zero(&limbs[i]),
+                "HeaplessBigInt::from_limbs: zero-tail invariant violated at index {}",
+                i
+            );
+            i += 1;
         }
         Self {
             limbs,
@@ -243,8 +245,10 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Clone for HeaplessBigInt<
 
 impl<T: MachineWord, const CAP: usize, P: Personality> Copy for HeaplessBigInt<T, CAP, P> {}
 
-impl<T: MachineWord + core::fmt::Debug, const CAP: usize, P: Personality> core::fmt::Debug
-    for HeaplessBigInt<T, CAP, P>
+// Debug is personality-split like `FixedUInt`: `Nct` prints the limbs,
+// `Ct` is opaque so secret values never reach a formatter.
+impl<T: MachineWord + core::fmt::Debug, const CAP: usize> core::fmt::Debug
+    for HeaplessBigInt<T, CAP, Nct>
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
@@ -255,6 +259,12 @@ impl<T: MachineWord + core::fmt::Debug, const CAP: usize, P: Personality> core::
             &self.limbs[..self.len as usize],
             self.len,
         )
+    }
+}
+
+impl<T: MachineWord, const CAP: usize> core::fmt::Debug for HeaplessBigInt<T, CAP, Ct> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("HeaplessBigInt<…>")
     }
 }
 

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -19,6 +19,44 @@
 //! `zero_with_precision_of(&modulus)` — rather than seeding from an identity
 //! and letting it silently run narrow.
 //!
+//! # Width contract
+//!
+//! Every operation resolves at the *value* width `len·word_bits` and returns
+//! bit-for-bit what the same-width `FixedUInt` would — no op grows past
+//! `max(operand len)` or narrows the magnitude, and `CAP` never enters a
+//! result. The result `len` of each op:
+//!
+//! | operation | result `len` |
+//! |---|---|
+//! | `wrapping`/`overflowing`/`checked` `add`·`sub`·`mul`, `+` `-` `*` | `max(a.len, b.len)` |
+//! | `Shl` (`<<`) | `self.len` — high bits past the width are discarded |
+//! | `Shr` (`>>`) | `self.len` minus the whole-word shift |
+//! | `WideMul` / [`CarryingMul`](const_num_traits::CarryingMul) | `lo` and `hi` each `max(a.len, b.len)`; reconstruct `hi·2^(W·word_bits) + lo` |
+//! | `Div` (`/`), `Rem` (`%`) | `max(dividend.len, divisor.len)` |
+//! | `BitAnd` (`&`) | `min(a.len, b.len)` |
+//! | `BitOr` | `max(a.len, b.len)` |
+//! | [`widened`](HeaplessBigInt::widened) / `WithPrecision` | the requested width (grow-only) |
+//!
+//! ## Construction & serialization widths
+//!
+//! Constructors and byte I/O carry *different* widths for the same value —
+//! there is no single "natural" one for a runtime carrier. When the width
+//! matters, pick the row you mean, or pin afterward with `WithPrecision`:
+//!
+//! | path | width |
+//! |---|---|
+//! | `From<u8/u16/u32>` | `ceil(size_of::<uN>() / word)` — the source int's width |
+//! | inherent [`from_le_bytes`](HeaplessBigInt::from_le_bytes) / `from_be_bytes(&[u8])` | `ceil(slice.len() / word)` — the slice width |
+//! | [`new_zero_with_len`](HeaplessBigInt::new_zero_with_len) / [`from_limbs`](HeaplessBigInt::from_limbs) | exactly the given `len` |
+//! | `FromBytes` **trait** (`BytesHolder<T, CAP>`) | **`CAP`** — an owned holder can't be runtime-sized |
+//! | inherent [`to_le_bytes`](HeaplessBigInt::to_le_bytes) / `to_be_bytes(&mut [u8])` | value width (`len·word` bytes) |
+//! | `ToBytes` **trait** (`BytesHolder<T, CAP>`) | **`CAP`** — same reason |
+//!
+//! The trait (`ToBytes`/`FromBytes`) paths are capacity-width because their
+//! owned `Bytes` associated type is fixed-size — the intended shape for a
+//! full-precision operand (a modulus with `len == CAP`) and for round-tripping
+//! against `FixedUInt<T, CAP>`. For value-width bytes use the inherent methods.
+//!
 //! Behind the off-by-default `heapless-runtime-len` feature.
 
 use crate::MachineWord;

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -17,6 +17,10 @@ use const_num_traits::{Nct, Personality};
 use core::marker::PhantomData;
 
 mod arith;
+mod bits;
+mod bytes;
+#[cfg(feature = "cios")]
+mod cios;
 mod cmp;
 mod identities;
 mod shift;

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -29,6 +29,8 @@ mod has_personality;
 mod identities;
 mod parity;
 mod shift;
+#[cfg(any(feature = "nightly", feature = "use-unsafe"))]
+mod to_bytes;
 #[cfg(feature = "zeroize")]
 mod zeroize_impl;
 

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -139,14 +139,29 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         CAP
     }
 
-    /// Return a copy carried at `new_len` words. Widening only relabels
-    /// the width — the limbs in `[len, new_len)` are already zero by the
-    /// zero-tail invariant. Used by algorithms that need a fixed working
-    /// width wider than an operand (e.g. long division shifting the
-    /// divisor up). `new_len` must be `>= len` and `<= CAP`.
+    /// Return a copy carried at `new_len` words, pinning the operating
+    /// width without changing the value.
+    ///
+    /// Arithmetic here is width-driven: a `HeaplessBigInt` at `len = k`
+    /// behaves exactly like `FixedUInt<T, k>`, and every op resolves at
+    /// `max(operand len)`. So a value assembled from small pieces (e.g. an
+    /// accumulator seeded from [`zero`](const_num_traits::Zero::zero) then
+    /// added to a one-word digit) is a *narrow* type and wraps at that
+    /// narrow width. To carry it at a chosen width — the way you pick `N`
+    /// for `FixedUInt` — pin it here once; subsequent ops keep that width
+    /// because `max` preserves it. Widening only relabels the width: the
+    /// limbs in `[len, new_len)` are already zero by the zero-tail
+    /// invariant.
+    ///
+    /// Panics if `new_len < len` (this only widens) or `new_len > CAP`.
     #[inline]
-    pub(crate) fn widened(&self, new_len: u16) -> Self {
-        debug_assert!(new_len >= self.len && new_len as usize <= CAP);
+    #[must_use]
+    pub fn widened(&self, new_len: u16) -> Self {
+        assert!(
+            new_len >= self.len && new_len as usize <= CAP,
+            "widened: new_len {new_len} must be in [len {}, CAP {CAP}]",
+            self.len
+        );
         let mut out = *self;
         out.len = new_len;
         out

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -24,6 +24,7 @@ mod cios;
 mod cmp;
 mod div_rem;
 mod from_prim;
+mod has_personality;
 mod identities;
 mod parity;
 mod shift;

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -1,16 +1,25 @@
-//! Fixed-capacity, runtime-length unsigned bignum.
+//! Unsigned integer whose width is chosen at runtime, not by the type.
 //!
-//! Sibling type to [`FixedUInt`](crate::FixedUInt). Same `Personality`
-//! typestate (`Nct` / `Ct`), same `T: MachineWord` bound. The distinction:
-//! `CAP` is compile-time, `len` is a runtime shape parameter treated as
-//! public. Every arithmetic op iterates `0..self.len` (or
-//! `0..output.len()`), not `0..CAP`.
+//! A [`HeaplessBigInt<T, CAP>`](HeaplessBigInt) carried at `len = k` **is** a
+//! `k`-word integer and behaves bit-for-bit like
+//! [`FixedUInt<T, k>`](crate::FixedUInt): arithmetic wraps, `<<` truncates, and
+//! overflow is reported at the value's width — it is *not* a growable bignum.
+//! The only difference from `FixedUInt` is that the width is `len`, a runtime
+//! (public) shape parameter, rather than the const `N`. You pick `len` at
+//! construction the way you pick `N`; `CAP` is only the storage ceiling
+//! (`len <= CAP`), invisible to arithmetic. Every op iterates `0..self.len`,
+//! never `0..CAP`. Same `Personality` typestate (`Nct` / `Ct`) and
+//! `T: MachineWord` bound as `FixedUInt`.
 //!
-//! See `notes/HEAPLESS_BIGINT_SPEC_v3.md` for the full design record.
+//! Because the width is `len`, a value must be *constructed* at its intended
+//! width: `zero()` / `one()` / short decodes are minimal-width, so anywhere the
+//! operating width matters (accumulators, field elements, reduction targets)
+//! pin it from a witness with
+//! [`WithPrecision`](const_num_traits::WithPrecision) — e.g.
+//! `zero_with_precision_of(&modulus)` — rather than seeding from an identity
+//! and letting it silently run narrow.
 //!
-//! **Sketch / parked.** The full trait surface, CIOS integration, and
-//! CT-verify fixtures come later; this module covers the core basics
-//! needed to prototype modmath arithmetic against.
+//! Behind the off-by-default `heapless-runtime-len` feature.
 
 use crate::MachineWord;
 use const_num_traits::{Nct, Personality};
@@ -34,10 +43,14 @@ mod to_bytes;
 #[cfg(feature = "zeroize")]
 mod zeroize_impl;
 
-/// Fixed-capacity, runtime-length unsigned bignum.
+/// A `len`-word unsigned integer whose width is chosen at runtime.
 ///
-/// `CAP` is the maximum limb count (compile-time). `len` is the logical
-/// used-limb count (runtime). Invariants (enforced by the module):
+/// Behaves bit-for-bit like [`FixedUInt<T, len>`](crate::FixedUInt): every op
+/// resolves at the value's width (`len·word_bits`), never a growable bignum.
+/// `CAP` is the maximum limb count (compile-time storage ceiling); `len` is the
+/// logical used-limb count (runtime) and the operating width — the words in
+/// `[len, CAP)` do not exist for arithmetic. Invariants (enforced by the
+/// module):
 ///
 /// - `CAP <= u16::MAX as usize` (compile-time-asserted).
 /// - `(len as usize) <= CAP`.

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -139,6 +139,19 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         CAP
     }
 
+    /// Return a copy carried at `new_len` words. Widening only relabels
+    /// the width — the limbs in `[len, new_len)` are already zero by the
+    /// zero-tail invariant. Used by algorithms that need a fixed working
+    /// width wider than an operand (e.g. long division shifting the
+    /// divisor up). `new_len` must be `>= len` and `<= CAP`.
+    #[inline]
+    pub(crate) fn widened(&self, new_len: u16) -> Self {
+        debug_assert!(new_len >= self.len && new_len as usize <= CAP);
+        let mut out = *self;
+        out.len = new_len;
+        out
+    }
+
     /// Read-only view of the used limbs.
     #[inline]
     pub fn limbs(&self) -> &[T] {

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -18,6 +18,7 @@ use core::marker::PhantomData;
 
 mod arith;
 mod bits;
+mod bitwise;
 mod bytes;
 #[cfg(feature = "cios")]
 mod cios;

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -56,8 +56,6 @@
 //! owned `Bytes` associated type is fixed-size — the intended shape for a
 //! full-precision operand (a modulus with `len == CAP`) and for round-tripping
 //! against `FixedUInt<T, CAP>`. For value-width bytes use the inherent methods.
-//!
-//! Behind the off-by-default `heapless-runtime-len` feature.
 
 use crate::MachineWord;
 use const_num_traits::{Ct, Nct, Personality};
@@ -122,7 +120,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
     /// a public shape parameter from here on. Panics if `len > CAP`.
     #[inline]
     pub fn new_zero_with_len(len: u16) -> Self {
-        let _ = <Self as AssertCapFits>::CHECK;
+        let () = <Self as AssertCapFits>::CHECK;
         assert!(
             (len as usize) <= CAP,
             "HeaplessBigInt::new_zero_with_len: len {} > CAP {}",
@@ -152,7 +150,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
     /// hidden limb into the value.
     #[inline]
     pub fn from_limbs(limbs: [T; CAP], len: u16) -> Self {
-        let _ = <Self as AssertCapFits>::CHECK;
+        let () = <Self as AssertCapFits>::CHECK;
         assert!((len as usize) <= CAP);
         let mut i = len as usize;
         while i < CAP {

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -115,7 +115,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> AssertCapFits for Heaples
     );
 }
 
-// ── Constructors (all Class A: shape-setting from public parameters) ──
+// ── Constructors (shape-setting from public parameters) ──
 
 impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
     /// Zero with a caller-supplied logical length. The `len` is treated as

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -1,0 +1,178 @@
+//! Fixed-capacity, runtime-length unsigned bignum.
+//!
+//! Sibling type to [`FixedUInt`](crate::FixedUInt). Same `Personality`
+//! typestate (`Nct` / `Ct`), same `T: MachineWord` bound. The distinction:
+//! `CAP` is compile-time, `len` is a runtime shape parameter treated as
+//! public. Every arithmetic op iterates `0..self.len` (or
+//! `0..output.len()`), not `0..CAP`.
+//!
+//! See `notes/HEAPLESS_BIGINT_SPEC_v3.md` for the full design record.
+//!
+//! **Sketch / parked.** The full trait surface, CIOS integration, and
+//! CT-verify fixtures come later; this module covers the core basics
+//! needed to prototype modmath arithmetic against.
+
+use crate::MachineWord;
+use const_num_traits::{Nct, Personality};
+use core::marker::PhantomData;
+
+mod arith;
+mod cmp;
+mod identities;
+
+/// Fixed-capacity, runtime-length unsigned bignum.
+///
+/// `CAP` is the maximum limb count (compile-time). `len` is the logical
+/// used-limb count (runtime). Invariants (enforced by the module):
+///
+/// - `CAP <= u16::MAX as usize` (compile-time-asserted).
+/// - `(len as usize) <= CAP`.
+/// - `limbs[len as usize..CAP]` is all zero at every observable state.
+/// - `len` is set only from public shape parameters, never from limb content.
+pub struct HeaplessBigInt<T, const CAP: usize, P: Personality = Nct>
+where
+    T: MachineWord,
+{
+    pub(crate) limbs: [T; CAP],
+    pub(crate) len: u16,
+    pub(crate) _p: PhantomData<P>,
+}
+
+/// Compile-time assertion that `CAP` fits in `u16` (the `len` field type).
+pub(crate) trait AssertCapFits {
+    const CHECK: ();
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> AssertCapFits for HeaplessBigInt<T, CAP, P> {
+    const CHECK: () = assert!(
+        CAP <= u16::MAX as usize,
+        "HeaplessBigInt: CAP exceeds u16::MAX; len type cannot represent this capacity"
+    );
+}
+
+// ── Constructors (all Class A: shape-setting from public parameters) ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
+    /// Zero with a caller-supplied logical length. The `len` is treated as
+    /// a public shape parameter from here on. Panics if `len > CAP`.
+    #[inline]
+    pub fn new_zero_with_len(len: u16) -> Self {
+        let _ = <Self as AssertCapFits>::CHECK;
+        assert!(
+            (len as usize) <= CAP,
+            "HeaplessBigInt::new_zero_with_len: len {} > CAP {}",
+            len,
+            CAP,
+        );
+        Self {
+            limbs: [zero::<T>(); CAP],
+            len,
+            _p: PhantomData,
+        }
+    }
+
+    /// Full-capacity zero: `len = CAP`. Used where an algorithm needs a
+    /// pre-sized workspace (CIOS accumulator, product buffer).
+    #[inline]
+    pub fn zero_full_cap() -> Self {
+        Self::new_zero_with_len(CAP as u16)
+    }
+
+    /// Construct from a limb array + explicit `len`. Panics if `len > CAP`
+    /// or if any limb at index `>= len` is non-zero (invariant check).
+    #[inline]
+    pub fn from_limbs(limbs: [T; CAP], len: u16) -> Self {
+        let _ = <Self as AssertCapFits>::CHECK;
+        assert!((len as usize) <= CAP);
+        #[cfg(debug_assertions)]
+        {
+            let mut i = len as usize;
+            while i < CAP {
+                assert!(
+                    is_zero(&limbs[i]),
+                    "HeaplessBigInt::from_limbs: zero-tail invariant violated at index {}",
+                    i
+                );
+                i += 1;
+            }
+        }
+        Self {
+            limbs,
+            len,
+            _p: PhantomData,
+        }
+    }
+}
+
+// ── Accessors ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
+    /// Logical length in used limbs. Public shape parameter.
+    #[inline]
+    pub const fn len(&self) -> u16 {
+        self.len
+    }
+
+    /// True iff `len == 0` (mathematical zero shape).
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Maximum limb count.
+    #[inline]
+    pub const fn capacity(&self) -> usize {
+        CAP
+    }
+
+    /// Read-only view of the used limbs.
+    #[inline]
+    pub fn limbs(&self) -> &[T] {
+        &self.limbs[..self.len as usize]
+    }
+
+    /// Full-buffer view including the zero tail. Only meaningful under
+    /// the zero-tail invariant.
+    #[inline]
+    pub fn all_limbs(&self) -> &[T; CAP] {
+        &self.limbs
+    }
+}
+
+// ── Copy / Clone ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Clone for HeaplessBigInt<T, CAP, P> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Copy for HeaplessBigInt<T, CAP, P> {}
+
+impl<T: MachineWord + core::fmt::Debug, const CAP: usize, P: Personality> core::fmt::Debug
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "HeaplessBigInt<{}, {}, _>{{ limbs: {:?}, len: {} }}",
+            core::any::type_name::<T>(),
+            CAP,
+            &self.limbs[..self.len as usize],
+            self.len,
+        )
+    }
+}
+
+// ── Internal helpers ──
+
+#[inline]
+pub(crate) fn zero<T: MachineWord>() -> T {
+    <T as const_num_traits::ConstZero>::ZERO
+}
+
+#[inline]
+pub(crate) fn is_zero<T: MachineWord>(v: &T) -> bool {
+    <T as const_num_traits::Zero>::is_zero(v)
+}

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -22,7 +22,10 @@ mod bytes;
 #[cfg(feature = "cios")]
 mod cios;
 mod cmp;
+mod div_rem;
+mod from_prim;
 mod identities;
+mod parity;
 mod shift;
 
 /// Fixed-capacity, runtime-length unsigned bignum.

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -19,6 +19,7 @@ use core::marker::PhantomData;
 mod arith;
 mod cmp;
 mod identities;
+mod shift;
 
 /// Fixed-capacity, runtime-length unsigned bignum.
 ///

--- a/src/heapless/parity.rs
+++ b/src/heapless/parity.rs
@@ -1,0 +1,26 @@
+//! `const_num_traits::Parity` for `HeaplessBigInt`.
+//!
+//! Parity is a single-bit inspection of the lowest limb — no full-value
+//! scan. For `len == 0` (mathematical zero shape) the answer is
+//! deterministically even.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{Parity, Personality};
+
+impl<T, const CAP: usize, P: Personality> Parity for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + Parity,
+{
+    fn is_odd(self) -> bool {
+        if self.len == 0 {
+            false
+        } else {
+            self.limbs[0].is_odd()
+        }
+    }
+
+    fn is_even(self) -> bool {
+        !self.is_odd()
+    }
+}

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -4,8 +4,12 @@
 //! from operand `len` + shift amount, both public shape parameters. The
 //! shape math:
 //!
-//! - `Shl`: `out_len = min(ceil((self.len * word_bits + bits) / word_bits), CAP)`.
-//!   Bits that would need `CAP + 1` limbs are discarded (wrapping).
+//! - `Shl`: width-preserving — `out_len = self.len`, bits shifted past the
+//!   operand width are discarded (`x << bits mod 2^(len·word_bits)`), so a
+//!   value at `len = k` shifts exactly like `FixedUInt<T, k>`. `CAP` never
+//!   enters; the words beyond `len` do not exist. A caller wanting the
+//!   shifted value to occupy more words constructs it at the wider width
+//!   first (as `div_rem` does).
 //! - `Shr`: `out_len = self.len.saturating_sub(bits / word_bits)`. The
 //!   top limb may become zero — that's fine under the zero-tail invariant
 //!   and downstream can trim explicitly if needed (NCT-only).
@@ -27,23 +31,14 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Shl<usize> for HeaplessBi
         let word_shift = bits / word_bits;
         let bit_shift = bits % word_bits;
 
-        // out_len: enough to hold self.len limbs shifted by word_shift,
-        // plus one extra if any bits carry across a word boundary.
-        let extra = if bit_shift > 0 { 1 } else { 0 };
-        let natural = self.len as usize + word_shift + extra;
-        let out_len = core::cmp::min(natural, CAP);
-
+        // Width-preserving: the result occupies the operand's own `len`
+        // words; anything shifted past that is discarded, matching a
+        // fixed-width `<<`. `CAP` never enters.
+        let out_len = self.len as usize;
         let mut limbs = [zero::<T>(); CAP];
-        if word_shift >= CAP {
-            return Self {
-                limbs,
-                len: 0,
-                _p: PhantomData,
-            };
-        }
 
         let mut i = 0;
-        while i < self.len as usize {
+        while i < out_len {
             let dst_lo = i + word_shift;
             if dst_lo < out_len {
                 let lo = self.limbs[i] << bit_shift;

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -17,7 +17,7 @@ use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
 use const_num_traits::Personality;
 use core::marker::PhantomData;
-use core::ops::{Shl, Shr};
+use core::ops::{Shl, ShlAssign, Shr, ShrAssign};
 
 impl<T: MachineWord, const CAP: usize, P: Personality> Shl<usize> for HeaplessBigInt<T, CAP, P> {
     type Output = Self;
@@ -64,6 +64,22 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Shl<usize> for HeaplessBi
             len: out_len as u16,
             _p: PhantomData,
         }
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> ShlAssign<usize>
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn shl_assign(&mut self, bits: usize) {
+        *self = *self << bits;
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> ShrAssign<usize>
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn shr_assign(&mut self, bits: usize) {
+        *self = *self >> bits;
     }
 }
 

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -40,12 +40,12 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Shl<usize> for HeaplessBi
             let dst_lo = i + word_shift;
             if dst_lo < out_len {
                 let lo = self.limbs[i] << bit_shift;
-                limbs[dst_lo] = limbs[dst_lo] | lo;
+                limbs[dst_lo] |= lo;
                 if bit_shift > 0 {
                     let dst_hi = dst_lo + 1;
                     if dst_hi < out_len {
                         let hi = self.limbs[i] >> (word_bits - bit_shift);
-                        limbs[dst_hi] = limbs[dst_hi] | hi;
+                        limbs[dst_hi] |= hi;
                     }
                 }
             }

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -1,0 +1,108 @@
+//! `Shl<usize>` / `Shr<usize>` for `HeaplessBigInt`.
+//!
+//! Bit-count shifts by a public `usize` amount. Output `len` is derived
+//! from operand `len` + shift amount, both public shape parameters. The
+//! shape math:
+//!
+//! - `Shl`: `out_len = min(ceil((self.len * word_bits + bits) / word_bits), CAP)`.
+//!   Bits that would need `CAP + 1` limbs are discarded (wrapping).
+//! - `Shr`: `out_len = self.len.saturating_sub(bits / word_bits)`. The
+//!   top limb may become zero — that's fine under the zero-tail invariant
+//!   and downstream can trim explicitly if needed (NCT-only).
+//!
+//! Iteration count is derived from `self.len` + shift amount — both
+//! public — so the Nct and Ct arms share the same body.
+
+use super::{HeaplessBigInt, zero};
+use crate::MachineWord;
+use const_num_traits::Personality;
+use core::marker::PhantomData;
+use core::ops::{Shl, Shr};
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Shl<usize> for HeaplessBigInt<T, CAP, P> {
+    type Output = Self;
+
+    fn shl(self, bits: usize) -> Self::Output {
+        let word_bits = core::mem::size_of::<T>() * 8;
+        let word_shift = bits / word_bits;
+        let bit_shift = bits % word_bits;
+
+        // out_len: enough to hold self.len limbs shifted by word_shift,
+        // plus one extra if any bits carry across a word boundary.
+        let extra = if bit_shift > 0 { 1 } else { 0 };
+        let natural = self.len as usize + word_shift + extra;
+        let out_len = core::cmp::min(natural, CAP);
+
+        let mut limbs = [zero::<T>(); CAP];
+        if word_shift >= CAP {
+            return Self {
+                limbs,
+                len: 0,
+                _p: PhantomData,
+            };
+        }
+
+        let mut i = 0;
+        while i < self.len as usize {
+            let dst_lo = i + word_shift;
+            if dst_lo < out_len {
+                let lo = self.limbs[i] << bit_shift;
+                limbs[dst_lo] = limbs[dst_lo] | lo;
+                if bit_shift > 0 {
+                    let dst_hi = dst_lo + 1;
+                    if dst_hi < out_len {
+                        let hi = self.limbs[i] >> (word_bits - bit_shift);
+                        limbs[dst_hi] = limbs[dst_hi] | hi;
+                    }
+                }
+            }
+            i += 1;
+        }
+
+        Self {
+            limbs,
+            len: out_len as u16,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Shr<usize> for HeaplessBigInt<T, CAP, P> {
+    type Output = Self;
+
+    fn shr(self, bits: usize) -> Self::Output {
+        let word_bits = core::mem::size_of::<T>() * 8;
+        let word_shift = bits / word_bits;
+        let bit_shift = bits % word_bits;
+
+        let mut limbs = [zero::<T>(); CAP];
+        if word_shift >= self.len as usize {
+            return Self {
+                limbs,
+                len: 0,
+                _p: PhantomData,
+            };
+        }
+
+        let out_len = self.len as usize - word_shift;
+
+        let mut i = 0;
+        while i < out_len {
+            let src_lo = i + word_shift;
+            let lo = self.limbs[src_lo] >> bit_shift;
+            let hi = if bit_shift > 0 && src_lo + 1 < self.len as usize {
+                self.limbs[src_lo + 1] << (word_bits - bit_shift)
+            } else {
+                zero::<T>()
+            };
+            limbs[i] = lo | hi;
+            i += 1;
+        }
+
+        Self {
+            limbs,
+            len: out_len as u16,
+            _p: PhantomData,
+        }
+    }
+}

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -31,9 +31,7 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Shl<usize> for HeaplessBi
         let word_shift = bits / word_bits;
         let bit_shift = bits % word_bits;
 
-        // Width-preserving: the result occupies the operand's own `len`
-        // words; anything shifted past that is discarded, matching a
-        // fixed-width `<<`. `CAP` never enters.
+        // Width-preserving: out_len = self.len (see module doc).
         let out_len = self.len as usize;
         let mut limbs = [zero::<T>(); CAP];
 

--- a/src/heapless/to_bytes.rs
+++ b/src/heapless/to_bytes.rs
@@ -6,11 +6,19 @@
 //! `BytesHolder` already carries, so this module rides the same
 //! `nightly | use-unsafe` gate that guards `BytesHolder`.
 //!
-//! The representation is **full container width** (`CAP * size_of::<T>()`
-//! bytes): all `CAP` limbs are serialised, high (zero-tail) limbs
-//! producing leading zero bytes for BE / trailing for LE. This matches
-//! `FixedUInt<T, CAP>`'s byte shape, so a modmath consumer generic over
-//! the carrier round-trips a modulus/scalar identically on either type.
+//! The `ToBytes` representation is **capacity-width** (`CAP *
+//! size_of::<T>()` bytes): all `CAP` limbs are serialised, high
+//! (zero-tail) limbs producing leading zero bytes for BE / trailing for
+//! LE. This is the one place the carrier's `CAP` is intentionally
+//! exposed — an *owned* fixed holder cannot be sized to the runtime
+//! width — so it necessarily reports capacity, not the value's width.
+//! It's the right shape for a full-precision operand (a crypto modulus
+//! is constructed at `len == CAP`, so capacity == width there) and it
+//! matches `FixedUInt<T, CAP>`'s bytes, letting a carrier-generic
+//! consumer round-trip a modulus identically on either type. A caller
+//! that needs **width-based** (`len * word_size`) bytes uses the
+//! inherent `to_be_bytes(&mut [u8]) -> &[u8]` / `to_le_bytes` instead,
+//! which serialise only the value's own words.
 
 use super::HeaplessBigInt;
 use crate::MachineWord;

--- a/src/heapless/to_bytes.rs
+++ b/src/heapless/to_bytes.rs
@@ -9,16 +9,13 @@
 //! The `ToBytes` representation is **capacity-width** (`CAP *
 //! size_of::<T>()` bytes): all `CAP` limbs are serialised, high
 //! (zero-tail) limbs producing leading zero bytes for BE / trailing for
-//! LE. This is the one place the carrier's `CAP` is intentionally
-//! exposed — an *owned* fixed holder cannot be sized to the runtime
-//! width — so it necessarily reports capacity, not the value's width.
-//! It's the right shape for a full-precision operand (a crypto modulus
-//! is constructed at `len == CAP`, so capacity == width there) and it
-//! matches `FixedUInt<T, CAP>`'s bytes, letting a carrier-generic
-//! consumer round-trip a modulus identically on either type. A caller
-//! that needs **width-based** (`len * word_size`) bytes uses the
-//! inherent `to_be_bytes(&mut [u8]) -> &[u8]` / `to_le_bytes` instead,
-//! which serialise only the value's own words.
+//! LE. This is the one place the carrier's `CAP` is intentionally exposed:
+//! an *owned* fixed holder cannot be sized to the runtime width, so it
+//! reports capacity. That matches `FixedUInt<T, CAP>`'s bytes — a
+//! carrier-generic consumer round-trips a full-precision operand (e.g. a
+//! crypto modulus, constructed at `len == CAP`) identically on either type.
+//! A caller that needs **width-based** (`len * word_size`) bytes uses the
+//! inherent `to_be_bytes(&mut [u8]) -> &[u8]` / `to_le_bytes` instead.
 
 use super::HeaplessBigInt;
 use crate::MachineWord;
@@ -32,8 +29,7 @@ where
     // Full-width big-endian holder: highest limb first, each limb's own
     // bytes big-endian. Byte writes go through `as_byte_slice_mut` so the
     // sequence is host-endianness-independent (the `[T; CAP]` typing is
-    // incidental storage for the byte pattern). Zip byte-loop copy — no
-    // `copy_from_slice` length assert to fold.
+    // incidental storage for the byte pattern).
     fn holder_be(&self) -> BytesHolder<T, CAP> {
         let mut ret = BytesHolder::default();
         let word_size = core::mem::size_of::<T>();
@@ -67,11 +63,9 @@ where
     }
 }
 
-/// **Capacity-width** serialization: `CAP · size_of::<T>()` bytes (all `CAP`
-/// limbs, zero-tail included), because the owned `Bytes` holder is fixed-size.
-/// For value-width (`len·word`) bytes use the inherent
-/// [`to_le_bytes`](HeaplessBigInt::to_le_bytes) / `to_be_bytes(&mut [u8])`. See
-/// the construction-width table in the [module docs](super).
+/// **Capacity-width** serialization — see the [module docs](super). For
+/// value-width bytes use the inherent
+/// [`to_le_bytes`](HeaplessBigInt::to_le_bytes) / `to_be_bytes(&mut [u8])`.
 impl<T, const CAP: usize, P: Personality> ToBytes for HeaplessBigInt<T, CAP, P>
 where
     T: MachineWord + core::fmt::Debug,
@@ -101,20 +95,18 @@ where
     }
 }
 
-/// **Capacity-width** deserialization: the fixed-size `BytesHolder` yields a
-/// value at `len == CAP`. To parse a shorter fixed encoding at its own width,
-/// use the inherent [`from_le_bytes`](HeaplessBigInt::from_le_bytes) /
-/// `from_be_bytes(&[u8])` on a slice of the exact length. See the
-/// construction-width table in the [module docs](super).
+/// **Capacity-width** deserialization — the fixed-size `BytesHolder` yields a
+/// value at `len == CAP` (see the [module docs](super)). To parse a shorter
+/// fixed encoding at its own width, use the inherent
+/// [`from_le_bytes`](HeaplessBigInt::from_le_bytes) / `from_be_bytes(&[u8])`
+/// on a slice of the exact length.
 impl<T, const CAP: usize, P: Personality> FromBytes for HeaplessBigInt<T, CAP, P>
 where
     T: MachineWord + core::fmt::Debug,
 {
     type Bytes = BytesHolder<T, CAP>;
     fn from_be_bytes(bytes: &Self::Bytes) -> Self {
-        // `as_ref()` yields the full `CAP * word_size` byte sequence the
-        // holder was built from; the inherent slice reader reconstructs
-        // the value (len = CAP).
+        // Reconstructs at len = CAP from the holder's full byte sequence.
         Self::from_be_bytes(bytes.as_ref())
     }
     fn from_le_bytes(bytes: &Self::Bytes) -> Self {

--- a/src/heapless/to_bytes.rs
+++ b/src/heapless/to_bytes.rs
@@ -67,6 +67,11 @@ where
     }
 }
 
+/// **Capacity-width** serialization: `CAP · size_of::<T>()` bytes (all `CAP`
+/// limbs, zero-tail included), because the owned `Bytes` holder is fixed-size.
+/// For value-width (`len·word`) bytes use the inherent
+/// [`to_le_bytes`](HeaplessBigInt::to_le_bytes) / `to_be_bytes(&mut [u8])`. See
+/// the construction-width table in the [module docs](super).
 impl<T, const CAP: usize, P: Personality> ToBytes for HeaplessBigInt<T, CAP, P>
 where
     T: MachineWord + core::fmt::Debug,
@@ -96,6 +101,11 @@ where
     }
 }
 
+/// **Capacity-width** deserialization: the fixed-size `BytesHolder` yields a
+/// value at `len == CAP`. To parse a shorter fixed encoding at its own width,
+/// use the inherent [`from_le_bytes`](HeaplessBigInt::from_le_bytes) /
+/// `from_be_bytes(&[u8])` on a slice of the exact length. See the
+/// construction-width table in the [module docs](super).
 impl<T, const CAP: usize, P: Personality> FromBytes for HeaplessBigInt<T, CAP, P>
 where
     T: MachineWord + core::fmt::Debug,

--- a/src/heapless/to_bytes.rs
+++ b/src/heapless/to_bytes.rs
@@ -1,0 +1,105 @@
+//! `const_num_traits::ToBytes` / `FromBytes` for `HeaplessBigInt`.
+//!
+//! Reuses `FixedUInt`'s `BytesHolder<T, CAP>` as the owned `Bytes`
+//! associated type — on stable, an owned byte holder for a `T`/`CAP`-
+//! generic type is only representable via the `unsafe` slice reinterpret
+//! `BytesHolder` already carries, so this module rides the same
+//! `nightly | use-unsafe` gate that guards `BytesHolder`.
+//!
+//! The representation is **full container width** (`CAP * size_of::<T>()`
+//! bytes): all `CAP` limbs are serialised, high (zero-tail) limbs
+//! producing leading zero bytes for BE / trailing for LE. This matches
+//! `FixedUInt<T, CAP>`'s byte shape, so a modmath consumer generic over
+//! the carrier round-trips a modulus/scalar identically on either type.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use crate::fixeduint::BytesHolder;
+use const_num_traits::{FromBytes, Personality, ToBytes};
+
+impl<T, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + core::fmt::Debug,
+{
+    // Full-width big-endian holder: highest limb first, each limb's own
+    // bytes big-endian. Byte writes go through `as_byte_slice_mut` so the
+    // sequence is host-endianness-independent (the `[T; CAP]` typing is
+    // incidental storage for the byte pattern). Zip byte-loop copy — no
+    // `copy_from_slice` length assert to fold.
+    fn holder_be(&self) -> BytesHolder<T, CAP> {
+        let mut ret = BytesHolder::default();
+        let word_size = core::mem::size_of::<T>();
+        for (chunk, word) in ret
+            .as_byte_slice_mut()
+            .chunks_exact_mut(word_size)
+            .zip(self.limbs.iter().rev())
+        {
+            let word_bytes = word.to_be_bytes();
+            for (dst, src) in chunk.iter_mut().zip(word_bytes.as_ref()) {
+                *dst = *src;
+            }
+        }
+        ret
+    }
+
+    fn holder_le(&self) -> BytesHolder<T, CAP> {
+        let mut ret = BytesHolder::default();
+        let word_size = core::mem::size_of::<T>();
+        for (chunk, word) in ret
+            .as_byte_slice_mut()
+            .chunks_exact_mut(word_size)
+            .zip(self.limbs.iter())
+        {
+            let word_bytes = word.to_le_bytes();
+            for (dst, src) in chunk.iter_mut().zip(word_bytes.as_ref()) {
+                *dst = *src;
+            }
+        }
+        ret
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> ToBytes for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + core::fmt::Debug,
+{
+    type Bytes = BytesHolder<T, CAP>;
+    fn to_be_bytes(self) -> Self::Bytes {
+        self.holder_be()
+    }
+    fn to_le_bytes(self) -> Self::Bytes {
+        self.holder_le()
+    }
+}
+
+// `ToBytes for &HeaplessBigInt` — mirrors `FixedUInt`; lets a caller
+// serialise without moving the value (relevant to Ct roles where the
+// operand lives behind a wrapper).
+impl<T, const CAP: usize, P: Personality> ToBytes for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + core::fmt::Debug,
+{
+    type Bytes = BytesHolder<T, CAP>;
+    fn to_be_bytes(self) -> Self::Bytes {
+        self.holder_be()
+    }
+    fn to_le_bytes(self) -> Self::Bytes {
+        self.holder_le()
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> FromBytes for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + core::fmt::Debug,
+{
+    type Bytes = BytesHolder<T, CAP>;
+    fn from_be_bytes(bytes: &Self::Bytes) -> Self {
+        // `as_ref()` yields the full `CAP * word_size` byte sequence the
+        // holder was built from; the inherent slice reader reconstructs
+        // the value (len = CAP).
+        Self::from_be_bytes(bytes.as_ref())
+    }
+    fn from_le_bytes(bytes: &Self::Bytes) -> Self {
+        Self::from_le_bytes(bytes.as_ref())
+    }
+}

--- a/src/heapless/zeroize_impl.rs
+++ b/src/heapless/zeroize_impl.rs
@@ -1,0 +1,17 @@
+//! `zeroize::DefaultIsZeroes` for `HeaplessBigInt`.
+//!
+//! `Default` is the mathematical zero (all limbs zero, `len = 0`) and the
+//! type is `Copy` with no `Drop`, so the all-zero bit pattern is a valid
+//! `Default` — the `DefaultIsZeroes` contract. This is the marker
+//! downstream secret (Ct) roles bind on (`Zeroize` follows via the
+//! blanket impl), and what lets modmath's `MontStorage` satisfy its
+//! `Zeroize` bound.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::Personality;
+
+impl<T: MachineWord, const CAP: usize, P: Personality> zeroize::DefaultIsZeroes
+    for HeaplessBigInt<T, CAP, P>
+{
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,5 +64,13 @@ pub mod fixeduint;
 /// Machine word and doubleword
 mod machineword;
 
+/// Fixed-capacity, runtime-length bignum sketch. Parked; see the module
+/// header for the design record.
+#[cfg(feature = "heapless-runtime-len")]
+pub mod heapless;
+
 pub use crate::fixeduint::{FixedUInt, NonZeroFixedUInt};
 pub use crate::machineword::MachineWord;
+
+#[cfg(feature = "heapless-runtime-len")]
+pub use crate::heapless::HeaplessBigInt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,13 +88,10 @@ pub mod fixeduint;
 /// Machine word and doubleword
 mod machineword;
 
-/// Fixed-capacity, runtime-length bignum sketch. Parked; see the module
-/// header for the design record.
-#[cfg(feature = "heapless-runtime-len")]
+/// Fixed-capacity, runtime-length unsigned bignum. See the module header.
 pub mod heapless;
 
 pub use crate::fixeduint::{FixedUInt, NonZeroFixedUInt};
 pub use crate::machineword::MachineWord;
 
-#[cfg(feature = "heapless-runtime-len")]
 pub use crate::heapless::HeaplessBigInt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,30 @@
 //! with a compile-time `Personality` (`Nct` or `Ct`) that selects between
 //! value-dependent and constant-time impl bodies at every operator.
 //!
+//! ## Personality and constant-time operations
+//!
+//! `P` is a typestate: `Nct` (non-constant-time, the default) or `Ct`
+//! (constant-time). `Nct` bodies may branch on operand *values*; `Ct` bodies
+//! may not. Operations whose only sensible implementation has **data-dependent
+//! control flow** are therefore provided for `Nct` only — the `Ct` type simply
+//! does not implement the trait, so a misuse is a compile-time *"trait bound
+//! not satisfied"* error, never a silent timing leak. That error names the
+//! missing std/`num-traits` trait (e.g. `FixedUInt<u8, 4, Ct>: Div is not
+//! satisfied`); this table is the explanation, since a custom `#[diagnostic]`
+//! message cannot be attached to a trait defined in another crate.
+//!
+//! | operation | `Nct` | `Ct` | why `Ct` omits it |
+//! |---|---|---|---|
+//! | `+` `-` `*`, `wrapping`/`overflowing`/`carrying`, bit ops, shifts, compare, byte I/O | ✅ | ✅ | branchless |
+//! | `/` `%` (`Div`/`Rem`/`*Assign`), `CheckedDiv`, `Euclid` | ✅ | — | long division early-exits on operand bits |
+//! | `Ilog`/`Ilog2`/`Ilog10`, `Isqrt` | ✅ | — | data-dependent iteration / division |
+//! | `Num::from_str_radix`, `FromStr` | ✅ | — | parse length and digit branches depend on the input |
+//! | `CheckedAdd`/`CheckedMul` on `HeaplessBigInt` | ✅ | — | value-aware overflow report scans content |
+//!
+//! A `Ct` value that needs `x mod modulus` uses Montgomery reduction (the CIOS
+//! driver), not `/` / `%`. Every operator not in the omitted rows has one body
+//! shared by both personalities.
+//!
 //! Basic usage:
 //! ```
 //! use fixed_bigint::FixedUInt;

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -3,6 +3,11 @@
 //! Zero/One/Default line up, and Ct paths (subtle::ConstantTimeEq) agree
 //! with the value.
 
+// The `to_from_bytes` submodule exercises `FixedUInt`/`HeaplessBigInt`'s
+// const `ToBytes`/`FromBytes`, whose `generic_const_exprs` bound is viral;
+// a downstream crate (this test) must enable the feature itself on nightly.
+#![cfg_attr(feature = "nightly", feature(generic_const_exprs))]
+#![cfg_attr(feature = "nightly", allow(incomplete_features))]
 // Several tests deliberately spell out `&a op &b` (and the mixed receiver
 // forms) to check that every operator impl — value/value, value/ref,
 // ref/value, ref/ref — agrees. That is the point, so `op_ref` is allowed.

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -209,6 +209,29 @@ fn wrapping_ops_do_not_grow_width() {
     assert_eq!(r.limbs()[0], 2u32.wrapping_sub(35)); // wraps at 2^32
 }
 
+#[test]
+fn carrying_add_reports_width_carry_without_growing() {
+    use const_num_traits::CarryingAdd;
+    // Symmetric to borrowing_sub: value-width add-with-carry. The carry
+    // out of the width is a flag, not a grown limb — what wide-REDC needs.
+    // u32::MAX + 1 at len 1 → (0, carry=true), stays len 1.
+    let a = H4u32Nct::from_limbs([u32::MAX, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
+    let (sum, carry) = CarryingAdd::carrying_add(a, b, false);
+    assert!(carry);
+    assert_eq!(sum.len(), 1);
+    assert_eq!(sum.limbs()[0], 0);
+
+    // carry_in threads through: 5 + 2 + carry = 8, no carry-out.
+    let (s2, c2) = CarryingAdd::carrying_add(
+        H4u32Nct::from_limbs([5, 0, 0, 0], 1),
+        H4u32Nct::from_limbs([2, 0, 0, 0], 1),
+        true,
+    );
+    assert!(!c2);
+    assert_eq!(s2.limbs()[0], 8);
+}
+
 // ── PartialEq / PartialOrd (value-based) ──
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -5,9 +5,12 @@
 
 #![cfg(feature = "heapless-runtime-len")]
 
+use const_num_traits::ops::ct::CtIsZero;
 use const_num_traits::{Ct, Nct, One, Zero};
 use fixed_bigint::HeaplessBigInt;
-use subtle::ConstantTimeEq;
+use subtle::{
+    Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
+};
 
 type H8Nct = HeaplessBigInt<u8, 8, Nct>;
 type H8Ct = HeaplessBigInt<u8, 8, Ct>;
@@ -214,4 +217,194 @@ fn ct_eq_across_shapes() {
     let a = H8Ct::zero_full_cap();
     let b = <H8Ct as Zero>::zero();
     assert_eq!(bool::from(a.ct_eq(&b)), true);
+}
+
+// ── subtle::ConditionallySelectable ──
+
+#[test]
+fn cselect_choice_1_returns_b() {
+    let a = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([200, 0, 0, 0], 1);
+    let out = H4u32Nct::conditional_select(&a, &b, Choice::from(1u8));
+    assert_eq!(out, b);
+}
+
+#[test]
+fn cselect_choice_0_returns_a() {
+    let a = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([200, 0, 0, 0], 1);
+    let out = H4u32Nct::conditional_select(&a, &b, Choice::from(0u8));
+    assert_eq!(out, a);
+}
+
+#[test]
+fn cselect_output_len_is_max_of_operand_lens() {
+    // a.len = 1, b.len = 3 → out.len = 3 regardless of choice.
+    let a = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([1, 2, 3, 0], 3);
+    let out_a = H4u32Nct::conditional_select(&a, &b, Choice::from(0u8));
+    let out_b = H4u32Nct::conditional_select(&a, &b, Choice::from(1u8));
+    assert_eq!(out_a.len(), 3);
+    assert_eq!(out_b.len(), 3);
+    // Value-check: choice=0 picks a's limbs, higher limbs come from a's
+    // zero tail, so the value is still 100.
+    assert_eq!(out_a.limbs(), &[100, 0, 0]);
+    assert_eq!(out_b.limbs(), &[1, 2, 3]);
+}
+
+#[test]
+fn cselect_preserves_zero_tail() {
+    let a = H4u32Nct::from_limbs([0xAAAAAAAA, 0xBBBBBBBB, 0, 0], 2);
+    let b = H4u32Nct::from_limbs([0xCCCCCCCC, 0xDDDDDDDD, 0, 0], 2);
+    let out = H4u32Nct::conditional_select(&a, &b, Choice::from(1u8));
+    // limbs beyond len must remain zero.
+    assert_eq!(out.all_limbs()[2], 0);
+    assert_eq!(out.all_limbs()[3], 0);
+}
+
+// ── CtIsZero ──
+
+#[test]
+fn ct_is_zero_true_for_zero_shapes() {
+    let z = <H4u32Nct as Zero>::zero();
+    let f = H4u32Nct::zero_full_cap();
+    let s = H4u32Nct::from_limbs([0, 0, 0, 0], 4);
+    assert!(bool::from(z.ct_is_zero()));
+    assert!(bool::from(f.ct_is_zero()));
+    assert!(bool::from(s.ct_is_zero()));
+}
+
+#[test]
+fn ct_is_zero_false_for_nonzero() {
+    let a = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([0, 1, 0, 0], 2);
+    assert!(!bool::from(a.ct_is_zero()));
+    assert!(!bool::from(b.ct_is_zero()));
+}
+
+// ── ConstantTimeGreater / ConstantTimeLess ──
+
+#[test]
+fn ct_gt_matches_partial_ord() {
+    let a = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([200, 0, 0, 0], 1);
+    assert!(!bool::from(a.ct_gt(&b)));
+    assert!(bool::from(b.ct_gt(&a)));
+    assert!(!bool::from(a.ct_gt(&a)));
+}
+
+#[test]
+fn ct_gt_across_lens() {
+    // b has a bit in limb 1 → b > a even though a's limb 0 > b's.
+    let a = H4u32Nct::from_limbs([u32::MAX, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([0, 1, 0, 0], 2);
+    assert!(bool::from(b.ct_gt(&a)));
+    assert!(!bool::from(a.ct_gt(&b)));
+    assert!(bool::from(a.ct_lt(&b)));
+    assert!(!bool::from(b.ct_lt(&a)));
+}
+
+#[test]
+fn ct_lt_and_eq_partition_ordering() {
+    let a = H4u32Nct::from_limbs([5, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([7, 0, 0, 0], 1);
+    // Exactly one of {a<b, a==b, a>b} holds.
+    let lt = bool::from(a.ct_lt(&b));
+    let eq = bool::from(a.ct_eq(&b));
+    let gt = bool::from(a.ct_gt(&b));
+    assert_eq!(lt as u8 + eq as u8 + gt as u8, 1);
+    assert!(lt);
+}
+
+// ── Shl ──
+
+#[test]
+fn shl_by_zero_is_identity() {
+    let a = H4u32Nct::from_limbs([0xDEADBEEF, 0, 0, 0], 1);
+    let b = a << 0;
+    assert_eq!(a, b);
+    assert_eq!(a.len(), b.len());
+}
+
+#[test]
+fn shl_within_a_limb() {
+    let a = H4u32Nct::from_limbs([0x0000_00AB, 0, 0, 0], 1);
+    let b = a << 8;
+    // 0xAB << 8 = 0xAB00, still fits in limb 0.
+    assert_eq!(b.limbs()[0], 0x0000_AB00);
+}
+
+#[test]
+fn shl_crosses_a_limb() {
+    // Shift a byte at bit position 24 by 8 → carries into limb 1.
+    let a = H4u32Nct::from_limbs([0xAB000000, 0, 0, 0], 1);
+    let b = a << 8;
+    // Low limb: top byte 0xAB shifts out, low bytes are 0. New limb 0 = 0.
+    // High limb: 0xAB now in the low byte of limb 1.
+    assert_eq!(b.limbs()[0], 0);
+    assert_eq!(b.limbs()[1], 0x000000AB);
+    assert_eq!(b.len(), 2);
+}
+
+#[test]
+fn shl_by_full_word() {
+    let a = H4u32Nct::from_limbs([1, 2, 0, 0], 2);
+    let b = a << 32;
+    assert_eq!(b.limbs()[0], 0);
+    assert_eq!(b.limbs()[1], 1);
+    assert_eq!(b.limbs()[2], 2);
+    // out_len = min(2 + 1 + 0, 4) = 3.
+    assert_eq!(b.len(), 3);
+}
+
+#[test]
+fn shl_beyond_capacity_truncates() {
+    let a = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
+    // CAP=4, WORD_BITS=32 → 128 bits total. Shift by 128 → zero.
+    let b = a << 128;
+    assert!(<H4u32Nct as Zero>::is_zero(&b));
+    assert_eq!(b.len(), 0);
+}
+
+// ── Shr ──
+
+#[test]
+fn shr_by_zero_is_identity() {
+    let a = H4u32Nct::from_limbs([0xDEADBEEF, 0x12345678, 0, 0], 2);
+    let b = a >> 0;
+    assert_eq!(a, b);
+    assert_eq!(a.len(), b.len());
+}
+
+#[test]
+fn shr_within_a_limb() {
+    let a = H4u32Nct::from_limbs([0x0000_AB00, 0, 0, 0], 1);
+    let b = a >> 8;
+    assert_eq!(b.limbs()[0], 0x0000_00AB);
+}
+
+#[test]
+fn shr_crosses_a_limb() {
+    let a = H4u32Nct::from_limbs([0, 0x0000_00AB, 0, 0], 2);
+    let b = a >> 32;
+    assert_eq!(b.limbs()[0], 0x0000_00AB);
+    assert_eq!(b.len(), 1);
+}
+
+#[test]
+fn shr_bit_carries_from_higher_limb() {
+    // limb1 = 0x00000001. Shr by 1 puts that bit at the top of limb 0.
+    let a = H4u32Nct::from_limbs([0, 1, 0, 0], 2);
+    let b = a >> 1;
+    assert_eq!(b.limbs()[0], 0x8000_0000);
+    // out_len = self.len - word_shift = 2 - 0 = 2.
+    assert_eq!(b.len(), 2);
+}
+
+#[test]
+fn shr_by_more_than_value_bits_zeros() {
+    let a = H4u32Nct::from_limbs([0xDEADBEEF, 0, 0, 0], 1);
+    let b = a >> 64;
+    assert!(<H4u32Nct as Zero>::is_zero(&b));
+    assert_eq!(b.len(), 0);
 }

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1038,3 +1038,56 @@ fn trim_leaves_content_untouched() {
     assert_eq!(t.len(), 2);
     assert_eq!(t.limbs(), v.limbs());
 }
+
+// ── const_num_traits CheckedAdd / CheckedMul trait forms (Nct) ──
+
+#[test]
+fn trait_checked_add_matches_inherent() {
+    use const_num_traits::CheckedAdd;
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 250u32.into();
+    let via_trait = <H4u32Nct as CheckedAdd>::checked_add(a, b);
+    let via_inherent = HeaplessBigInt::checked_add(&a, &b);
+    assert_eq!(via_trait, via_inherent);
+    assert_eq!(via_trait, Some(HeaplessBigInt::from(350u32)));
+}
+
+#[test]
+fn trait_checked_add_reports_overflow() {
+    use const_num_traits::CheckedAdd;
+    let max = H4u32Nct::from_limbs([u32::MAX; 4], 4);
+    let one: H4u32Nct = 1u8.into();
+    assert_eq!(<H4u32Nct as CheckedAdd>::checked_add(max, one), None);
+}
+
+#[test]
+fn trait_checked_mul_matches_inherent() {
+    use const_num_traits::CheckedMul;
+    let a: H4u32Nct = 13u8.into();
+    let b: H4u32Nct = 17u8.into();
+    let via_trait = <H4u32Nct as CheckedMul>::checked_mul(a, b);
+    let via_inherent = HeaplessBigInt::checked_mul(&a, &b);
+    assert_eq!(via_trait, via_inherent);
+    assert_eq!(via_trait, Some(HeaplessBigInt::from(221u32)));
+}
+
+#[test]
+fn trait_checked_mul_is_value_aware_through_the_trait() {
+    // The whole point of routing modmath's inv through the trait: a
+    // value that fits despite shape-len overrun returns Some via the
+    // trait form, not just the inherent.
+    use const_num_traits::CheckedMul;
+    let a = H4u8Nct::from_limbs([5, 0, 0, 0], 4); // value 5, shape len=4
+    let b = H4u8Nct::from_limbs([7, 0, 0, 0], 4); // value 7, shape len=4
+    let out = <H4u8Nct as CheckedMul>::checked_mul(a, b).expect("value fits");
+    assert_eq!(out.limbs()[0], 35);
+    assert_eq!(out.len(), 1);
+}
+
+#[test]
+fn trait_checked_mul_reports_true_overflow() {
+    use const_num_traits::CheckedMul;
+    let a = H4u8Nct::from_limbs([0, 0, 0, 1], 4); // 2^24
+    let b = H4u8Nct::from_limbs([0, 0, 1, 0], 3); // 2^16
+    assert_eq!(<H4u8Nct as CheckedMul>::checked_mul(a, b), None);
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -233,6 +233,37 @@ fn carrying_add_reports_width_carry_without_growing() {
     assert_eq!(s2.limbs()[0], 8);
 }
 
+#[test]
+fn accumulator_must_be_width_pinned() {
+    use const_num_traits::OverflowingAdd;
+    // Horner-style doubling: acc = acc*2, repeated. The width is whatever
+    // acc is carried at — value-width ops resolve at max(operand len), so
+    // a value grown from a narrow seed stays narrow and wraps early
+    // (exactly like a narrow FixedUInt). A width-pinned seed carries the
+    // full width, like FixedUInt<u32,8>. This is the recurring downstream
+    // trap: pin the width the way you pick N for FixedUInt.
+    let double = |acc: H4u32Nct| OverflowingAdd::overflowing_add(acc, acc).0;
+
+    // Start from 1, double 40 times → 2^40, which needs limb 1.
+    let start = H4u32Nct::from_limbs([1, 0, 0, 0], 1); // narrow: len 1
+    let mut narrow = start;
+    for _ in 0..40 {
+        narrow = double(narrow);
+    }
+    // Narrow stayed len 1 and wrapped at 2^32 → 0.
+    assert_eq!(narrow.len(), 1);
+    assert!(<H4u32Nct as Zero>::is_zero(&narrow));
+
+    // Pin to width 2 (64 bits) up front; 2^40 now fits.
+    let mut wide = start.widened(2);
+    for _ in 0..40 {
+        wide = double(wide);
+    }
+    assert_eq!(wide.len(), 2);
+    assert_eq!(wide.limbs()[0], 0); // low 32 bits of 2^40
+    assert_eq!(wide.limbs()[1], 1 << 8); // 2^40 = 2^8 · 2^32
+}
+
 // ── PartialEq / PartialOrd (value-based) ──
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -307,8 +307,8 @@ fn with_precision_seeds_at_witness_width() {
     assert!(<H4u32Nct as Zero>::is_zero(&z));
     assert_eq!(z.len(), 3);
     assert_eq!(
-        BitsPrecision::bits_precision(z),
-        BitsPrecision::bits_precision(q)
+        BitsPrecision::bits_precision(&z),
+        BitsPrecision::bits_precision(&q)
     );
     let idiom = WrappingSub::wrapping_sub(q, q);
     assert_eq!(z, idiom);
@@ -771,7 +771,7 @@ fn leading_zeros_plus_bit_length_equals_width() {
     // And that equals bits_precision().
     assert_eq!(
         v.leading_zeros() + v.bit_length(),
-        <H4u32Nct as const_num_traits::BitsPrecision>::bits_precision(v) as usize
+        <H4u32Nct as const_num_traits::BitsPrecision>::bits_precision(&v) as usize
     );
 }
 
@@ -782,23 +782,26 @@ fn bits_precision_is_len_times_word_bits_not_cap() {
     use const_num_traits::BitsPrecision;
     // u32 backing: width = len * 32, tracks the constructed len, never CAP.
     assert_eq!(
-        BitsPrecision::bits_precision(H4u32Nct::from_limbs([1, 0, 0, 0], 1)),
+        BitsPrecision::bits_precision(&H4u32Nct::from_limbs([1, 0, 0, 0], 1)),
         32
     );
     assert_eq!(
-        BitsPrecision::bits_precision(H4u32Nct::from_limbs([1, 2, 0, 0], 2)),
+        BitsPrecision::bits_precision(&H4u32Nct::from_limbs([1, 2, 0, 0], 2)),
         64
     );
     assert_eq!(
-        BitsPrecision::bits_precision(H4u32Nct::from_limbs([1, 2, 3, 4], 4)),
+        BitsPrecision::bits_precision(&H4u32Nct::from_limbs([1, 2, 3, 4], 4)),
         128
     );
     // len 0 (mathematical zero) → width 0.
-    assert_eq!(BitsPrecision::bits_precision(<H4u32Nct as Zero>::zero()), 0);
+    assert_eq!(
+        BitsPrecision::bits_precision(&<H4u32Nct as Zero>::zero()),
+        0
+    );
     // u8 backing: width = len * 8.
     type H8u8 = HeaplessBigInt<u8, 8, Nct>;
     assert_eq!(
-        BitsPrecision::bits_precision(H8u8::from_be_bytes(&[1, 2, 3])),
+        BitsPrecision::bits_precision(&H8u8::from_be_bytes(&[1, 2, 3])),
         24
     );
 }
@@ -823,10 +826,10 @@ fn bit_width_is_bit_length() {
     let v = H4u32Nct::from_limbs([0xFF, 0, 0, 0], 2);
     assert_eq!(BitWidth::bit_width(v), 8);
     assert_eq!(
-        <H4u32Nct as const_num_traits::BitsPrecision>::bits_precision(v),
+        <H4u32Nct as const_num_traits::BitsPrecision>::bits_precision(&v),
         64
     );
-    assert!(BitWidth::bit_width(v) <= const_num_traits::BitsPrecision::bits_precision(v));
+    assert!(BitWidth::bit_width(v) <= const_num_traits::BitsPrecision::bits_precision(&v));
 }
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -3,7 +3,10 @@
 //! Zero/One/Default line up, and Ct paths (subtle::ConstantTimeEq) agree
 //! with the value.
 
-#![cfg(feature = "heapless-runtime-len")]
+// Several tests deliberately spell out `&a op &b` (and the mixed receiver
+// forms) to check that every operator impl — value/value, value/ref,
+// ref/value, ref/ref — agrees. That is the point, so `op_ref` is allowed.
+#![allow(clippy::op_ref)]
 
 // `WrappingAdd`/`WrappingSub`/`OverflowingAdd`/`OverflowingSub` are used
 // via fully-qualified paths below because they shadow the inherent
@@ -384,8 +387,8 @@ fn ct_eq_agrees_with_partial_eq() {
     let a = H8Ct::from_limbs([1, 2, 3, 0, 0, 0, 0, 0], 3);
     let b = H8Ct::from_limbs([1, 2, 3, 0, 0, 0, 0, 0], 3);
     let c = H8Ct::from_limbs([1, 2, 4, 0, 0, 0, 0, 0], 3);
-    assert_eq!(bool::from(a.ct_eq(&b)), true);
-    assert_eq!(bool::from(a.ct_eq(&c)), false);
+    assert!(bool::from(a.ct_eq(&b)));
+    assert!(!bool::from(a.ct_eq(&c)));
     assert!(a == b);
     assert!(a != c);
 }
@@ -395,7 +398,7 @@ fn ct_eq_across_shapes() {
     // Same-value, different-shape operands agree under Ct equality too.
     let a = H8Ct::zero_full_cap();
     let b = <H8Ct as Zero>::zero();
-    assert_eq!(bool::from(a.ct_eq(&b)), true);
+    assert!(bool::from(a.ct_eq(&b)));
 }
 
 // ── subtle::ConditionallySelectable ──
@@ -809,7 +812,7 @@ fn bits_precision_is_len_times_word_bits_not_cap() {
 fn bits_precision_via_reference() {
     use const_num_traits::BitsPrecision;
     let v = H4u32Nct::from_limbs([1, 2, 0, 0], 2);
-    assert_eq!((&v).bits_precision(), 64);
+    assert_eq!(<&H4u32Nct as BitsPrecision>::bits_precision(&&v), 64);
 }
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1006,24 +1006,22 @@ fn carrying_mul_add_two_adders() {
 }
 
 #[test]
-fn carrying_mul_splits_at_carrier_width_like_fixeduint() {
+fn carrying_mul_splits_at_value_width_not_cap() {
     use const_num_traits::CarryingMul;
-    // WideMul is a fixed-carrier-width op: the (lo, hi) split is at CAP
-    // words (the carrier width), so it reconstructs as
-    // `hi·2^(CAP·word_bits) + lo` — exactly like FixedUInt<u8, CAP>, which
-    // wide-REDC relies on. For sub-width operands (200 at len 1 in an
-    // 8-word container), 40000 stays in the low half: lo = 40000, hi = 0.
-    // (Splitting at the OPERAND width would give (64, 156) and misplace
-    // hi in the REDC — the ed25519 r2_mod_n bug.)
+    // WideMul splits at the operands' value width (max len), so (lo, hi)
+    // reconstruct as `hi·2^(len·word_bits) + lo`, matching bits_precision
+    // and the primitive (200u8.wide_mul(200) = (64, 156), split at 8
+    // bits). At len 1 (width 8) in an 8-word carrier, 40000 must split
+    // into (64, 156), NOT stay whole in lo at CAP — a CAP split strands
+    // the high half and misplaces hi in the REDC (the RSA bug).
     type H4u8 = HeaplessBigInt<u8, 4, Nct>;
     let a = H4u8::from_limbs([200, 0, 0, 0], 1);
     let b = H4u8::from_limbs([200, 0, 0, 0], 1);
     let (lo, hi) = a.carrying_mul(b, <H4u8 as Zero>::zero());
-    // 40000 = 0x9C40 → low half limbs [0x40, 0x9C, 0, 0]; high half zero.
-    assert_eq!(lo.len(), 4);
-    assert_eq!(hi.len(), 4);
-    assert_eq!(lo.all_limbs(), &[0x40, 0x9C, 0, 0]);
-    assert!(<H4u8 as Zero>::is_zero(&hi));
+    assert_eq!(lo.len(), 1, "split at value width (1 word), not CAP");
+    assert_eq!(hi.len(), 1);
+    assert_eq!(lo.limbs()[0], 64); // 40000 & 0xFF
+    assert_eq!(hi.limbs()[0], 156); // 40000 >> 8
 }
 
 // ── BorrowingSub at the bigint level ──

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1237,6 +1237,55 @@ fn bitand_with_full_width_mask() {
     assert_eq!(out.len(), 1);
 }
 
+// ── BitOr ──
+
+#[test]
+fn bitor_sets_bits() {
+    let a: H4u32Nct = 0xF0F0_0000u32.into();
+    let b: H4u32Nct = 0x0000_0F0Fu32.into();
+    assert_eq!((a | b).limbs()[0], 0xF0F0_0F0F);
+}
+
+#[test]
+fn bitor_output_len_is_max_of_operand_lens() {
+    // a spans 1 limb, b spans 3 → result spans 3 (OR sets bits in the
+    // wider operand's limbs, which the shorter operand's zero-tail leaves).
+    let a: H4u32Nct = 0x0000_00FFu32.into(); // len 1
+    let b = H4u32Nct::from_limbs([0xFF00, 0xAAAA, 0xBBBB, 0], 3);
+    let out = &a | &b;
+    assert_eq!(out.len(), 3);
+    assert_eq!(out.limbs(), &[0x0000_FFFF, 0xAAAA, 0xBBBB]);
+}
+
+#[test]
+fn bitor_preserves_zero_tail() {
+    let a = H4u32Nct::from_limbs([0xAAAA, 0xBBBB, 0, 0], 2);
+    let b = H4u32Nct::from_limbs([0x5555, 0x4444, 0, 0], 2);
+    let out = a | b;
+    assert_eq!(out.all_limbs()[2], 0);
+    assert_eq!(out.all_limbs()[3], 0);
+}
+
+#[test]
+fn bitor_all_receiver_forms_agree() {
+    let a: H4u32Nct = 0xF0F0_F0F0u32.into();
+    let b: H4u32Nct = 0x0F0F_0F0Fu32.into();
+    let ref_ref = &a | &b;
+    assert_eq!(a | b, ref_ref);
+    assert_eq!(a | &b, ref_ref);
+    assert_eq!(&a | b, ref_ref);
+    // Full-width OR.
+    assert_eq!(ref_ref.limbs()[0], 0xFFFF_FFFF);
+}
+
+#[test]
+fn bitor_with_zero_is_identity() {
+    let a = H4u32Nct::from_limbs([0x1234, 0x5678, 0, 0], 2);
+    let z = <H4u32Nct as Zero>::zero();
+    assert_eq!((&a | &z), a);
+    assert_eq!((&z | &a), a);
+}
+
 // ── FromByteSlice ──
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -264,6 +264,36 @@ fn accumulator_must_be_width_pinned() {
     assert_eq!(wide.limbs()[1], 1 << 8); // 2^40 = 2^8 · 2^32
 }
 
+#[test]
+fn wrapping_sub_preserves_width_no_stale_len() {
+    use const_num_traits::{OverflowingAdd, WrappingSub};
+    // A wrapping_sub whose result is numerically small keeps the operands'
+    // width — len is NOT trimmed to the value. So a later doubling still has
+    // room and retains the carry: there is no "stale/shrunk len" feeding a
+    // truncated add. (len IS the width, like the 8 in u8 — not value-tight
+    // metadata.)
+    let big = H4u32Nct::from_limbs([0x9807_72de, 5, 0, 0], 2); // width 2
+    let sub = H4u32Nct::from_limbs([0, 5, 0, 0], 2); // width 2
+    let small = WrappingSub::wrapping_sub(big, sub); // value 0x980772de
+    assert_eq!(
+        small.len(),
+        2,
+        "wrapping_sub keeps width, does not trim len"
+    );
+    assert_eq!(small.limbs()[0], 0x9807_72de);
+    assert_eq!(small.limbs()[1], 0);
+
+    // Doubling the "shrunk" value still carries into limb 1 (width 2 room).
+    let (dbl, _) = OverflowingAdd::overflowing_add(small, small);
+    assert_eq!(dbl.len(), 2);
+    assert_eq!(dbl.limbs()[0], 0x9807_72deu32.wrapping_shl(1));
+    assert_eq!(
+        dbl.limbs()[1],
+        1,
+        "carry retained after sub->double at width 2"
+    );
+}
+
 // ── PartialEq / PartialOrd (value-based) ──
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1006,24 +1006,24 @@ fn carrying_mul_add_two_adders() {
 }
 
 #[test]
-fn carrying_mul_splits_at_operand_width_not_cap() {
+fn carrying_mul_splits_at_carrier_width_like_fixeduint() {
     use const_num_traits::CarryingMul;
-    // The WideMul/wide-REDC contract: split at the operand WIDTH, so the
-    // (lo, hi) reconstruct as `hi·2^width + lo`. For width-8 operands
-    // (u8 backing, len 1), 200 * 200 = 40000 must split at 8 bits into
-    // (64, 156) — exactly like the u8 primitive — NOT (40000, 0) at CAP.
+    // WideMul is a fixed-carrier-width op: the (lo, hi) split is at CAP
+    // words (the carrier width), so it reconstructs as
+    // `hi·2^(CAP·word_bits) + lo` — exactly like FixedUInt<u8, CAP>, which
+    // wide-REDC relies on. For sub-width operands (200 at len 1 in an
+    // 8-word container), 40000 stays in the low half: lo = 40000, hi = 0.
+    // (Splitting at the OPERAND width would give (64, 156) and misplace
+    // hi in the REDC — the ed25519 r2_mod_n bug.)
     type H4u8 = HeaplessBigInt<u8, 4, Nct>;
-    let a = H4u8::from_limbs([200, 0, 0, 0], 1); // width 8
+    let a = H4u8::from_limbs([200, 0, 0, 0], 1);
     let b = H4u8::from_limbs([200, 0, 0, 0], 1);
-    let zero_v = <H4u8 as Zero>::zero();
-    let (lo, hi) = a.carrying_mul(b, zero_v);
-    assert_eq!(lo.len(), 1, "lo width == operand width (1 word), not CAP");
-    assert_eq!(hi.len(), 1);
-    assert_eq!(lo.limbs()[0], 64); // 40000 & 0xFF
-    assert_eq!(hi.limbs()[0], 156); // 40000 >> 8
-    // Matches the primitive wide-multiply exactly.
-    assert_eq!((200u8 as u16 * 200) & 0xFF, lo.limbs()[0] as u16);
-    assert_eq!((200u8 as u16 * 200) >> 8, hi.limbs()[0] as u16);
+    let (lo, hi) = a.carrying_mul(b, <H4u8 as Zero>::zero());
+    // 40000 = 0x9C40 → low half limbs [0x40, 0x9C, 0, 0]; high half zero.
+    assert_eq!(lo.len(), 4);
+    assert_eq!(hi.len(), 4);
+    assert_eq!(lo.all_limbs(), &[0x40, 0x9C, 0, 0]);
+    assert!(<H4u8 as Zero>::is_zero(&hi));
 }
 
 // ── BorrowingSub at the bigint level ──

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -583,22 +583,29 @@ fn bit_length_ignores_zero_high_limbs() {
 }
 
 #[test]
-fn leading_zeros_zero() {
+fn leading_zeros_zero_is_zero_width() {
+    // Zero has len 0 → width 0 → no leading zeros (CAP does not enter).
     let z = <H4u32Nct as Zero>::zero();
-    // CAP=4 × 32 bits = 128.
-    assert_eq!(z.leading_zeros(), 128);
+    assert_eq!(z.leading_zeros(), 0);
 }
 
 #[test]
 fn leading_zeros_full_width_value() {
+    // len 4 → width 128, top bit set → 0 leading zeros.
     let v = H4u32Nct::from_limbs([0, 0, 0, 1u32 << 31], 4);
     assert_eq!(v.leading_zeros(), 0);
 }
 
 #[test]
-fn leading_zeros_plus_bit_length_equals_cap_bits() {
+fn leading_zeros_plus_bit_length_equals_width() {
+    // width = len·word_bits = 2·32 = 64 (not CAP·32 = 128).
     let v = H4u32Nct::from_limbs([0, 1u32 << 20, 0, 0], 2);
-    assert_eq!(v.leading_zeros() + v.bit_length(), 128);
+    assert_eq!(v.leading_zeros() + v.bit_length(), 64);
+    // And that equals bits_precision().
+    assert_eq!(
+        v.leading_zeros() + v.bit_length(),
+        <H4u32Nct as const_num_traits::BitsPrecision>::bits_precision(v) as usize
+    );
 }
 
 // ── BitsPrecision (width = len·word_bits) / BitWidth (bit-length) ──
@@ -996,6 +1003,27 @@ fn carrying_mul_add_two_adders() {
     let expected_lo: H4u32Nct = 42u8.into();
     assert_eq!(lo, expected_lo);
     assert!(<H4u32Nct as const_num_traits::Zero>::is_zero(&hi));
+}
+
+#[test]
+fn carrying_mul_splits_at_operand_width_not_cap() {
+    use const_num_traits::CarryingMul;
+    // The WideMul/wide-REDC contract: split at the operand WIDTH, so the
+    // (lo, hi) reconstruct as `hi·2^width + lo`. For width-8 operands
+    // (u8 backing, len 1), 200 * 200 = 40000 must split at 8 bits into
+    // (64, 156) — exactly like the u8 primitive — NOT (40000, 0) at CAP.
+    type H4u8 = HeaplessBigInt<u8, 4, Nct>;
+    let a = H4u8::from_limbs([200, 0, 0, 0], 1); // width 8
+    let b = H4u8::from_limbs([200, 0, 0, 0], 1);
+    let zero_v = <H4u8 as Zero>::zero();
+    let (lo, hi) = a.carrying_mul(b, zero_v);
+    assert_eq!(lo.len(), 1, "lo width == operand width (1 word), not CAP");
+    assert_eq!(hi.len(), 1);
+    assert_eq!(lo.limbs()[0], 64); // 40000 & 0xFF
+    assert_eq!(hi.limbs()[0], 156); // 40000 >> 8
+    // Matches the primitive wide-multiply exactly.
+    assert_eq!((200u8 as u16 * 200) & 0xFF, lo.limbs()[0] as u16);
+    assert_eq!((200u8 as u16 * 200) >> 8, hi.limbs()[0] as u16);
 }
 
 // ── BorrowingSub at the bigint level ──

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -5,8 +5,12 @@
 
 #![cfg(feature = "heapless-runtime-len")]
 
+// `WrappingAdd`/`WrappingSub`/`OverflowingAdd`/`OverflowingSub` are used
+// via fully-qualified paths below because they shadow the inherent
+// methods on `HeaplessBigInt` when in scope — the existing `.wrapping_add(&b)`
+// callers need the inherent to win method resolution.
 use const_num_traits::ops::ct::CtIsZero;
-use const_num_traits::{Ct, Nct, One, Zero};
+use const_num_traits::{Ct, Nct, One, Parity, Zero};
 use fixed_bigint::HeaplessBigInt;
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -597,4 +601,180 @@ fn bytes_work_across_widths() {
     let v = H2u64Nct::from_be_bytes(&[0, 0, 0, 0, 0, 0, 0, 0x42]);
     assert_eq!(v.len(), 1);
     assert_eq!(v.limbs()[0], 0x42);
+}
+
+// ── From<u8>/<u16>/<u32> ──
+
+#[test]
+fn from_u8_matches_le_bytes() {
+    let v: H4u32Nct = 0xABu8.into();
+    assert_eq!(v.limbs()[0], 0xAB);
+    // u32 backing, u8 source: single limb.
+    assert_eq!(v.len(), 1);
+}
+
+#[test]
+fn from_u16_multi_limb_when_backing_is_u8() {
+    type H8u8Nct = HeaplessBigInt<u8, 8, Nct>;
+    let v: H8u8Nct = 0xABCDu16.into();
+    // u8 backing splits u16 across two limbs (LE).
+    assert_eq!(v.limbs()[0], 0xCD);
+    assert_eq!(v.limbs()[1], 0xAB);
+    assert_eq!(v.len(), 2);
+}
+
+#[test]
+fn from_u32_across_u8_backing() {
+    type H8u8Nct = HeaplessBigInt<u8, 8, Nct>;
+    let v: H8u8Nct = 0x12345678u32.into();
+    assert_eq!(v.limbs(), &[0x78, 0x56, 0x34, 0x12]);
+    assert_eq!(v.len(), 4);
+}
+
+#[test]
+fn from_u32_single_limb_when_backing_is_u32() {
+    let v: H4u32Nct = 0xDEADBEEFu32.into();
+    assert_eq!(v.limbs()[0], 0xDEADBEEF);
+    assert_eq!(v.len(), 1);
+}
+
+// ── Trait-form Wrapping / Overflowing Add / Sub ──
+
+#[test]
+fn trait_wrapping_add_matches_inherent() {
+    use const_num_traits::WrappingAdd;
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 250u32.into();
+    let via_trait = <H4u32Nct as WrappingAdd>::wrapping_add(a, b);
+    let via_inherent = HeaplessBigInt::wrapping_add(&a, &b);
+    assert_eq!(via_trait, via_inherent);
+}
+
+#[test]
+fn trait_wrapping_sub_matches_inherent() {
+    use const_num_traits::WrappingSub;
+    let a: H4u32Nct = 500u32.into();
+    let b: H4u32Nct = 200u32.into();
+    let via_trait = <H4u32Nct as WrappingSub>::wrapping_sub(a, b);
+    let via_inherent = HeaplessBigInt::wrapping_sub(&a, &b);
+    assert_eq!(via_trait, via_inherent);
+}
+
+#[test]
+fn trait_overflowing_add_reports_overflow() {
+    use const_num_traits::OverflowingAdd;
+    let max = H4u32Nct::from_limbs([u32::MAX; 4], 4);
+    let one: H4u32Nct = 1u8.into();
+    let (_, overflow) = <H4u32Nct as OverflowingAdd>::overflowing_add(max, one);
+    assert!(overflow);
+}
+
+#[test]
+fn trait_overflowing_sub_reports_borrow() {
+    use const_num_traits::OverflowingSub;
+    let a: H4u32Nct = 1u8.into();
+    let b: H4u32Nct = 2u8.into();
+    let (_, borrow) = <H4u32Nct as OverflowingSub>::overflowing_sub(a, b);
+    assert!(borrow);
+}
+
+// ── Parity ──
+
+#[test]
+fn parity_zero_is_even() {
+    let z = <H4u32Nct as Zero>::zero();
+    assert!(!z.is_odd());
+    assert!(z.is_even());
+}
+
+#[test]
+fn parity_reads_lowest_bit() {
+    let odd: H4u32Nct = 5u32.into();
+    let even: H4u32Nct = 4u32.into();
+    assert!(odd.is_odd());
+    assert!(!odd.is_even());
+    assert!(!even.is_odd());
+    assert!(even.is_even());
+}
+
+#[test]
+fn parity_reads_only_lowest_limb() {
+    // High limbs are non-zero; parity must still come from limb 0.
+    let v = H4u32Nct::from_limbs([0xFFFF_FFFE, 0xFFFF_FFFF, 0, 0], 2);
+    assert!(v.is_even()); // low bit of 0xFFFF_FFFE is 0
+}
+
+// ── Div / Rem ──
+
+#[test]
+fn div_rem_dividend_less_than_divisor() {
+    let a: H4u32Nct = 3u8.into();
+    let b: H4u32Nct = 10u8.into();
+    assert_eq!(a / b, <H4u32Nct as Zero>::zero());
+    assert_eq!(a % b, a);
+}
+
+#[test]
+fn div_rem_equal() {
+    let a: H4u32Nct = 42u32.into();
+    let b: H4u32Nct = 42u32.into();
+    assert_eq!(a / b, <H4u32Nct as One>::one());
+    assert_eq!(a % b, <H4u32Nct as Zero>::zero());
+}
+
+#[test]
+fn div_rem_small_values() {
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 7u8.into();
+    // 100 = 14*7 + 2.
+    let expected_q: H4u32Nct = 14u32.into();
+    let expected_r: H4u32Nct = 2u8.into();
+    assert_eq!(a / b, expected_q);
+    assert_eq!(a % b, expected_r);
+}
+
+#[test]
+fn div_rem_cross_limb() {
+    // 0x1_0000_0000 / 3 = 0x5555_5555 rem 1.
+    let a = H4u32Nct::from_limbs([0, 1, 0, 0], 2);
+    let b: H4u32Nct = 3u32.into();
+    let q = a / b;
+    let r = a % b;
+    let expected_q: H4u32Nct = 0x5555_5555u32.into();
+    let expected_r: H4u32Nct = 1u8.into();
+    assert_eq!(q, expected_q);
+    assert_eq!(r, expected_r);
+}
+
+#[test]
+#[should_panic]
+fn div_by_zero_panics() {
+    let a: H4u32Nct = 5u8.into();
+    let b = <H4u32Nct as Zero>::zero();
+    let _ = a / b;
+}
+
+#[test]
+fn div_rem_ref_variants_agree_with_owned() {
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 7u8.into();
+    assert_eq!(a / b, (&a) / (&b));
+    assert_eq!(a % b, (&a) % (&b));
+    assert_eq!(a / b, a / &b);
+    assert_eq!(a % b, a % &b);
+    assert_eq!(a / b, (&a) / b);
+    assert_eq!(a % b, (&a) % b);
+}
+
+#[test]
+fn div_rem_round_trip_identity() {
+    // For any a, b > 0: (a / b) * b + (a % b) == a.
+    let a = H4u32Nct::from_limbs([0xDEAD_BEEFu32, 0x1234_5678u32, 0, 0], 2);
+    let b: H4u32Nct = 0xABCDu32.into();
+    let q = a / b;
+    let r = a % b;
+    // Sanity-check: q * b + r == a. Use inherent wrapping_mul + wrapping_add.
+    let product = q.wrapping_mul(&b);
+    let reconstructed = product.wrapping_add(&r);
+    assert_eq!(reconstructed, a);
 }

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -81,33 +81,32 @@ fn add_small_values() {
 
 #[test]
 fn add_cross_limb_carry() {
-    // (u32::MAX) + 1 = 0x1_0000_0000. wrapping_add wraps at the value
-    // width (len 1 → 2^32), so the carry is discarded → 0 at len 1
-    // (like FixedUInt<u32,1>). The growing sum that keeps the carry is
-    // overflowing_add / core::ops::+, which is what EEA relies on.
+    // (u32::MAX) + 1 = 0x1_0000_0000 at width 1 (len 1). The carry is out
+    // of the width, reported as a flag, result wraps to 0 — exactly like
+    // FixedUInt<u32,1>. No limb growth: the words beyond len do not exist.
     let a = H4u32Nct::from_limbs([u32::MAX, 0, 0, 0], 1);
     let b = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
     let w = a.wrapping_add(&b);
     assert_eq!(w.len(), 1);
     assert_eq!(w.limbs()[0], 0);
 
-    // overflowing_add grows a limb to hold the carry (no CAP overflow).
-    let (grown, overflow) = a.overflowing_add(&b);
-    assert!(!overflow);
-    assert_eq!(grown.len(), 2);
-    assert_eq!(grown.limbs()[0], 0);
-    assert_eq!(grown.limbs()[1], 1);
+    let (res, overflow) = a.overflowing_add(&b);
+    assert!(overflow, "carry out of width 1");
+    assert_eq!(res.len(), 1);
+    assert_eq!(res.limbs()[0], 0);
+    assert_eq!(a.checked_add(&b), None);
 }
 
 #[test]
-fn add_overflows_when_natural_len_exceeds_cap() {
-    // 2 CAP=4 32-bit values whose sum needs 5 limbs.
+fn add_overflow_at_operand_width() {
+    // Sum overflowing the operands' width flags, regardless of capacity:
+    // here width == 4 (== CAP), but the rule is width, not CAP.
     let max = H4u32Nct::from_limbs([u32::MAX; 4], 4);
     let one = <H4u32Nct as One>::one();
     let (_wrapped, overflow) = max.overflowing_add(&one);
     assert!(
         overflow,
-        "expected overflow when natural sum needs CAP+1 limbs"
+        "expected overflow when the sum exceeds the operand width"
     );
     assert_eq!(max.checked_add(&one), None);
 }
@@ -159,30 +158,32 @@ fn mul_small_product_fits() {
 
 #[test]
 fn mul_cross_limb_carry() {
-    // 0x1_0000 * 0x1_0000 = 2^32. wrapping_mul wraps at the value width
-    // (len 1 → 2^32) → 0, like FixedUInt<u32,1>. The full growing
-    // product lives in checked_mul / core::ops::* (used by EEA).
+    // 0x1_0000 * 0x1_0000 = 2^32. At width 1 (len 1) the product exceeds
+    // the width: wrapping_mul → 0, overflowing_mul flags, checked_mul is
+    // None — exactly like FixedUInt<u32,1>. The high half beyond the
+    // width does not exist here; WideMul is the op that returns it.
     let a = H4u32Nct::from_limbs([0x1_0000, 0, 0, 0], 1);
     let b = H4u32Nct::from_limbs([0x1_0000, 0, 0, 0], 1);
     let w = a.wrapping_mul(&b);
     assert_eq!(w.len(), 1);
     assert_eq!(w.limbs()[0], 0);
 
-    // The full product 2^32 = [0, 1] is available (fits in CAP=4).
-    let full = a.checked_mul(&b).expect("2^32 fits in CAP");
-    assert_eq!(full.limbs()[0], 0);
-    assert_eq!(full.limbs()[1], 1);
+    let (_res, overflow) = a.overflowing_mul(&b);
+    assert!(overflow, "2^32 overflows width 1");
+    assert_eq!(a.checked_mul(&b), None);
 }
 
 #[test]
-fn mul_overflow_when_natural_len_exceeds_cap() {
-    // len=3 * len=3 → natural product needs 6 limbs; CAP=4.
+fn mul_overflow_at_operand_width() {
+    // len=3 * len=3 → product exceeds width 3, so it flags — the rule is
+    // the operand width, not CAP (here CAP=4 also fits fewer than 6 words,
+    // but that is not what decides it).
     let a = H4u32Nct::from_limbs([1, 1, 1, 0], 3);
     let b = H4u32Nct::from_limbs([1, 1, 1, 0], 3);
     let (_wrapped, overflow) = a.overflowing_mul(&b);
     assert!(
         overflow,
-        "expected overflow when natural product exceeds CAP"
+        "expected overflow when the product exceeds the operand width"
     );
     assert_eq!(a.checked_mul(&b), None);
 }
@@ -1118,51 +1119,45 @@ fn borrowing_sub_underflow_reports_borrow_out() {
     assert!(borrow);
 }
 
-// ── Nct value-aware checked_mul + trim ──
+// ── checked_mul (behaves like the same-width FixedUInt) + trim ──
 
 type H4u8Nct = HeaplessBigInt<u8, 4, Nct>;
 
 #[test]
-fn checked_mul_returns_some_when_value_fits_but_shape_overflows_nct() {
-    // Two operands whose `len` sum exceeds CAP but whose true product
-    // still fits — the shape check would falsely reject, but the value
-    // check accepts.
-    //
-    // Set up: build values with inflated len (all-zero high limbs).
-    let a = H4u8Nct::from_limbs([5, 0, 0, 0], 4); // value 5, shape len=4
-    let b = H4u8Nct::from_limbs([7, 0, 0, 0], 4); // value 7, shape len=4
-    // len sum = 8 > CAP=4, but 5*7 = 35 fits.
-    let out = a
-        .checked_mul(&b)
-        .expect("value fits, checked_mul should accept");
+fn checked_mul_at_operand_width_like_fixeduint() {
+    // A value carried at len=4 IS a 4-word (32-bit) integer, so checked_mul
+    // behaves exactly like FixedUInt<u8,4>: 5 * 7 = 35 fits in width 4 →
+    // Some(35) at len 4 (the operating width). No trim: those words are the
+    // value's real width, not inflation, and capacity never enters.
+    let a = H4u8Nct::from_limbs([5, 0, 0, 0], 4);
+    let b = H4u8Nct::from_limbs([7, 0, 0, 0], 4);
+    let out = a.checked_mul(&b).expect("35 fits in width 4");
+    assert_eq!(out.len(), 4);
     assert_eq!(out.limbs()[0], 35);
-    // Nct path trims: len reflects value.
-    assert_eq!(out.len(), 1);
 }
 
 #[test]
-fn checked_mul_returns_none_when_value_truly_overflows() {
-    // 2^24 (limb 3) * 2^16 (limb 2) = 2^40 — doesn't fit in u8*4 = 32 bits.
+fn checked_mul_returns_none_when_value_overflows_width() {
+    // 2^24 (limb 3) * 2^16 (limb 2) = 2^40 — exceeds the 32-bit operand
+    // width (u8*4), so None, exactly as FixedUInt<u8,4> would report.
     let a = H4u8Nct::from_limbs([0, 0, 0, 1], 4); // 2^24
     let b = H4u8Nct::from_limbs([0, 0, 1, 0], 3); // 2^16
     assert!(a.checked_mul(&b).is_none());
 }
 
 #[test]
-fn checked_mul_chain_survives_shape_inflation() {
-    // The "modmath EEA" pattern that would panic under a shape-based
-    // check: multiply small values that keep growing `len` under the
-    // untrimmed shape but whose true values stay small.
+fn checked_mul_chain_stays_within_width() {
+    // Chained small products (the modmath EEA pattern): each stays within
+    // the operand width, so the chain never falsely overflows.
     let start: H4u8Nct = 1u8.into();
     let a: H4u8Nct = 3u8.into();
     let b: H4u8Nct = 5u8.into();
     let c: H4u8Nct = 7u8.into();
-    // start * a * b * c = 105. Fits trivially in one u8 limb.
+    // 1 * 3 * 5 * 7 = 105, fits in width 1.
     let p1 = start.checked_mul(&a).unwrap();
     let p2 = p1.checked_mul(&b).unwrap();
     let p3 = p2.checked_mul(&c).unwrap();
     assert_eq!(p3.limbs()[0], 105);
-    assert_eq!(p3.len(), 1);
 }
 
 #[test]
@@ -1226,16 +1221,15 @@ fn trait_checked_mul_matches_inherent() {
 }
 
 #[test]
-fn trait_checked_mul_is_value_aware_through_the_trait() {
-    // The whole point of routing modmath's inv through the trait: a
-    // value that fits despite shape-len overrun returns Some via the
-    // trait form, not just the inherent.
+fn trait_checked_mul_matches_fixeduint_width_behavior() {
+    // Through the trait form modmath's inv binds on: checked_mul at the
+    // operand width, same as FixedUInt<u8,4>. 5 * 7 = 35 fits in width 4.
     use const_num_traits::CheckedMul;
-    let a = H4u8Nct::from_limbs([5, 0, 0, 0], 4); // value 5, shape len=4
-    let b = H4u8Nct::from_limbs([7, 0, 0, 0], 4); // value 7, shape len=4
-    let out = <H4u8Nct as CheckedMul>::checked_mul(a, b).expect("value fits");
+    let a = H4u8Nct::from_limbs([5, 0, 0, 0], 4);
+    let b = H4u8Nct::from_limbs([7, 0, 0, 0], 4);
+    let out = <H4u8Nct as CheckedMul>::checked_mul(a, b).expect("35 fits in width 4");
+    assert_eq!(out.len(), 4);
     assert_eq!(out.limbs()[0], 35);
-    assert_eq!(out.len(), 1);
 }
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1650,3 +1650,89 @@ fn div_rem_early_returns_preserve_width() {
     assert!(<H4u32Nct as Zero>::is_zero(&q));
     assert_eq!(r, a);
 }
+
+// ── Trait-form ops and less-travelled paths ──
+
+// The `WrappingAdd`/`OverflowingAdd`/… trait impls (as opposed to the
+// inherent methods) are what generic callers reach through; exercise them
+// on both value and reference receivers.
+#[test]
+fn trait_form_wrapping_and_overflowing_ops() {
+    use const_num_traits::{
+        OverflowingAdd, OverflowingMul, OverflowingSub, WrappingAdd, WrappingMul, WrappingSub,
+    };
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 30u32.into();
+
+    assert_eq!(WrappingAdd::wrapping_add(&a, &b), 130u32.into());
+    assert_eq!(WrappingSub::wrapping_sub(&a, &b), 70u32.into());
+    assert_eq!(WrappingMul::wrapping_mul(&a, &b), 3000u32.into());
+
+    assert_eq!(
+        OverflowingAdd::overflowing_add(&a, &b),
+        (130u32.into(), false)
+    );
+    assert_eq!(
+        OverflowingSub::overflowing_sub(&a, &b),
+        (70u32.into(), false)
+    );
+    assert_eq!(
+        OverflowingMul::overflowing_mul(&a, &b),
+        (3000u32.into(), false)
+    );
+    // Value-receiver trait forms.
+    assert_eq!(
+        OverflowingMul::overflowing_mul(a, b),
+        (3000u32.into(), false)
+    );
+}
+
+// `Hash` is value-based: equal values at different shapes hash alike.
+#[test]
+fn hash_is_value_based() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let digest = |x: &H4u32Nct| {
+        let mut s = DefaultHasher::new();
+        x.hash(&mut s);
+        s.finish()
+    };
+    let narrow = H4u32Nct::from_limbs([5, 0, 0, 0], 1);
+    let wide = H4u32Nct::from_limbs([5, 0, 0, 0], 3);
+    assert_eq!(digest(&narrow), digest(&wide));
+}
+
+// `ConstZero::ZERO` / `ConstOne::ONE` const items and the `set_*` mutators.
+#[test]
+fn const_items_and_setters() {
+    use const_num_traits::{ConstOne, ConstZero};
+    let z = <H4u32Nct as ConstZero>::ZERO;
+    let o = <H4u32Nct as ConstOne>::ONE;
+    assert!(<H4u32Nct as Zero>::is_zero(&z));
+    assert!(<H4u32Nct as One>::is_one(&o));
+
+    let mut x: H4u32Nct = 42u32.into();
+    <H4u32Nct as Zero>::set_zero(&mut x);
+    assert!(<H4u32Nct as Zero>::is_zero(&x));
+    <H4u32Nct as One>::set_one(&mut x);
+    assert!(<H4u32Nct as One>::is_one(&x));
+}
+
+// Ct-personality magnitude scans (the branchless leading-zero arm) and the
+// by-reference `BitWidth` impl.
+#[test]
+fn ct_magnitude_and_reference_bit_width() {
+    use const_num_traits::BitWidth;
+    // value = 2^32, width 64: 33 significant bits, 31 leading zeros.
+    let v = HeaplessBigInt::<u32, 4, Ct>::from_limbs([0, 1, 0, 0], 2);
+    assert_eq!(v.bit_length(), 33);
+    assert_eq!(v.leading_zeros(), 31);
+
+    let n = H4u32Nct::from_limbs([0, 1, 0, 0], 2);
+    let r: &H4u32Nct = &n;
+    assert_eq!(BitWidth::bit_width(r), 33);
+
+    // Ct is_one on a zero-length value takes the early `n == 0` path.
+    let z = <HeaplessBigInt<u32, 4, Ct> as Zero>::zero();
+    assert!(!<HeaplessBigInt<u32, 4, Ct> as One>::is_one(&z));
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -414,35 +414,41 @@ fn shl_within_a_limb() {
 }
 
 #[test]
-fn shl_crosses_a_limb() {
-    // Shift a byte at bit position 24 by 8 → carries into limb 1.
+fn shl_crosses_a_limb_within_width() {
+    // Width-preserving: at width 1 (len 1) the top byte shifts out, like
+    // FixedUInt<u32,1>. 0xAB000000 << 8 = 0 (mod 2^32).
     let a = H4u32Nct::from_limbs([0xAB000000, 0, 0, 0], 1);
     let b = a << 8;
-    // Low limb: top byte 0xAB shifts out, low bytes are 0. New limb 0 = 0.
-    // High limb: 0xAB now in the low byte of limb 1.
+    assert_eq!(b.len(), 1);
     assert_eq!(b.limbs()[0], 0);
-    assert_eq!(b.limbs()[1], 0x000000AB);
-    assert_eq!(b.len(), 2);
+
+    // At width 2 (len 2) the same byte has room to carry into limb 1.
+    let a2 = H4u32Nct::from_limbs([0xAB000000, 0, 0, 0], 2);
+    let b2 = a2 << 8;
+    assert_eq!(b2.len(), 2);
+    assert_eq!(b2.limbs()[0], 0);
+    assert_eq!(b2.limbs()[1], 0x000000AB);
 }
 
 #[test]
-fn shl_by_full_word() {
+fn shl_by_full_word_preserves_width() {
+    // Width 2 (len 2): << 32 shifts limb 0 into limb 1; the old limb 1
+    // (value 2) shifts out of the width. Matches FixedUInt<u32,2>.
     let a = H4u32Nct::from_limbs([1, 2, 0, 0], 2);
     let b = a << 32;
+    assert_eq!(b.len(), 2);
     assert_eq!(b.limbs()[0], 0);
     assert_eq!(b.limbs()[1], 1);
-    assert_eq!(b.limbs()[2], 2);
-    // out_len = min(2 + 1 + 0, 4) = 3.
-    assert_eq!(b.len(), 3);
 }
 
 #[test]
-fn shl_beyond_capacity_truncates() {
+fn shl_beyond_width_is_zero() {
+    // Width 1 (len 1, 32 bits): shifting by >= the width gives zero, like
+    // FixedUInt<u32,1>. Width is preserved (len stays 1); CAP is irrelevant.
     let a = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
-    // CAP=4, WORD_BITS=32 → 128 bits total. Shift by 128 → zero.
     let b = a << 128;
     assert!(<H4u32Nct as Zero>::is_zero(&b));
-    assert_eq!(b.len(), 0);
+    assert_eq!(b.len(), 1);
 }
 
 // ── Shr ──

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1091,3 +1091,52 @@ fn trait_checked_mul_reports_true_overflow() {
     let b = H4u8Nct::from_limbs([0, 0, 1, 0], 3); // 2^16
     assert_eq!(<H4u8Nct as CheckedMul>::checked_mul(a, b), None);
 }
+
+// ── BitAnd ──
+
+#[test]
+fn bitand_masks_bits() {
+    let a: H4u32Nct = 0xF0F0_F0F0u32.into();
+    let mask: H4u32Nct = 0x00FF_00FFu32.into();
+    let out = a & mask;
+    assert_eq!(out.limbs()[0], 0x00F0_00F0);
+}
+
+#[test]
+fn bitand_output_len_is_min_of_operand_lens() {
+    // a spans 3 limbs, mask spans 1 → result can only have limb 0 set.
+    let a = H4u32Nct::from_limbs([0xFFFF_FFFF, 0xFFFF_FFFF, 0xFFFF_FFFF, 0], 3);
+    let mask: H4u32Nct = 0x0000_00FFu32.into(); // len 1
+    let out = &a & &mask;
+    assert_eq!(out.len(), 1);
+    assert_eq!(out.limbs()[0], 0x0000_00FF);
+}
+
+#[test]
+fn bitand_preserves_zero_tail() {
+    let a = H4u32Nct::from_limbs([0xAAAA_AAAA, 0xBBBB_BBBB, 0, 0], 2);
+    let b = H4u32Nct::from_limbs([0xFFFF_0000, 0x0000_FFFF, 0, 0], 2);
+    let out = a & b;
+    assert_eq!(out.all_limbs()[2], 0);
+    assert_eq!(out.all_limbs()[3], 0);
+}
+
+#[test]
+fn bitand_all_receiver_forms_agree() {
+    let a: H4u32Nct = 0xF0F0_F0F0u32.into();
+    let b: H4u32Nct = 0x00FF_00FFu32.into();
+    let ref_ref = &a & &b;
+    assert_eq!(a & b, ref_ref);
+    assert_eq!(a & &b, ref_ref);
+    assert_eq!(&a & b, ref_ref);
+}
+
+#[test]
+fn bitand_with_full_width_mask() {
+    // Masking a short value by a full-CAP all-ones mask returns the value.
+    let v: H4u32Nct = 0x1234_5678u32.into(); // len 1
+    let mask = H4u32Nct::from_limbs([u32::MAX; 4], 4);
+    let out = v & mask;
+    assert_eq!(out.limbs()[0], 0x1234_5678);
+    assert_eq!(out.len(), 1);
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -64,8 +64,8 @@ fn from_limbs_preserves_shape() {
 
 #[test]
 #[should_panic]
-fn from_limbs_rejects_nonzero_tail_in_debug() {
-    // In release this passes silently (debug_assert only).
+fn from_limbs_rejects_nonzero_tail() {
+    // The tail check is unconditional, so this panics in release too.
     let _ = H4u32Nct::from_limbs([1, 0, 42, 0], 1);
 }
 
@@ -366,9 +366,10 @@ fn ord_by_highest_limb() {
 
 // ── Ct-personality carriers ──
 //
-// The impls are shared across Nct/Ct (personality dispatch enters only
-// when the output shape differs). Sanity-check that Ct-typed values
-// arithmetic works and produces the same values.
+// Shared ops dispatch on `P` where the Ct arm must avoid value-dependent
+// control flow (arithmetic panics, compare/is_zero short-circuits, Debug).
+// The Ct arm produces the same values as Nct; these check that plus the
+// constant-time-shaped behavior (wrap instead of panic, opaque Debug).
 
 #[test]
 fn ct_add_matches_nct() {
@@ -1566,4 +1567,78 @@ mod to_from_bytes {
         assert_eq!(bytes.as_ref().len(), 8);
         assert_eq!(bytes.as_ref(), &[0, 0, 0, 0, 0x11, 0x22, 0x33, 0x44]);
     }
+}
+
+// ── Ct constant-time contract (regression for the PR #138 review) ──
+
+// `+` on Ct must not panic on a data-dependent overflow: it wraps, like
+// `wrapping_add`. The same operands panic under Nct.
+#[test]
+fn ct_add_overflow_wraps_instead_of_panicking() {
+    let a = HeaplessBigInt::<u8, 8, Ct>::from_limbs([0xff, 0, 0, 0, 0, 0, 0, 0], 1);
+    let b = HeaplessBigInt::<u8, 8, Ct>::from_limbs([1, 0, 0, 0, 0, 0, 0, 0], 1);
+    let s = &a + &b; // width 1: 0x100 wraps to 0
+    assert_eq!(s.len(), 1);
+    assert_eq!(s.limbs()[0], 0);
+}
+
+#[test]
+#[should_panic]
+fn nct_add_overflow_panics() {
+    let a = H8Nct::from_limbs([0xff, 0, 0, 0, 0, 0, 0, 0], 1);
+    let b = H8Nct::from_limbs([1, 0, 0, 0, 0, 0, 0, 0], 1);
+    let _ = &a + &b;
+}
+
+// Ct Debug is opaque; Nct still prints limbs.
+#[test]
+fn ct_debug_is_opaque() {
+    let ct = HeaplessBigInt::<u32, 4, Ct>::from_limbs([0xdead_beef, 0, 0, 0], 1);
+    let s = format!("{ct:?}");
+    assert_eq!(s, "HeaplessBigInt<…>");
+    assert!(!s.contains("beef"));
+
+    let nct = H4u32Nct::from_limbs([0xdead_beef, 0, 0, 0], 1);
+    assert!(format!("{nct:?}").contains("limbs"));
+}
+
+// Ct compare and is_zero/is_one return the same answers as Nct.
+#[test]
+fn ct_cmp_and_predicates_match_values() {
+    let a = HeaplessBigInt::<u32, 4, Ct>::from_limbs([5, 7, 0, 0], 2);
+    let b = HeaplessBigInt::<u32, 4, Ct>::from_limbs([9, 7, 0, 0], 2);
+    assert!(a < b);
+    assert!(b > a);
+    assert_eq!(a.cmp(&a), core::cmp::Ordering::Equal);
+
+    let z = <HeaplessBigInt<u32, 4, Ct> as Zero>::zero();
+    let one = <HeaplessBigInt<u32, 4, Ct> as One>::one();
+    assert!(<HeaplessBigInt<u32, 4, Ct> as Zero>::is_zero(&z));
+    assert!(!<HeaplessBigInt<u32, 4, Ct> as Zero>::is_zero(&a));
+    assert!(<HeaplessBigInt<u32, 4, Ct> as One>::is_one(&one));
+    assert!(!<HeaplessBigInt<u32, 4, Ct> as One>::is_one(&a));
+}
+
+// Div/Rem early-return paths carry the operands' width, like the general
+// path — otherwise `x / x` would come back one word wide.
+#[test]
+fn div_rem_early_returns_preserve_width() {
+    // Equal: quotient 1, remainder 0, both at work_len = 2.
+    let x = H4u32Nct::from_limbs([5, 7, 0, 0], 2);
+    let q = x / x;
+    let r = x % x;
+    assert_eq!(q.len(), 2);
+    assert_eq!(r.len(), 2);
+    assert_eq!(q, H4u32Nct::from(1u32));
+    assert!(<H4u32Nct as Zero>::is_zero(&r));
+
+    // Less: quotient 0, remainder == dividend, both at work_len = 2.
+    let a = H4u32Nct::from_limbs([3, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([5, 7, 0, 0], 2);
+    let q = a / b;
+    let r = a % b;
+    assert_eq!(q.len(), 2);
+    assert_eq!(r.len(), 2);
+    assert!(<H4u32Nct as Zero>::is_zero(&q));
+    assert_eq!(r, a);
 }

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -601,6 +601,60 @@ fn leading_zeros_plus_bit_length_equals_cap_bits() {
     assert_eq!(v.leading_zeros() + v.bit_length(), 128);
 }
 
+// ── BitsPrecision (width = len·word_bits) / BitWidth (bit-length) ──
+
+#[test]
+fn bits_precision_is_len_times_word_bits_not_cap() {
+    use const_num_traits::BitsPrecision;
+    // u32 backing: width = len * 32, tracks the constructed len, never CAP.
+    assert_eq!(
+        BitsPrecision::bits_precision(H4u32Nct::from_limbs([1, 0, 0, 0], 1)),
+        32
+    );
+    assert_eq!(
+        BitsPrecision::bits_precision(H4u32Nct::from_limbs([1, 2, 0, 0], 2)),
+        64
+    );
+    assert_eq!(
+        BitsPrecision::bits_precision(H4u32Nct::from_limbs([1, 2, 3, 4], 4)),
+        128
+    );
+    // len 0 (mathematical zero) → width 0.
+    assert_eq!(BitsPrecision::bits_precision(<H4u32Nct as Zero>::zero()), 0);
+    // u8 backing: width = len * 8.
+    type H8u8 = HeaplessBigInt<u8, 8, Nct>;
+    assert_eq!(
+        BitsPrecision::bits_precision(H8u8::from_be_bytes(&[1, 2, 3])),
+        24
+    );
+}
+
+#[test]
+fn bits_precision_via_reference() {
+    use const_num_traits::BitsPrecision;
+    let v = H4u32Nct::from_limbs([1, 2, 0, 0], 2);
+    assert_eq!((&v).bits_precision(), 64);
+}
+
+#[test]
+fn bit_width_is_bit_length() {
+    use const_num_traits::BitWidth;
+    // Magnitude (top set bit), <= bits_precision.
+    assert_eq!(BitWidth::bit_width(<H4u32Nct as Zero>::zero()), 0);
+    assert_eq!(
+        BitWidth::bit_width(H4u32Nct::from_limbs([0b101, 0, 0, 0], 1)),
+        3
+    );
+    // A value at len 2 (width 64) whose magnitude is small: bit_width < precision.
+    let v = H4u32Nct::from_limbs([0xFF, 0, 0, 0], 2);
+    assert_eq!(BitWidth::bit_width(v), 8);
+    assert_eq!(
+        <H4u32Nct as const_num_traits::BitsPrecision>::bits_precision(v),
+        64
+    );
+    assert!(BitWidth::bit_width(v) <= const_num_traits::BitsPrecision::bits_precision(v));
+}
+
 #[test]
 fn bytes_work_across_widths() {
     // u8 backing: byte-per-limb, no cross-limb assembly.

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -123,31 +123,17 @@ fn sub_underflow_wraps_and_flags() {
 }
 
 #[test]
-fn sub_underflow_wraps_at_full_cap_width() {
-    // Underflow wraps at the full container width (CAP limbs), matching
-    // FixedUInt<T, CAP> — not at max(operand_len). Output len = CAP.
-    let a = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
-    let b = H4u32Nct::from_limbs([2, 0, 0, 0], 1);
+fn sub_underflow_wraps_at_operand_width_not_cap() {
+    // A HeaplessBigInt's width is len·word_bits, not CAP. Underflow wraps
+    // at the operands' width (max len), leaving CAP out of it: 5 - 7 at
+    // len 1 (u32 backing → width 32) is a 32-bit wrap, and the result
+    // stays len 1 — the high CAP limbs are untouched.
+    let a: H4u32Nct = 5u32.into(); // len 1, width 32
+    let b: H4u32Nct = 7u32.into();
     let w = a.wrapping_sub(&b);
-    assert_eq!(w.len(), 4);
-    assert_eq!(w.all_limbs(), &[u32::MAX; 4]); // 2^128 - 1
-}
-
-#[test]
-fn wrapping_sub_is_value_deterministic_not_len_deterministic() {
-    // Same values carried at different lens must give the same wrapped
-    // result — the property the len-derived width previously violated.
-    let five_short: H4u32Nct = 5u32.into(); // len 1
-    let seven_short: H4u32Nct = 7u32.into();
-    let five_long = H4u32Nct::from_limbs([5, 0, 0, 0], 4); // len 4
-    let seven_long = H4u32Nct::from_limbs([7, 0, 0, 0], 4);
-    assert_eq!(
-        five_short.wrapping_sub(&seven_short),
-        five_long.wrapping_sub(&seven_long)
-    );
-    // And the value is the CAP-width wrap of 5 - 7 = -2.
-    let w = five_short.wrapping_sub(&seven_short);
-    assert_eq!(w.all_limbs(), &[u32::MAX - 1, u32::MAX, u32::MAX, u32::MAX]);
+    assert_eq!(w.len(), 1);
+    assert_eq!(w.limbs()[0], u32::MAX - 1); // 2^32 - 2
+    assert_eq!(w.all_limbs()[1], 0); // CAP limbs beyond the width stay zero
 }
 
 // ── Mul ──

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1,0 +1,217 @@
+//! Sketch-level sanity tests: constructors work, Add/Sub/Mul produce
+//! correct values against small u16/u32 inputs, PartialEq is
+//! value-based across shapes, Zero/One/Default line up, and Ct paths
+//! (subtle::ConstantTimeEq) agree with the value.
+
+#![cfg(feature = "heapless-runtime-len")]
+
+use const_num_traits::{Ct, Nct, One, Zero};
+use fixed_bigint::HeaplessBigInt;
+use subtle::ConstantTimeEq;
+
+type H8Nct = HeaplessBigInt<u8, 8, Nct>;
+type H8Ct = HeaplessBigInt<u8, 8, Ct>;
+type H4u32Nct = HeaplessBigInt<u32, 4, Nct>;
+
+// ── Constructors ──
+
+#[test]
+fn zero_has_len_zero() {
+    let z = <H8Nct as Zero>::zero();
+    assert_eq!(z.len(), 0);
+    assert!(z.is_empty());
+    assert!(<H8Nct as Zero>::is_zero(&z));
+}
+
+#[test]
+fn one_has_len_one_and_top_limb_one() {
+    let o = <H8Nct as One>::one();
+    assert_eq!(o.len(), 1);
+    assert_eq!(o.limbs(), &[1u8]);
+}
+
+#[test]
+fn default_equals_zero() {
+    let d = H8Nct::default();
+    let z = <H8Nct as Zero>::zero();
+    assert_eq!(d.len(), z.len());
+    assert_eq!(d, z);
+}
+
+#[test]
+fn zero_full_cap_len_equals_cap() {
+    let f = H8Nct::zero_full_cap();
+    assert_eq!(f.len(), 8);
+    assert_eq!(f.capacity(), 8);
+    // Value-equal to Zero despite different shape.
+    let z = <H8Nct as Zero>::zero();
+    assert_eq!(f, z);
+}
+
+#[test]
+fn from_limbs_preserves_shape() {
+    let v = H4u32Nct::from_limbs([0x1234, 0x5678, 0, 0], 2);
+    assert_eq!(v.len(), 2);
+    assert_eq!(v.limbs(), &[0x1234, 0x5678]);
+}
+
+#[test]
+#[should_panic]
+fn from_limbs_rejects_nonzero_tail_in_debug() {
+    // In release this passes silently (debug_assert only).
+    let _ = H4u32Nct::from_limbs([1, 0, 42, 0], 1);
+}
+
+// ── Add / Sub ──
+
+#[test]
+fn add_small_values() {
+    let a = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([200, 0, 0, 0], 1);
+    let s = a.wrapping_add(&b);
+    assert_eq!(s.limbs()[0], 300);
+}
+
+#[test]
+fn add_cross_limb_carry() {
+    // (u32::MAX) + 1 = 0x1_0000_0000, spans two limbs.
+    let a = H4u32Nct::from_limbs([u32::MAX, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
+    let s = a.wrapping_add(&b);
+    // Output len is max(1, 1) + 1 = 2.
+    assert_eq!(s.len(), 2);
+    assert_eq!(s.limbs()[0], 0);
+    assert_eq!(s.limbs()[1], 1);
+}
+
+#[test]
+fn add_overflows_when_natural_len_exceeds_cap() {
+    // 2 CAP=4 32-bit values whose sum needs 5 limbs.
+    let max = H4u32Nct::from_limbs([u32::MAX; 4], 4);
+    let one = <H4u32Nct as One>::one();
+    let (_wrapped, overflow) = max.overflowing_add(&one);
+    assert!(
+        overflow,
+        "expected overflow when natural sum needs CAP+1 limbs"
+    );
+    assert_eq!(max.checked_add(&one), None);
+}
+
+#[test]
+fn sub_within_range() {
+    let a = H4u32Nct::from_limbs([300, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
+    let d = a.wrapping_sub(&b);
+    assert_eq!(d.limbs()[0], 200);
+}
+
+#[test]
+fn sub_underflow_wraps_and_flags() {
+    let a = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([2, 0, 0, 0], 1);
+    let (wrapped, borrow) = a.overflowing_sub(&b);
+    assert!(borrow, "expected borrow on underflow");
+    assert_eq!(wrapped.limbs()[0], u32::MAX);
+    assert_eq!(a.checked_sub(&b), None);
+}
+
+// ── Mul ──
+
+#[test]
+fn mul_small_product_fits() {
+    let a = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([200, 0, 0, 0], 1);
+    let p = a.wrapping_mul(&b);
+    // Output len = min(1 + 1, 4) = 2. Value = 20_000 fits in limb 0.
+    assert_eq!(p.len(), 2);
+    assert_eq!(p.limbs()[0], 20_000);
+    assert_eq!(p.limbs()[1], 0);
+}
+
+#[test]
+fn mul_cross_limb_carry() {
+    // 0x1_0000 * 0x1_0000 = 0x1_0000_0000, straddles limb boundary.
+    let a = H4u32Nct::from_limbs([0x1_0000, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([0x1_0000, 0, 0, 0], 1);
+    let p = a.wrapping_mul(&b);
+    assert_eq!(p.limbs()[0], 0);
+    assert_eq!(p.limbs()[1], 1);
+}
+
+#[test]
+fn mul_overflow_when_natural_len_exceeds_cap() {
+    // len=3 * len=3 → natural product needs 6 limbs; CAP=4.
+    let a = H4u32Nct::from_limbs([1, 1, 1, 0], 3);
+    let b = H4u32Nct::from_limbs([1, 1, 1, 0], 3);
+    let (_wrapped, overflow) = a.overflowing_mul(&b);
+    assert!(
+        overflow,
+        "expected overflow when natural product exceeds CAP"
+    );
+    assert_eq!(a.checked_mul(&b), None);
+}
+
+// ── PartialEq / PartialOrd (value-based) ──
+
+#[test]
+fn eq_across_shapes_when_values_match() {
+    let a = <H4u32Nct as Zero>::zero(); // len = 0
+    let b = H4u32Nct::from_limbs([0, 0, 0, 0], 4); // len = 4 (all-zero)
+    assert_eq!(a, b, "value-based Eq: both represent mathematical zero");
+}
+
+#[test]
+fn eq_distinct_values_differ() {
+    let a = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([2, 0, 0, 0], 1);
+    assert_ne!(a, b);
+}
+
+#[test]
+fn ord_less_greater() {
+    let a = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([200, 0, 0, 0], 1);
+    assert!(a < b);
+    assert!(b > a);
+}
+
+#[test]
+fn ord_by_highest_limb() {
+    let a = H4u32Nct::from_limbs([u32::MAX, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([0, 1, 0, 0], 2);
+    // b has a bit set in limb 1, so b > a even though a's limb 0 > b's.
+    assert!(b > a);
+}
+
+// ── Ct-personality carriers ──
+//
+// The impls are shared across Nct/Ct (personality dispatch enters only
+// when the output shape differs). Sanity-check that Ct-typed values
+// arithmetic works and produces the same values.
+
+#[test]
+fn ct_add_matches_nct() {
+    let a_ct = HeaplessBigInt::<u32, 4, Ct>::from_limbs([100, 0, 0, 0], 1);
+    let b_ct = HeaplessBigInt::<u32, 4, Ct>::from_limbs([200, 0, 0, 0], 1);
+    let s_ct = a_ct.wrapping_add(&b_ct);
+    assert_eq!(s_ct.limbs()[0], 300);
+}
+
+#[test]
+fn ct_eq_agrees_with_partial_eq() {
+    let a = H8Ct::from_limbs([1, 2, 3, 0, 0, 0, 0, 0], 3);
+    let b = H8Ct::from_limbs([1, 2, 3, 0, 0, 0, 0, 0], 3);
+    let c = H8Ct::from_limbs([1, 2, 4, 0, 0, 0, 0, 0], 3);
+    assert_eq!(bool::from(a.ct_eq(&b)), true);
+    assert_eq!(bool::from(a.ct_eq(&c)), false);
+    assert!(a == b);
+    assert!(a != c);
+}
+
+#[test]
+fn ct_eq_across_shapes() {
+    // Same-value, different-shape operands agree under Ct equality too.
+    let a = H8Ct::zero_full_cap();
+    let b = <H8Ct as Zero>::zero();
+    assert_eq!(bool::from(a.ct_eq(&b)), true);
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1188,3 +1188,78 @@ fn zeroize_wipes_value() {
     assert_eq!(v, H4u32Nct::default());
     assert_eq!(v.len(), 0);
 }
+
+// ── const_num_traits::ToBytes / FromBytes (needs BytesHolder) ──
+
+#[cfg(any(feature = "use-unsafe", feature = "nightly"))]
+mod to_from_bytes {
+    use super::*;
+    use const_num_traits::{FromBytes, ToBytes};
+
+    #[test]
+    fn to_be_bytes_is_full_container_width() {
+        // len=1 value in a CAP=4 u32 container → 16 bytes, left-padded.
+        let v: H4u32Nct = 0x1234_5678u32.into();
+        let bytes = ToBytes::to_be_bytes(v);
+        assert_eq!(bytes.as_ref().len(), 16);
+        // High 12 bytes zero, low 4 = the value big-endian.
+        assert_eq!(&bytes.as_ref()[..12], &[0u8; 12]);
+        assert_eq!(&bytes.as_ref()[12..], &[0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn to_le_bytes_is_full_container_width() {
+        let v: H4u32Nct = 0x1234_5678u32.into();
+        let bytes = ToBytes::to_le_bytes(v);
+        assert_eq!(bytes.as_ref().len(), 16);
+        assert_eq!(&bytes.as_ref()[..4], &[0x78, 0x56, 0x34, 0x12]);
+        assert_eq!(&bytes.as_ref()[4..], &[0u8; 12]);
+    }
+
+    #[test]
+    fn be_round_trip_through_holder() {
+        let v = H4u32Nct::from_limbs([0xDEAD_BEEF, 0xCAFE_BABE, 0x0102_0304, 0], 3);
+        let bytes = ToBytes::to_be_bytes(v);
+        let back = <H4u32Nct as FromBytes>::from_be_bytes(&bytes);
+        // FromBytes reconstructs at full width (len = CAP); trim to compare value.
+        assert_eq!(back.trim(), v);
+    }
+
+    #[test]
+    fn le_round_trip_through_holder() {
+        let v = H4u32Nct::from_limbs([0xDEAD_BEEF, 0xCAFE_BABE, 0x0102_0304, 0], 3);
+        let bytes = ToBytes::to_le_bytes(v);
+        let back = <H4u32Nct as FromBytes>::from_le_bytes(&bytes);
+        assert_eq!(back.trim(), v);
+    }
+
+    #[test]
+    fn ref_tobytes_matches_owned() {
+        let v: H4u32Nct = 0xABCD_1234u32.into();
+        let owned = ToBytes::to_be_bytes(v);
+        let by_ref = ToBytes::to_be_bytes(&v);
+        assert_eq!(owned.as_ref(), by_ref.as_ref());
+    }
+
+    #[test]
+    fn byte_shape_matches_fixeduint_same_params() {
+        // The whole point of the full-width representation: a HeaplessBigInt
+        // and a FixedUInt of the same <T, CAP> serialise identically, so a
+        // carrier-generic consumer round-trips a modulus the same way.
+        use fixed_bigint::FixedUInt;
+        let h: H4u32Nct = 0x1234_5678u32.into();
+        let f = FixedUInt::<u32, 4>::from(0x1234_5678u32);
+        let hb = ToBytes::to_be_bytes(h);
+        let fb = <FixedUInt<u32, 4> as ToBytes>::to_be_bytes(f);
+        assert_eq!(hb.as_ref(), fb.as_ref());
+    }
+
+    #[test]
+    fn works_across_widths() {
+        type H8u8 = HeaplessBigInt<u8, 8, Nct>;
+        let v = H8u8::from_be_bytes(&[0x11, 0x22, 0x33, 0x44]);
+        let bytes = ToBytes::to_be_bytes(v);
+        assert_eq!(bytes.as_ref().len(), 8);
+        assert_eq!(bytes.as_ref(), &[0, 0, 0, 0, 0x11, 0x22, 0x33, 0x44]);
+    }
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -81,14 +81,22 @@ fn add_small_values() {
 
 #[test]
 fn add_cross_limb_carry() {
-    // (u32::MAX) + 1 = 0x1_0000_0000, spans two limbs.
+    // (u32::MAX) + 1 = 0x1_0000_0000. wrapping_add wraps at the value
+    // width (len 1 → 2^32), so the carry is discarded → 0 at len 1
+    // (like FixedUInt<u32,1>). The growing sum that keeps the carry is
+    // overflowing_add / core::ops::+, which is what EEA relies on.
     let a = H4u32Nct::from_limbs([u32::MAX, 0, 0, 0], 1);
     let b = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
-    let s = a.wrapping_add(&b);
-    // Output len is max(1, 1) + 1 = 2.
-    assert_eq!(s.len(), 2);
-    assert_eq!(s.limbs()[0], 0);
-    assert_eq!(s.limbs()[1], 1);
+    let w = a.wrapping_add(&b);
+    assert_eq!(w.len(), 1);
+    assert_eq!(w.limbs()[0], 0);
+
+    // overflowing_add grows a limb to hold the carry (no CAP overflow).
+    let (grown, overflow) = a.overflowing_add(&b);
+    assert!(!overflow);
+    assert_eq!(grown.len(), 2);
+    assert_eq!(grown.limbs()[0], 0);
+    assert_eq!(grown.limbs()[1], 1);
 }
 
 #[test]
@@ -140,23 +148,30 @@ fn sub_underflow_wraps_at_operand_width_not_cap() {
 
 #[test]
 fn mul_small_product_fits() {
+    // 100 * 200 = 20_000 < 2^32, so at value width 1 it fits in one limb
+    // with no wrap. wrapping_mul stays len 1 (like FixedUInt<u32,1>).
     let a = H4u32Nct::from_limbs([100, 0, 0, 0], 1);
     let b = H4u32Nct::from_limbs([200, 0, 0, 0], 1);
     let p = a.wrapping_mul(&b);
-    // Output len = min(1 + 1, 4) = 2. Value = 20_000 fits in limb 0.
-    assert_eq!(p.len(), 2);
+    assert_eq!(p.len(), 1);
     assert_eq!(p.limbs()[0], 20_000);
-    assert_eq!(p.limbs()[1], 0);
 }
 
 #[test]
 fn mul_cross_limb_carry() {
-    // 0x1_0000 * 0x1_0000 = 0x1_0000_0000, straddles limb boundary.
+    // 0x1_0000 * 0x1_0000 = 2^32. wrapping_mul wraps at the value width
+    // (len 1 → 2^32) → 0, like FixedUInt<u32,1>. The full growing
+    // product lives in checked_mul / core::ops::* (used by EEA).
     let a = H4u32Nct::from_limbs([0x1_0000, 0, 0, 0], 1);
     let b = H4u32Nct::from_limbs([0x1_0000, 0, 0, 0], 1);
-    let p = a.wrapping_mul(&b);
-    assert_eq!(p.limbs()[0], 0);
-    assert_eq!(p.limbs()[1], 1);
+    let w = a.wrapping_mul(&b);
+    assert_eq!(w.len(), 1);
+    assert_eq!(w.limbs()[0], 0);
+
+    // The full product 2^32 = [0, 1] is available (fits in CAP=4).
+    let full = a.checked_mul(&b).expect("2^32 fits in CAP");
+    assert_eq!(full.limbs()[0], 0);
+    assert_eq!(full.limbs()[1], 1);
 }
 
 #[test]
@@ -170,6 +185,28 @@ fn mul_overflow_when_natural_len_exceeds_cap() {
         "expected overflow when natural product exceeds CAP"
     );
     assert_eq!(a.checked_mul(&b), None);
+}
+
+#[test]
+fn wrapping_ops_do_not_grow_width() {
+    // The headline symptom from the Montgomery n_prime trace: wrapping
+    // ops must keep the value width fixed so iterative modular algorithms
+    // stay self-consistent. one + one = 2 at len 1 (not [2,0] at len 2).
+    let one = <H4u32Nct as One>::one();
+    let two = one.wrapping_add(&one);
+    assert_eq!(two.len(), 1);
+    assert_eq!(two.limbs()[0], 2);
+
+    // A newton-style step at a fixed width-1 modulus: 2 - (m*x) stays
+    // len 1 through wrapping_mul / wrapping_sub, matching the width-1
+    // FixedUInt arithmetic the parity test pins. Here m=35, x=1.
+    let m = H4u32Nct::from_limbs([35, 0, 0, 0], 1);
+    let x = one;
+    let mx = m.wrapping_mul(&x);
+    assert_eq!(mx.len(), 1);
+    let r = two.wrapping_sub(&mx);
+    assert_eq!(r.len(), 1);
+    assert_eq!(r.limbs()[0], 2u32.wrapping_sub(35)); // wraps at 2^32
 }
 
 // ── PartialEq / PartialOrd (value-based) ──

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -294,6 +294,45 @@ fn wrapping_sub_preserves_width_no_stale_len() {
     );
 }
 
+#[test]
+fn with_precision_seeds_at_witness_width() {
+    use const_num_traits::{BitsPrecision, WithPrecision, WrappingSub};
+    // A witness (stand-in modulus) carried at len 3 (sub-CAP, CAP=4).
+    let q = H4u32Nct::from_limbs([7, 0, 5, 0], 3);
+
+    // zero_with_precision_of(&q): a zero pinned at q's width (len 3), NOT the
+    // minimal-width len-0 zero(). This is the named replacement for the
+    // load-bearing wrapping_sub(q, q) seed idiom — identical result.
+    let z = <H4u32Nct as WithPrecision>::zero_with_precision_of(&q);
+    assert!(<H4u32Nct as Zero>::is_zero(&z));
+    assert_eq!(z.len(), 3);
+    assert_eq!(
+        BitsPrecision::bits_precision(z),
+        BitsPrecision::bits_precision(q)
+    );
+    let idiom = WrappingSub::wrapping_sub(q, q);
+    assert_eq!(z, idiom);
+    assert_eq!(z.len(), idiom.len());
+
+    // one_with_precision_of(&q): value 1 at q's width.
+    let one = <H4u32Nct as WithPrecision>::one_with_precision_of(&q);
+    assert_eq!(one.len(), 3);
+    assert_eq!(one.limbs()[0], 1);
+
+    // widen_to_precision_of: grow a narrow value to the witness width,
+    // value preserved.
+    let small = H4u32Nct::from_limbs([42, 0, 0, 0], 1);
+    let widened = <H4u32Nct as WithPrecision>::widen_to_precision_of(small, &q);
+    assert_eq!(widened.len(), 3);
+    assert_eq!(widened.limbs()[0], 42);
+    assert_eq!(small, widened); // same value, wider carrier
+
+    // Grow-only: widening to a narrower witness keeps the current width.
+    let narrow_witness = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
+    let kept = <H4u32Nct as WithPrecision>::widen_to_precision_of(widened, &narrow_witness);
+    assert_eq!(kept.len(), 3);
+}
+
 // ── PartialEq / PartialOrd (value-based) ──
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -408,3 +408,193 @@ fn shr_by_more_than_value_bits_zeros() {
     assert!(<H4u32Nct as Zero>::is_zero(&b));
     assert_eq!(b.len(), 0);
 }
+
+// ── Byte serialization ──
+
+#[test]
+fn to_be_bytes_single_limb() {
+    let v = H4u32Nct::from_limbs([0x12345678, 0, 0, 0], 1);
+    let mut buf = [0u8; 4];
+    let written = v.to_be_bytes(&mut buf);
+    assert_eq!(written, &[0x12, 0x34, 0x56, 0x78]);
+}
+
+#[test]
+fn to_be_bytes_multiple_limbs_high_first() {
+    let v = H4u32Nct::from_limbs([0xAAAAAAAA, 0xBBBBBBBB, 0, 0], 2);
+    let mut buf = [0u8; 8];
+    let written = v.to_be_bytes(&mut buf);
+    // Limb 1 (higher) at the front, limb 0 at the back.
+    assert_eq!(written, &[0xBB, 0xBB, 0xBB, 0xBB, 0xAA, 0xAA, 0xAA, 0xAA]);
+}
+
+#[test]
+fn to_le_bytes_matches_le_convention() {
+    let v = H4u32Nct::from_limbs([0x12345678, 0, 0, 0], 1);
+    let mut buf = [0u8; 4];
+    let written = v.to_le_bytes(&mut buf);
+    assert_eq!(written, &[0x78, 0x56, 0x34, 0x12]);
+}
+
+#[test]
+fn to_bytes_zero_produces_empty_slice() {
+    let z = <H4u32Nct as Zero>::zero();
+    let mut buf = [0u8; 4];
+    let written = z.to_be_bytes(&mut buf);
+    assert_eq!(written.len(), 0);
+    let written = z.to_le_bytes(&mut buf);
+    assert_eq!(written.len(), 0);
+}
+
+#[test]
+#[should_panic]
+fn to_be_bytes_panics_on_undersized_buffer() {
+    let v = H4u32Nct::from_limbs([1, 2, 0, 0], 2);
+    let mut buf = [0u8; 4]; // needs 8
+    let _ = v.to_be_bytes(&mut buf);
+}
+
+#[test]
+fn from_be_bytes_word_aligned() {
+    let v = H4u32Nct::from_be_bytes(&[0x12, 0x34, 0x56, 0x78]);
+    assert_eq!(v.len(), 1);
+    assert_eq!(v.limbs()[0], 0x12345678);
+}
+
+#[test]
+fn from_be_bytes_partial_top_word_zero_pads() {
+    // 5 bytes = 2 limbs. Low limb has 4 bytes, top limb has 1 byte.
+    let v = H4u32Nct::from_be_bytes(&[0xAB, 0x12, 0x34, 0x56, 0x78]);
+    assert_eq!(v.len(), 2);
+    assert_eq!(v.limbs()[0], 0x12345678);
+    assert_eq!(v.limbs()[1], 0x000000AB);
+}
+
+#[test]
+fn from_le_bytes_word_aligned() {
+    let v = H4u32Nct::from_le_bytes(&[0x78, 0x56, 0x34, 0x12]);
+    assert_eq!(v.len(), 1);
+    assert_eq!(v.limbs()[0], 0x12345678);
+}
+
+#[test]
+fn from_le_bytes_partial_top_word() {
+    let v = H4u32Nct::from_le_bytes(&[0x78, 0x56, 0x34, 0x12, 0xAB]);
+    assert_eq!(v.len(), 2);
+    assert_eq!(v.limbs()[0], 0x12345678);
+    assert_eq!(v.limbs()[1], 0x000000AB);
+}
+
+#[test]
+fn from_bytes_empty_gives_zero() {
+    let v = H4u32Nct::from_be_bytes(&[]);
+    assert_eq!(v.len(), 0);
+    assert!(<H4u32Nct as Zero>::is_zero(&v));
+    let v = H4u32Nct::from_le_bytes(&[]);
+    assert_eq!(v.len(), 0);
+}
+
+#[test]
+#[should_panic]
+fn from_be_bytes_panics_on_oversized_input() {
+    // CAP=4, word_size=4 → max 16 bytes. Give 17.
+    let bytes = [0u8; 17];
+    let _ = H4u32Nct::from_be_bytes(&bytes);
+}
+
+#[test]
+fn be_round_trip() {
+    let original = H4u32Nct::from_limbs([0xDEADBEEF, 0xCAFEBABE, 0x01020304, 0], 3);
+    let mut buf = [0u8; 12];
+    original.to_be_bytes(&mut buf);
+    let back = H4u32Nct::from_be_bytes(&buf);
+    assert_eq!(back.len(), 3);
+    assert_eq!(back.limbs(), original.limbs());
+}
+
+#[test]
+fn le_round_trip() {
+    let original = H4u32Nct::from_limbs([0xDEADBEEF, 0xCAFEBABE, 0x01020304, 0], 3);
+    let mut buf = [0u8; 12];
+    original.to_le_bytes(&mut buf);
+    let back = H4u32Nct::from_le_bytes(&buf);
+    assert_eq!(back.len(), 3);
+    assert_eq!(back.limbs(), original.limbs());
+}
+
+// ── bit_length / leading_zeros ──
+
+#[test]
+fn bit_length_zero_is_zero() {
+    let z = <H4u32Nct as Zero>::zero();
+    assert_eq!(z.bit_length(), 0);
+}
+
+#[test]
+fn bit_length_one_is_one() {
+    let o = <H4u32Nct as One>::one();
+    assert_eq!(o.bit_length(), 1);
+}
+
+#[test]
+fn bit_length_within_single_limb() {
+    let a = H4u32Nct::from_limbs([0x80, 0, 0, 0], 1);
+    assert_eq!(a.bit_length(), 8);
+    let b = H4u32Nct::from_limbs([0xFF, 0, 0, 0], 1);
+    assert_eq!(b.bit_length(), 8);
+    let c = H4u32Nct::from_limbs([1u32 << 31, 0, 0, 0], 1);
+    assert_eq!(c.bit_length(), 32);
+}
+
+#[test]
+fn bit_length_multi_limb() {
+    // Highest set bit is in limb 2, bit 0. Total = 2 * 32 + 1 = 65.
+    let a = H4u32Nct::from_limbs([0, 0, 1, 0], 3);
+    assert_eq!(a.bit_length(), 65);
+    // Highest set bit in limb 3, bit 31. Total = 3 * 32 + 32 = 128.
+    let b = H4u32Nct::from_limbs([0, 0, 0, 1u32 << 31], 4);
+    assert_eq!(b.bit_length(), 128);
+}
+
+#[test]
+fn bit_length_ignores_zero_high_limbs() {
+    // Explicit len=4 but high limbs happen to be zero — same value as
+    // a shorter `len` shape.
+    let a = H4u32Nct::from_limbs([0xABCD, 0, 0, 0], 4);
+    assert_eq!(a.bit_length(), 16);
+}
+
+#[test]
+fn leading_zeros_zero() {
+    let z = <H4u32Nct as Zero>::zero();
+    // CAP=4 × 32 bits = 128.
+    assert_eq!(z.leading_zeros(), 128);
+}
+
+#[test]
+fn leading_zeros_full_width_value() {
+    let v = H4u32Nct::from_limbs([0, 0, 0, 1u32 << 31], 4);
+    assert_eq!(v.leading_zeros(), 0);
+}
+
+#[test]
+fn leading_zeros_plus_bit_length_equals_cap_bits() {
+    let v = H4u32Nct::from_limbs([0, 1u32 << 20, 0, 0], 2);
+    assert_eq!(v.leading_zeros() + v.bit_length(), 128);
+}
+
+#[test]
+fn bytes_work_across_widths() {
+    // u8 backing: byte-per-limb, no cross-limb assembly.
+    type H8u8Nct = HeaplessBigInt<u8, 8, Nct>;
+    let v = H8u8Nct::from_be_bytes(&[0x12, 0x34, 0x56, 0x78]);
+    assert_eq!(v.len(), 4);
+    // BE, byte 0 = 0x12 is the highest byte → limb 3.
+    assert_eq!(v.limbs(), &[0x78, 0x56, 0x34, 0x12]);
+
+    // u64 backing: 8 bytes per limb.
+    type H2u64Nct = HeaplessBigInt<u64, 2, Nct>;
+    let v = H2u64Nct::from_be_bytes(&[0, 0, 0, 0, 0, 0, 0, 0x42]);
+    assert_eq!(v.len(), 1);
+    assert_eq!(v.limbs()[0], 0x42);
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -963,3 +963,78 @@ fn borrowing_sub_underflow_reports_borrow_out() {
     let (_, borrow) = a.borrowing_sub(b, false);
     assert!(borrow);
 }
+
+// ── Nct value-aware checked_mul + trim ──
+
+type H4u8Nct = HeaplessBigInt<u8, 4, Nct>;
+
+#[test]
+fn checked_mul_returns_some_when_value_fits_but_shape_overflows_nct() {
+    // Two operands whose `len` sum exceeds CAP but whose true product
+    // still fits — the shape check would falsely reject, but the value
+    // check accepts.
+    //
+    // Set up: build values with inflated len (all-zero high limbs).
+    let a = H4u8Nct::from_limbs([5, 0, 0, 0], 4); // value 5, shape len=4
+    let b = H4u8Nct::from_limbs([7, 0, 0, 0], 4); // value 7, shape len=4
+    // len sum = 8 > CAP=4, but 5*7 = 35 fits.
+    let out = a
+        .checked_mul(&b)
+        .expect("value fits, checked_mul should accept");
+    assert_eq!(out.limbs()[0], 35);
+    // Nct path trims: len reflects value.
+    assert_eq!(out.len(), 1);
+}
+
+#[test]
+fn checked_mul_returns_none_when_value_truly_overflows() {
+    // 2^24 (limb 3) * 2^16 (limb 2) = 2^40 — doesn't fit in u8*4 = 32 bits.
+    let a = H4u8Nct::from_limbs([0, 0, 0, 1], 4); // 2^24
+    let b = H4u8Nct::from_limbs([0, 0, 1, 0], 3); // 2^16
+    assert!(a.checked_mul(&b).is_none());
+}
+
+#[test]
+fn checked_mul_chain_survives_shape_inflation() {
+    // The "modmath EEA" pattern that would panic under a shape-based
+    // check: multiply small values that keep growing `len` under the
+    // untrimmed shape but whose true values stay small.
+    let start: H4u8Nct = 1u8.into();
+    let a: H4u8Nct = 3u8.into();
+    let b: H4u8Nct = 5u8.into();
+    let c: H4u8Nct = 7u8.into();
+    // start * a * b * c = 105. Fits trivially in one u8 limb.
+    let p1 = start.checked_mul(&a).unwrap();
+    let p2 = p1.checked_mul(&b).unwrap();
+    let p3 = p2.checked_mul(&c).unwrap();
+    assert_eq!(p3.limbs()[0], 105);
+    assert_eq!(p3.len(), 1);
+}
+
+#[test]
+fn trim_normalises_inflated_shape() {
+    // Inflated len=4, only limb 0 non-zero.
+    let v = H4u8Nct::from_limbs([42, 0, 0, 0], 4);
+    let t = v.trim();
+    assert_eq!(t.len(), 1);
+    assert_eq!(t.limbs()[0], 42);
+    // Value equality preserved.
+    assert_eq!(t, v);
+}
+
+#[test]
+fn trim_zero_gives_len_zero() {
+    let z = H4u8Nct::from_limbs([0; 4], 4);
+    let t = z.trim();
+    assert_eq!(t.len(), 0);
+    assert!(<H4u8Nct as Zero>::is_zero(&t));
+}
+
+#[test]
+fn trim_leaves_content_untouched() {
+    // len already tight; trim is a no-op.
+    let v = H4u8Nct::from_limbs([0xAB, 0xCD, 0, 0], 2);
+    let t = v.trim();
+    assert_eq!(t.len(), 2);
+    assert_eq!(t.limbs(), v.limbs());
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1140,3 +1140,51 @@ fn bitand_with_full_width_mask() {
     assert_eq!(out.limbs()[0], 0x1234_5678);
     assert_eq!(out.len(), 1);
 }
+
+// ── FromByteSlice ──
+
+#[test]
+fn from_be_slice_exact_and_short() {
+    use const_num_traits::FromByteSlice;
+    // Exact width.
+    let v = H4u32Nct::from_be_slice(&[0x12, 0x34, 0x56, 0x78]).unwrap();
+    assert_eq!(v.limbs()[0], 0x12345678);
+    // Short input zero-extends (BE reads the trailing window).
+    let v = H4u32Nct::from_be_slice(&[0x12, 0x34]).unwrap();
+    assert_eq!(v.limbs()[0], 0x1234);
+}
+
+#[test]
+fn from_le_slice_exact_and_short() {
+    use const_num_traits::FromByteSlice;
+    let v = H4u32Nct::from_le_slice(&[0x78, 0x56, 0x34, 0x12]).unwrap();
+    assert_eq!(v.limbs()[0], 0x12345678);
+    let v = H4u32Nct::from_le_slice(&[0x34, 0x12]).unwrap();
+    assert_eq!(v.limbs()[0], 0x1234);
+}
+
+#[test]
+fn from_slice_rejects_empty_and_overflow() {
+    use const_num_traits::FromByteSlice;
+    type H4u8 = HeaplessBigInt<u8, 4, Nct>; // 4-byte container
+    assert!(H4u8::from_be_slice(&[]).is_err()); // empty
+    assert!(H4u8::from_le_slice(&[]).is_err());
+    assert!(H4u8::from_be_slice(&[1, 2, 3, 4, 5]).is_err()); // wider than 4 bytes
+    assert!(H4u8::from_le_slice(&[1, 2, 3, 4, 5]).is_err());
+    // Exactly the width is accepted.
+    assert!(H4u8::from_be_slice(&[1, 2, 3, 4]).is_ok());
+}
+
+// ── DefaultIsZeroes / Zeroize ──
+
+#[cfg(feature = "zeroize")]
+#[test]
+fn zeroize_wipes_value() {
+    use zeroize::Zeroize;
+    let mut v = H4u32Nct::from_limbs([0xDEAD_BEEF, 0xCAFE_BABE, 0, 0], 2);
+    v.zeroize();
+    assert!(<H4u32Nct as Zero>::is_zero(&v));
+    // Default-is-zero: wiped value equals Default.
+    assert_eq!(v, H4u32Nct::default());
+    assert_eq!(v.len(), 0);
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -778,3 +778,81 @@ fn div_rem_round_trip_identity() {
     let reconstructed = product.wrapping_add(&r);
     assert_eq!(reconstructed, a);
 }
+
+// ── HasPersonality projection ──
+
+#[test]
+fn has_personality_projects_declared_type() {
+    use const_num_traits::HasPersonality;
+    fn assert_nct<T: HasPersonality<P = Nct>>() {}
+    fn assert_ct<T: HasPersonality<P = Ct>>() {}
+    assert_nct::<H4u32Nct>();
+    assert_ct::<HeaplessBigInt<u32, 4, Ct>>();
+}
+
+// ── RemAssign / DivAssign ──
+
+#[test]
+fn rem_assign_owned_matches_rem() {
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 7u8.into();
+    let mut x = a;
+    x %= b;
+    assert_eq!(x, a % b);
+}
+
+#[test]
+fn rem_assign_ref_matches_rem() {
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 7u8.into();
+    let mut x = a;
+    x %= &b;
+    assert_eq!(x, a % &b);
+}
+
+#[test]
+fn div_assign_owned_matches_div() {
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 7u8.into();
+    let mut x = a;
+    x /= b;
+    assert_eq!(x, a / b);
+}
+
+#[test]
+fn div_assign_ref_matches_div() {
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 7u8.into();
+    let mut x = a;
+    x /= &b;
+    assert_eq!(x, a / &b);
+}
+
+// ── Value + mixed core::ops receiver variants ──
+
+#[test]
+fn add_owned_owned_matches_ref_ref() {
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 200u32.into();
+    assert_eq!(a + b, &a + &b);
+    assert_eq!(a + &b, &a + &b);
+    assert_eq!(&a + b, &a + &b);
+}
+
+#[test]
+fn sub_owned_owned_matches_ref_ref() {
+    let a: H4u32Nct = 500u32.into();
+    let b: H4u32Nct = 200u32.into();
+    assert_eq!(a - b, &a - &b);
+    assert_eq!(a - &b, &a - &b);
+    assert_eq!(&a - b, &a - &b);
+}
+
+#[test]
+fn mul_owned_owned_matches_ref_ref() {
+    let a: H4u32Nct = 13u8.into();
+    let b: H4u32Nct = 17u8.into();
+    assert_eq!(a * b, &a * &b);
+    assert_eq!(a * &b, &a * &b);
+    assert_eq!(&a * b, &a * &b);
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1,7 +1,7 @@
-//! Sketch-level sanity tests: constructors work, Add/Sub/Mul produce
-//! correct values against small u16/u32 inputs, PartialEq is
-//! value-based across shapes, Zero/One/Default line up, and Ct paths
-//! (subtle::ConstantTimeEq) agree with the value.
+//! Sanity tests: constructors work, Add/Sub/Mul produce correct values
+//! against small u16/u32 inputs, PartialEq is value-based across shapes,
+//! Zero/One/Default line up, and Ct paths (subtle::ConstantTimeEq) agree
+//! with the value.
 
 #![cfg(feature = "heapless-runtime-len")]
 
@@ -190,9 +190,9 @@ fn mul_overflow_at_operand_width() {
 
 #[test]
 fn wrapping_ops_do_not_grow_width() {
-    // The headline symptom from the Montgomery n_prime trace: wrapping
-    // ops must keep the value width fixed so iterative modular algorithms
-    // stay self-consistent. one + one = 2 at len 1 (not [2,0] at len 2).
+    // Wrapping ops must keep the value width fixed so iterative modular
+    // algorithms stay self-consistent: one + one = 2 at len 1 (not [2,0]
+    // at len 2).
     let one = <H4u32Nct as One>::one();
     let two = one.wrapping_add(&one);
     assert_eq!(two.len(), 1);
@@ -240,8 +240,7 @@ fn accumulator_must_be_width_pinned() {
     // acc is carried at — value-width ops resolve at max(operand len), so
     // a value grown from a narrow seed stays narrow and wraps early
     // (exactly like a narrow FixedUInt). A width-pinned seed carries the
-    // full width, like FixedUInt<u32,8>. This is the recurring downstream
-    // trap: pin the width the way you pick N for FixedUInt.
+    // full width, like FixedUInt<u32,8>.
     let double = |acc: H4u32Nct| OverflowingAdd::overflowing_add(acc, acc).0;
 
     // Start from 1, double 40 times → 2^40, which needs limb 1.
@@ -301,8 +300,8 @@ fn with_precision_seeds_at_witness_width() {
     let q = H4u32Nct::from_limbs([7, 0, 5, 0], 3);
 
     // zero_with_precision_of(&q): a zero pinned at q's width (len 3), NOT the
-    // minimal-width len-0 zero(). This is the named replacement for the
-    // load-bearing wrapping_sub(q, q) seed idiom — identical result.
+    // minimal-width len-0 zero(). Named replacement for the
+    // `wrapping_sub(q, q)` seed idiom — identical result.
     let z = <H4u32Nct as WithPrecision>::zero_with_precision_of(&q);
     assert!(<H4u32Nct as Zero>::is_zero(&z));
     assert_eq!(z.len(), 3);
@@ -582,7 +581,6 @@ fn shr_bit_carries_from_higher_limb() {
     let a = H4u32Nct::from_limbs([0, 1, 0, 0], 2);
     let b = a >> 1;
     assert_eq!(b.limbs()[0], 0x8000_0000);
-    // out_len = self.len - word_shift = 2 - 0 = 2.
     assert_eq!(b.len(), 2);
 }
 
@@ -1183,7 +1181,7 @@ fn carrying_mul_splits_at_value_width_not_cap() {
     // and the primitive (200u8.wide_mul(200) = (64, 156), split at 8
     // bits). At len 1 (width 8) in an 8-word carrier, 40000 must split
     // into (64, 156), NOT stay whole in lo at CAP — a CAP split strands
-    // the high half and misplaces hi in the REDC (the RSA bug).
+    // the high half and misplaces hi in the REDC.
     type H4u8 = HeaplessBigInt<u8, 4, Nct>;
     let a = H4u8::from_limbs([200, 0, 0, 0], 1);
     let b = H4u8::from_limbs([200, 0, 0, 0], 1);
@@ -1256,8 +1254,8 @@ fn checked_mul_returns_none_when_value_overflows_width() {
 
 #[test]
 fn checked_mul_chain_stays_within_width() {
-    // Chained small products (the modmath EEA pattern): each stays within
-    // the operand width, so the chain never falsely overflows.
+    // Chained small products, each staying within the operand width, so
+    // the chain never falsely overflows.
     let start: H4u8Nct = 1u8.into();
     let a: H4u8Nct = 3u8.into();
     let b: H4u8Nct = 5u8.into();
@@ -1331,8 +1329,8 @@ fn trait_checked_mul_matches_inherent() {
 
 #[test]
 fn trait_checked_mul_matches_fixeduint_width_behavior() {
-    // Through the trait form modmath's inv binds on: checked_mul at the
-    // operand width, same as FixedUInt<u8,4>. 5 * 7 = 35 fits in width 4.
+    // Through the trait form: checked_mul at the operand width, same as
+    // FixedUInt<u8,4>. 5 * 7 = 35 fits in width 4.
     use const_num_traits::CheckedMul;
     let a = H4u8Nct::from_limbs([5, 0, 0, 0], 4);
     let b = H4u8Nct::from_limbs([7, 0, 0, 0], 4);

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -122,6 +122,34 @@ fn sub_underflow_wraps_and_flags() {
     assert_eq!(a.checked_sub(&b), None);
 }
 
+#[test]
+fn sub_underflow_wraps_at_full_cap_width() {
+    // Underflow wraps at the full container width (CAP limbs), matching
+    // FixedUInt<T, CAP> — not at max(operand_len). Output len = CAP.
+    let a = H4u32Nct::from_limbs([1, 0, 0, 0], 1);
+    let b = H4u32Nct::from_limbs([2, 0, 0, 0], 1);
+    let w = a.wrapping_sub(&b);
+    assert_eq!(w.len(), 4);
+    assert_eq!(w.all_limbs(), &[u32::MAX; 4]); // 2^128 - 1
+}
+
+#[test]
+fn wrapping_sub_is_value_deterministic_not_len_deterministic() {
+    // Same values carried at different lens must give the same wrapped
+    // result — the property the len-derived width previously violated.
+    let five_short: H4u32Nct = 5u32.into(); // len 1
+    let seven_short: H4u32Nct = 7u32.into();
+    let five_long = H4u32Nct::from_limbs([5, 0, 0, 0], 4); // len 4
+    let seven_long = H4u32Nct::from_limbs([7, 0, 0, 0], 4);
+    assert_eq!(
+        five_short.wrapping_sub(&seven_short),
+        five_long.wrapping_sub(&seven_long)
+    );
+    // And the value is the CAP-width wrap of 5 - 7 = -2.
+    let w = five_short.wrapping_sub(&seven_short);
+    assert_eq!(w.all_limbs(), &[u32::MAX - 1, u32::MAX, u32::MAX, u32::MAX]);
+}
+
 // ── Mul ──
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -856,3 +856,110 @@ fn mul_owned_owned_matches_ref_ref() {
     assert_eq!(a * &b, &a * &b);
     assert_eq!(&a * b, &a * &b);
 }
+
+// ── ShrAssign / ShlAssign ──
+
+#[test]
+fn shr_assign_matches_shr() {
+    let a: H4u32Nct = 0xABCD_EF01u32.into();
+    let mut x = a;
+    x >>= 8;
+    assert_eq!(x, a >> 8);
+}
+
+#[test]
+fn shl_assign_matches_shl() {
+    let a: H4u32Nct = 0xABCDu32.into();
+    let mut x = a;
+    x <<= 12;
+    assert_eq!(x, a << 12);
+}
+
+// ── WrappingMul trait ──
+
+#[test]
+fn wrapping_mul_trait_matches_inherent() {
+    use const_num_traits::WrappingMul;
+    let a: H4u32Nct = 13u8.into();
+    let b: H4u32Nct = 17u8.into();
+    let via_trait = <H4u32Nct as WrappingMul>::wrapping_mul(a, b);
+    let via_inherent = HeaplessBigInt::wrapping_mul(&a, &b);
+    assert_eq!(via_trait, via_inherent);
+}
+
+// ── CarryingMul at the bigint level ──
+
+#[test]
+fn carrying_mul_small_no_overflow() {
+    use const_num_traits::CarryingMul;
+    // 5 * 7 + 3 = 38. Fits in one limb, hi = 0.
+    let a: H4u32Nct = 5u8.into();
+    let b: H4u32Nct = 7u8.into();
+    let c: H4u32Nct = 3u8.into();
+    let (lo, hi) = a.carrying_mul(b, c);
+    let expected_lo: H4u32Nct = 38u8.into();
+    assert_eq!(lo, expected_lo);
+    assert!(<H4u32Nct as const_num_traits::Zero>::is_zero(&hi));
+}
+
+#[test]
+fn carrying_mul_produces_high_half() {
+    use const_num_traits::CarryingMul;
+    // MAX-limb value squared should populate hi. CAP=4, u32 → 128 bits.
+    // Use (2^127) * (2^1) = 2^128 → hi = 1.
+    let a = H4u32Nct::from_limbs([0, 0, 0, 1u32 << 31], 4); // 2^127
+    let b: H4u32Nct = 2u8.into(); // 2^1
+    let zero_v = <H4u32Nct as Zero>::zero();
+    let (lo, hi) = a.carrying_mul(b, zero_v);
+    // 2^128 = hi contribution of 1 at limb 0; lo is 0.
+    assert!(<H4u32Nct as const_num_traits::Zero>::is_zero(&lo));
+    assert_eq!(hi.all_limbs()[0], 1);
+}
+
+#[test]
+fn carrying_mul_add_two_adders() {
+    use const_num_traits::CarryingMul;
+    // 5 * 7 + 3 + 4 = 42.
+    let a: H4u32Nct = 5u8.into();
+    let b: H4u32Nct = 7u8.into();
+    let c: H4u32Nct = 3u8.into();
+    let d: H4u32Nct = 4u8.into();
+    let (lo, hi) = a.carrying_mul_add(b, c, d);
+    let expected_lo: H4u32Nct = 42u8.into();
+    assert_eq!(lo, expected_lo);
+    assert!(<H4u32Nct as const_num_traits::Zero>::is_zero(&hi));
+}
+
+// ── BorrowingSub at the bigint level ──
+
+#[test]
+fn borrowing_sub_no_borrow_in() {
+    use const_num_traits::BorrowingSub;
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 40u32.into();
+    let (diff, borrow) = a.borrowing_sub(b, false);
+    let expected: H4u32Nct = 60u8.into();
+    assert_eq!(diff, expected);
+    assert!(!borrow);
+}
+
+#[test]
+fn borrowing_sub_with_borrow_in() {
+    use const_num_traits::BorrowingSub;
+    // 100 - 40 - 1 = 59.
+    let a: H4u32Nct = 100u32.into();
+    let b: H4u32Nct = 40u32.into();
+    let (diff, borrow) = a.borrowing_sub(b, true);
+    let expected: H4u32Nct = 59u8.into();
+    assert_eq!(diff, expected);
+    assert!(!borrow);
+}
+
+#[test]
+fn borrowing_sub_underflow_reports_borrow_out() {
+    use const_num_traits::BorrowingSub;
+    let a: H4u32Nct = 1u8.into();
+    let b: H4u32Nct = 2u8.into();
+    let (_, borrow) = a.borrowing_sub(b, false);
+    assert!(borrow);
+}

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -1,17 +1,18 @@
 //! Width-model regression: a `HeaplessBigInt<u8, CAP>` value carried at
-//! `len = k` has **width `k · word_bits`** (per the bit-vocabulary
-//! canon), so it must behave like the fixed-width `FixedUInt<u8, k>` —
-//! *not* like `FixedUInt<u8, CAP>`. `CAP` is capacity, invisible to
-//! arithmetic; the operating width is the constructed `len`.
-//!
-//! This is the corrected form of an earlier test that wrongly expected
-//! CAP-width / FixedUInt<u8,CAP> parity at every len. Grew out of a
-//! Montgomery-multiply hunt whose real lesson was the width vs capacity
-//! distinction.
+//! `len = k` is a `k`-word integer of width `k · word_bits`, so every
+//! arithmetic op must return bit-for-bit what `FixedUInt<u8, k>` returns
+//! — wrapped value AND overflow/borrow flag alike. `CAP` is allocation,
+//! invisible to arithmetic; the words beyond `len` do not exist. This
+//! pins that equivalence across sub / wrapping_add / wrapping_mul /
+//! overflowing_add / overflowing_mul / checked_add / checked_mul at
+//! widths 1, 2, 4 inside a capacity-4 carrier.
 
 #![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
 
-use const_num_traits::{Nct, OverflowingSub, WrappingAdd, WrappingMul};
+use const_num_traits::{
+    CheckedAdd, CheckedMul, Nct, OverflowingAdd, OverflowingMul, OverflowingSub, WrappingAdd,
+    WrappingMul,
+};
 use fixed_bigint::{FixedUInt, HeaplessBigInt};
 use num_traits::ToPrimitive;
 
@@ -80,6 +81,39 @@ macro_rules! width_parity {
                     "wrapping_mul {a}*{b} width={} bytes",
                     $k
                 );
+
+                // Overflowing add/mul: wrapped value AND the overflow flag
+                // must both match the same-width FixedUInt.
+                let (ha, hac) = OverflowingAdd::overflowing_add(h(a, $k), h(b, $k));
+                let (fa, fac) =
+                    OverflowingAdd::overflowing_add(<$fixed>::from(a), <$fixed>::from(b));
+                assert_eq!(
+                    (h_val(&ha), hac),
+                    (fa.to_u64().unwrap(), fac),
+                    "overflowing_add {a}+{b} width={} bytes",
+                    $k
+                );
+
+                let (hp, hpo) = OverflowingMul::overflowing_mul(h(a, $k), h(b, $k));
+                let (fp, fpo) =
+                    OverflowingMul::overflowing_mul(<$fixed>::from(a), <$fixed>::from(b));
+                assert_eq!(
+                    (h_val(&hp), hpo),
+                    (fp.to_u64().unwrap(), fpo),
+                    "overflowing_mul {a}*{b} width={} bytes",
+                    $k
+                );
+
+                // Checked add/mul: None iff FixedUInt is None, else equal.
+                let hca = CheckedAdd::checked_add(h(a, $k), h(b, $k)).map(|v| h_val(&v));
+                let fca = CheckedAdd::checked_add(<$fixed>::from(a), <$fixed>::from(b))
+                    .map(|v| v.to_u64().unwrap());
+                assert_eq!(hca, fca, "checked_add {a}+{b} width={} bytes", $k);
+
+                let hcm = CheckedMul::checked_mul(h(a, $k), h(b, $k)).map(|v| h_val(&v));
+                let fcm = CheckedMul::checked_mul(<$fixed>::from(a), <$fixed>::from(b))
+                    .map(|v| v.to_u64().unwrap());
+                assert_eq!(hcm, fcm, "checked_mul {a}*{b} width={} bytes", $k);
             }
         }
     }};

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -150,13 +150,13 @@ where
     // (`width_bytes * 8`), never a size_of-inflated capacity — the exact
     // misread the historical Ed25519 reduce bug came from.
     assert_eq!(
-        BitsPrecision::bits_precision(h(&seeds[1])),
+        BitsPrecision::bits_precision(&h(&seeds[1])),
         (width_bytes * 8) as u32,
         "heapless bits_precision must be the width, not capacity"
     );
     assert_eq!(
-        BitsPrecision::bits_precision(f(&seeds[1])),
-        BitsPrecision::bits_precision(h(&seeds[1])),
+        BitsPrecision::bits_precision(&f(&seeds[1])),
+        BitsPrecision::bits_precision(&h(&seeds[1])),
         "bits_precision parity @ width {width_bytes}B"
     );
 

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -1,0 +1,115 @@
+//! Carrier-parity regression: `HeaplessBigInt<T, CAP>` must behave as a
+//! fixed-`CAP`-width integer, matching `FixedUInt<T, CAP>` and being a
+//! function of operand *values* only — never of how an operand's `len`
+//! was carried.
+//!
+//! Grew out of a Montgomery-multiply divergence hunt: the carrier bug
+//! that surfaced was subtraction wrapping at `max(operand_len)` instead
+//! of `CAP`, making `wrapping_sub` representation-dependent. These tests
+//! lock the fixed-width, value-deterministic contract for every op a
+//! modular-arithmetic consumer leans on.
+
+#![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
+
+use const_num_traits::{CheckedMul, Nct, OverflowingAdd, OverflowingSub};
+use core::ops::RemAssign;
+use fixed_bigint::{FixedUInt, HeaplessBigInt};
+
+type H = HeaplessBigInt<u8, 4, Nct>;
+type F = FixedUInt<u8, 4>;
+
+fn h_val(v: &H) -> u64 {
+    let mut buf = [0u8; 4];
+    let s = v.to_le_bytes(&mut buf);
+    let mut acc = 0u64;
+    for (i, b) in s.iter().enumerate() {
+        acc |= (*b as u64) << (8 * i);
+    }
+    acc
+}
+
+fn f_val(v: &F) -> u64 {
+    use num_traits::ToPrimitive;
+    v.to_u64().unwrap()
+}
+
+// Same value, chosen len (zero-tail invariant holds for both).
+fn h(val: u8, len: u16) -> H {
+    H::from_limbs([val, 0, 0, 0], len)
+}
+
+#[test]
+fn ops_are_len_invariant() {
+    // op(value @ len 1) must equal op(value @ len 2/4) in VALUE.
+    for val in [0u8, 1, 5, 8, 11, 13, 16, 100, 200, 255] {
+        for sh in [0usize, 1, 3, 4, 7, 8, 9] {
+            let s = [
+                h_val(&(h(val, 1) << sh)),
+                h_val(&(h(val, 2) << sh)),
+                h_val(&(h(val, 4) << sh)),
+            ];
+            assert_eq!(s[0], s[1], "Shl val={val} sh={sh}");
+            assert_eq!(s[0], s[2], "Shl val={val} sh={sh}");
+            let r1 = h_val(&(h(val, 1) >> sh));
+            let r4 = h_val(&(h(val, 4) >> sh));
+            assert_eq!(r1, r4, "Shr val={val} sh={sh}");
+        }
+    }
+    for a in [0u8, 5, 8, 15, 100, 200, 255] {
+        for mask in [1u8, 15, 0xFF] {
+            let mut vals = [0u64; 9];
+            let mut k = 0;
+            for al in [1u16, 2, 4] {
+                for ml in [1u16, 2, 4] {
+                    vals[k] = h_val(&(&h(a, al) & &h(mask, ml)));
+                    k += 1;
+                }
+            }
+            for w in vals.windows(2) {
+                assert_eq!(w[0], w[1], "BitAnd a={a} mask={mask}");
+            }
+        }
+    }
+}
+
+#[test]
+fn per_op_matches_fixeduint() {
+    // Every op's result (value + flag) matches FixedUInt<u8,4>, over
+    // operands carried at len 1, 2, and 4.
+    let ff = |v: u8| F::from(v as u32);
+    for a in [0u8, 1, 5, 7, 8, 11, 12] {
+        for b in [1u8, 5, 7, 11, 13] {
+            for al in [1u16, 2, 4] {
+                let (hs, ho) = OverflowingAdd::overflowing_add(h(a, al), h(b, al));
+                let (fs, fo) = OverflowingAdd::overflowing_add(ff(a), ff(b));
+                assert_eq!((h_val(&hs), ho), (f_val(&fs), fo), "add {a}+{b} al={al}");
+
+                let (hd, hb) = OverflowingSub::overflowing_sub(h(a, al), h(b, al));
+                let (fd, fb) = OverflowingSub::overflowing_sub(ff(a), ff(b));
+                assert_eq!((h_val(&hd), hb), (f_val(&fd), fb), "sub {a}-{b} al={al}");
+
+                let hm = CheckedMul::checked_mul(h(a, al), h(b, al)).map(|x| h_val(&x));
+                let fm = CheckedMul::checked_mul(ff(a), ff(b)).map(|x| f_val(&x));
+                assert_eq!(hm, fm, "mul {a}*{b} al={al}");
+
+                assert_eq!(
+                    h_val(&(&h(a, al) % &h(b, al))),
+                    f_val(&(&ff(a) % &ff(b))),
+                    "rem {a}%{b} al={al}"
+                );
+
+                let mut hra = h(a, al);
+                hra.rem_assign(&h(b, al));
+                let mut fra = ff(a);
+                fra %= ff(b);
+                assert_eq!(h_val(&hra), f_val(&fra), "rem_assign {a}%{b} al={al}");
+
+                assert_eq!(
+                    h(a, al).partial_cmp(&h(b, al)),
+                    ff(a).partial_cmp(&ff(b)),
+                    "cmp {a}?{b} al={al}"
+                );
+            }
+        }
+    }
+}

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -145,10 +145,9 @@ where
     let zero_f = F::make_le(&[0u8; BUF], width_words);
     let zero_h = H::make_le(&[0u8; BUF], width_words);
 
-    // The width a value REPORTS: `bits_precision` is the operating width
-    // modmath's reducer reads for R / n_prime. It must be the true width
-    // (`width_bytes * 8`), never a size_of-inflated capacity — the exact
-    // misread the historical Ed25519 reduce bug came from.
+    // The width a value REPORTS: `bits_precision` is the operating width a
+    // Montgomery reducer reads for R / n_prime. It must be the true width
+    // (`width_bytes * 8`), never a size_of-inflated capacity.
     assert_eq!(
         BitsPrecision::bits_precision(&h(&seeds[1])),
         (width_bytes * 8) as u32,
@@ -214,8 +213,8 @@ where
             assert_eq!(fpo, hpo, "overflowing_mul flag @ width {width_bytes}B");
             eq(&fp, &hp, "overflowing_mul value");
 
-            // carrying_mul (WideMul): both halves must match. This is the
-            // op modmath's wide-REDC reduces through.
+            // carrying_mul (WideMul): both halves must match — the op a
+            // wide Montgomery reduction reduces through.
             let (flo, fhi) = CarryingMul::carrying_mul(f(sa), f(sb), zero_f);
             let (hlo, hhi) = CarryingMul::carrying_mul(h(sa), h(sb), zero_h);
             eq(&flo, &hlo, "carrying_mul lo");

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -15,7 +15,7 @@
 //! carrier, the Ed25519 verify carrier) — are exercised against the
 //! matching `FixedUInt<u32, 8>` here.
 
-#![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
+#![cfg(feature = "num-traits")]
 
 use const_num_traits::{
     BitWidth, BitsPrecision, CarryingMul, CheckedAdd, CheckedMul, FromByteSlice, Nct,
@@ -98,8 +98,8 @@ fn value_seeds(width_bytes: usize) -> Vec<[u8; BUF]> {
     let mut out = Vec::new();
     let mut push = |f: &dyn Fn(usize) -> u8| {
         let mut b = [0u8; BUF];
-        for i in 0..width_bytes {
-            b[i] = f(i);
+        for (i, slot) in b.iter_mut().enumerate().take(width_bytes) {
+            *slot = f(i);
         }
         out.push(b);
     };

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -11,7 +11,7 @@
 
 #![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
 
-use const_num_traits::{Nct, OverflowingSub};
+use const_num_traits::{Nct, OverflowingSub, WrappingAdd, WrappingMul};
 use fixed_bigint::{FixedUInt, HeaplessBigInt};
 use num_traits::ToPrimitive;
 
@@ -35,11 +35,13 @@ fn h(val: u32, k: u16) -> H {
     H::from_limbs(limbs, k)
 }
 
-// Subtraction wraps at the operand width, so it matches the same-width
-// FixedUInt. (Add/mul are *growing* ops on this carrier — a+b can need
-// width+1 rather than wrapping — so they intentionally do NOT match a
-// fixed-width add; only sub's underflow-wrap is a fixed-width behavior.)
-macro_rules! sub_width_parity {
+// The wrapping/overflowing ops all wrap at the operand value width, so
+// each matches the same-width FixedUInt: sub's underflow-wrap,
+// wrapping_add's carry-out discard, and wrapping_mul's high-half
+// truncation are all fixed-width-at-`len` behaviors. (The *growing*
+// variants — core::ops::+/*, checked_* — are a separate carrier feature,
+// not exercised here; this file pins the value-width equivalence.)
+macro_rules! width_parity {
     ($k:literal, $fixed:ty) => {{
         let mask: u32 = if $k == 4 {
             u32::MAX
@@ -50,6 +52,7 @@ macro_rules! sub_width_parity {
         for &a in &vals {
             for &b in &vals {
                 let (a, b) = (a & mask, b & mask);
+
                 let (hd, hb) = OverflowingSub::overflowing_sub(h(a, $k), h(b, $k));
                 let (fd, fb) =
                     OverflowingSub::overflowing_sub(<$fixed>::from(a), <$fixed>::from(b));
@@ -59,16 +62,35 @@ macro_rules! sub_width_parity {
                     "sub {a}-{b} width={} bytes",
                     $k
                 );
+
+                let hs = WrappingAdd::wrapping_add(h(a, $k), h(b, $k));
+                let fs = WrappingAdd::wrapping_add(<$fixed>::from(a), <$fixed>::from(b));
+                assert_eq!(
+                    h_val(&hs),
+                    fs.to_u64().unwrap(),
+                    "wrapping_add {a}+{b} width={} bytes",
+                    $k
+                );
+
+                let hm = WrappingMul::wrapping_mul(h(a, $k), h(b, $k));
+                let fm = WrappingMul::wrapping_mul(<$fixed>::from(a), <$fixed>::from(b));
+                assert_eq!(
+                    h_val(&hm),
+                    fm.to_u64().unwrap(),
+                    "wrapping_mul {a}*{b} width={} bytes",
+                    $k
+                );
             }
         }
     }};
 }
 
 #[test]
-fn heapless_sub_at_len_k_matches_fixeduint_of_width_k() {
-    // width = len·8: HeaplessBigInt<u8,4> subtraction at len 1/2/4 wraps
-    // like FixedUInt<u8,1>/<u8,2>/<u8,4> — capacity 4 never enters.
-    sub_width_parity!(1u16, FixedUInt<u8, 1>);
-    sub_width_parity!(2u16, FixedUInt<u8, 2>);
-    sub_width_parity!(4u16, FixedUInt<u8, 4>);
+fn heapless_at_len_k_matches_fixeduint_of_width_k() {
+    // width = len·8: HeaplessBigInt<u8,4> sub / wrapping_add / wrapping_mul
+    // at len 1/2/4 wrap like FixedUInt<u8,1>/<u8,2>/<u8,4> — capacity 4
+    // never enters.
+    width_parity!(1u16, FixedUInt<u8, 1>);
+    width_parity!(2u16, FixedUInt<u8, 2>);
+    width_parity!(4u16, FixedUInt<u8, 4>);
 }

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -5,28 +5,32 @@
 //! `FixedUInt` returns — value AND flag — on every op. `CAP` is
 //! allocation; the words beyond `len` do not exist for arithmetic.
 //!
-//! This inverts the usual "test the type" setup: `FixedUInt` is the
-//! trusted reference (it carries fixed-bigint's own large arithmetic
-//! suite), and every op is checked ONCE in [`assert_carrier_parity`] with
-//! `HeaplessBigInt` driven against `FixedUInt`'s answer. Any behavior that
-//! is correct for the fixed-width type is thereby demanded of the carrier
-//! too, across u8/u16/u32 backings and widths up to 64 bits, inside a
-//! capacity far wider than the width under test — so a capacity leak into
-//! any answer diverges here.
+//! `FixedUInt` is the trusted reference (it carries fixed-bigint's own
+//! arithmetic suite); a `WidthCarrier` trait (build at a width / read the
+//! full byte value back) drives both types through one
+//! [`assert_carrier_parity`]. Comparison is over the full little-endian
+//! byte value, so widths are NOT capped at 64 bits: the sub-capacity
+//! multi-limb configs downstream actually deploys — notably
+//! `HeaplessBigInt<u32, 16>` at `len 8` (a 255/256-bit value in a 512-bit
+//! carrier, the Ed25519 verify carrier) — are exercised against the
+//! matching `FixedUInt<u32, 8>` here.
 
 #![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
 
 use const_num_traits::{
-    BitWidth, CheckedAdd, CheckedMul, FromByteSlice, Nct, OverflowingAdd, OverflowingMul,
-    OverflowingSub, WrappingAdd, WrappingMul, WrappingSub,
+    BitWidth, BitsPrecision, CarryingMul, CheckedAdd, CheckedMul, FromByteSlice, Nct,
+    OverflowingAdd, OverflowingMul, OverflowingSub, WrappingAdd, WrappingMul, WrappingSub,
 };
-use core::cmp::Ordering;
 use fixed_bigint::{FixedUInt, HeaplessBigInt};
-use num_traits::ToPrimitive;
+
+/// Byte buffer wide enough for any value or wide product under test
+/// (512-bit operands → 1024-bit `carrying_mul` result = 128 bytes).
+const BUF: usize = 128;
 
 /// A fixed-width unsigned these differential tests can drive: build a value
-/// at a chosen word-width and read it back as `u64`. `FixedUInt<T, N>`'s
-/// width is its `N`; `HeaplessBigInt<T, CAP>` constructs at `len = width`.
+/// at a chosen word-width from little-endian bytes, and read the full value
+/// back as little-endian bytes. `FixedUInt<T, N>`'s width is its `N`;
+/// `HeaplessBigInt<T, CAP>` constructs at `len = width`.
 trait WidthCarrier:
     Copy
     + WrappingAdd<Output = Self>
@@ -37,6 +41,7 @@ trait WidthCarrier:
     + OverflowingMul<Output = Self>
     + CheckedAdd<Output = Self>
     + CheckedMul<Output = Self>
+    + CarryingMul<Unsigned = Self, Output = Self>
     + core::ops::Div<Output = Self>
     + core::ops::Rem<Output = Self>
     + core::ops::Shl<usize, Output = Self>
@@ -45,41 +50,36 @@ trait WidthCarrier:
     + core::ops::BitOr<Output = Self>
     + PartialOrd
     + BitWidth
+    + BitsPrecision
 {
     const WORD_BYTES: usize;
-    fn make(v: u64, width_words: usize) -> Self;
-    fn read(&self) -> u64;
+    fn make_le(bytes: &[u8], width_words: usize) -> Self;
+    fn read_le(&self, out: &mut [u8; BUF]);
 }
 
 macro_rules! impl_carrier {
     (fixed $t:ty) => {
         impl<const N: usize> WidthCarrier for FixedUInt<$t, N, Nct> {
             const WORD_BYTES: usize = core::mem::size_of::<$t>();
-            fn make(v: u64, width_words: usize) -> Self {
+            fn make_le(bytes: &[u8], width_words: usize) -> Self {
                 assert_eq!(width_words, N, "FixedUInt<T, N> width is fixed at N");
-                let bytes = v.to_le_bytes();
                 FromByteSlice::from_le_slice(&bytes[..N * Self::WORD_BYTES]).unwrap()
             }
-            fn read(&self) -> u64 {
-                ToPrimitive::to_u64(self).unwrap()
+            fn read_le(&self, out: &mut [u8; BUF]) {
+                *out = [0u8; BUF];
+                self.to_le_bytes_fixed(out);
             }
         }
     };
     (heapless $t:ty) => {
         impl<const CAP: usize> WidthCarrier for HeaplessBigInt<$t, CAP, Nct> {
             const WORD_BYTES: usize = core::mem::size_of::<$t>();
-            fn make(v: u64, width_words: usize) -> Self {
-                let bytes = v.to_le_bytes();
+            fn make_le(bytes: &[u8], width_words: usize) -> Self {
                 HeaplessBigInt::from_le_bytes(&bytes[..width_words * Self::WORD_BYTES])
             }
-            fn read(&self) -> u64 {
-                let mut buf = [0u8; 64];
-                let s = self.to_le_bytes(&mut buf);
-                let mut acc = 0u64;
-                for (i, b) in s.iter().enumerate().take(8) {
-                    acc |= (*b as u64) << (8 * i);
-                }
-                acc
+            fn read_le(&self, out: &mut [u8; BUF]) {
+                *out = [0u8; BUF];
+                self.to_le_bytes(out);
             }
         }
     };
@@ -92,176 +92,190 @@ impl_carrier!(heapless u8);
 impl_carrier!(heapless u16);
 impl_carrier!(heapless u32);
 
-fn value_set(mask: u64) -> [u64; 9] {
-    [
-        0,
-        1,
-        2,
-        7,
-        mask,                               // all ones
-        mask >> 1,                          // 0b0111..1
-        (mask >> 1).wrapping_add(1) & mask, // high bit only
-        0xA5A5_A5A5_A5A5_A5A5 & mask,       // alternating
-        0x0F1E_2D3C_4B5A_6978 & mask,       // arbitrary spread
-    ]
+/// Byte-pattern operands of `width_bytes` significant bytes. Multi-limb
+/// patterns (not just u64-range values) so the wide configs are real.
+fn value_seeds(width_bytes: usize) -> Vec<[u8; BUF]> {
+    let mut out = Vec::new();
+    let mut push = |f: &dyn Fn(usize) -> u8| {
+        let mut b = [0u8; BUF];
+        for i in 0..width_bytes {
+            b[i] = f(i);
+        }
+        out.push(b);
+    };
+    push(&|_| 0); // zero
+    push(&|i| if i == 0 { 1 } else { 0 }); // one
+    push(&|i| if i == 0 { 2 } else { 0 }); // two
+    push(&|_| 0xFF); // all ones
+    push(&|i| if i + 1 == width_bytes { 0x80 } else { 0 }); // high bit only
+    push(&|i| if i % 2 == 0 { 0xA5 } else { 0x5A }); // alternating
+    push(&|i| (i as u8).wrapping_mul(37).wrapping_add(3)); // ramp
+    push(&|i| 0xED ^ (i as u8)); // curve-ish spread
+    push(&|i| if i + 1 == width_bytes { 0x7F } else { 0xFF }); // just under all-ones (p-like)
+    out
+}
+
+fn is_zero(seed: &[u8; BUF], width_bytes: usize) -> bool {
+    seed[..width_bytes].iter().all(|&b| b == 0)
 }
 
 /// Assert `F` (fixed-width reference) and `H` (carrier under test) agree on
-/// every op at `width_words`. Both value and flag must match.
+/// every op at `width_words`, comparing full byte values (and flags).
 fn assert_carrier_parity<F, H>(width_words: usize)
 where
     F: WidthCarrier,
     H: WidthCarrier,
 {
     assert_eq!(F::WORD_BYTES, H::WORD_BYTES);
-    let width_bits = width_words * F::WORD_BYTES * 8;
-    let mask = if width_bits >= 64 {
-        u64::MAX
-    } else {
-        (1u64 << width_bits) - 1
-    };
-    let vals = value_set(mask);
-    let f = |v| F::make(v, width_words);
-    let h = |v| H::make(v, width_words);
+    let width_bytes = width_words * F::WORD_BYTES;
+    let seeds = value_seeds(width_bytes);
+    let f = |s: &[u8; BUF]| F::make_le(s, width_words);
+    let h = |s: &[u8; BUF]| H::make_le(s, width_words);
 
-    // Unary ops.
-    for &ra in &vals {
-        let a = ra & mask;
-        assert_eq!(
-            BitWidth::bit_width(f(a)),
-            BitWidth::bit_width(h(a)),
-            "bit_width {a} @ width {width_bits}"
+    // Compare the full byte value of a fixed result against a heapless one.
+    let eq = |fv: &F, hv: &H, msg: &str| {
+        let (mut fb, mut hb) = ([0u8; BUF], [0u8; BUF]);
+        fv.read_le(&mut fb);
+        hv.read_le(&mut hb);
+        assert!(
+            fb == hb,
+            "{msg} @ width {width_bytes}B\n fixed={fb:02x?}\n  heap={hb:02x?}"
         );
-        for &sh in &[0usize, 1, width_bits / 2, width_bits.saturating_sub(1)] {
-            assert_eq!(
-                (f(a) << sh).read(),
-                (h(a) << sh).read(),
-                "shl {a} << {sh} @ width {width_bits}"
-            );
-            assert_eq!(
-                (f(a) >> sh).read(),
-                (h(a) >> sh).read(),
-                "shr {a} >> {sh} @ width {width_bits}"
-            );
+    };
+    let zero_f = F::make_le(&[0u8; BUF], width_words);
+    let zero_h = H::make_le(&[0u8; BUF], width_words);
+
+    // The width a value REPORTS: `bits_precision` is the operating width
+    // modmath's reducer reads for R / n_prime. It must be the true width
+    // (`width_bytes * 8`), never a size_of-inflated capacity — the exact
+    // misread the historical Ed25519 reduce bug came from.
+    assert_eq!(
+        BitsPrecision::bits_precision(h(&seeds[1])),
+        (width_bytes * 8) as u32,
+        "heapless bits_precision must be the width, not capacity"
+    );
+    assert_eq!(
+        BitsPrecision::bits_precision(f(&seeds[1])),
+        BitsPrecision::bits_precision(h(&seeds[1])),
+        "bits_precision parity @ width {width_bytes}B"
+    );
+
+    // Unary: bit_width, shifts.
+    for sa in &seeds {
+        assert_eq!(
+            BitWidth::bit_width(f(sa)),
+            BitWidth::bit_width(h(sa)),
+            "bit_width @ width {width_bytes}B"
+        );
+        let width_bits = width_bytes * 8;
+        for &sh in &[
+            0usize,
+            1,
+            width_bits / 2,
+            width_bits.saturating_sub(1),
+            width_bits,
+        ] {
+            eq(&(f(sa) << sh), &(h(sa) << sh), "shl");
+            eq(&(f(sa) >> sh), &(h(sa) >> sh), "shr");
         }
     }
 
-    // Binary ops.
-    for &ra in &vals {
-        for &rb in &vals {
-            let (a, b) = (ra & mask, rb & mask);
-
-            assert_eq!(
-                WrappingAdd::wrapping_add(f(a), f(b)).read(),
-                WrappingAdd::wrapping_add(h(a), h(b)).read(),
-                "wrapping_add {a}+{b} @ width {width_bits}"
+    // Binary.
+    for sa in &seeds {
+        for sb in &seeds {
+            eq(
+                &WrappingAdd::wrapping_add(f(sa), f(sb)),
+                &WrappingAdd::wrapping_add(h(sa), h(sb)),
+                "wrapping_add",
             );
-            assert_eq!(
-                WrappingSub::wrapping_sub(f(a), f(b)).read(),
-                WrappingSub::wrapping_sub(h(a), h(b)).read(),
-                "wrapping_sub {a}-{b} @ width {width_bits}"
+            eq(
+                &WrappingSub::wrapping_sub(f(sa), f(sb)),
+                &WrappingSub::wrapping_sub(h(sa), h(sb)),
+                "wrapping_sub",
             );
-            assert_eq!(
-                WrappingMul::wrapping_mul(f(a), f(b)).read(),
-                WrappingMul::wrapping_mul(h(a), h(b)).read(),
-                "wrapping_mul {a}*{b} @ width {width_bits}"
+            eq(
+                &WrappingMul::wrapping_mul(f(sa), f(sb)),
+                &WrappingMul::wrapping_mul(h(sa), h(sb)),
+                "wrapping_mul",
             );
 
-            let (fa, ffl) = OverflowingAdd::overflowing_add(f(a), f(b));
-            let (ha, hfl) = OverflowingAdd::overflowing_add(h(a), h(b));
-            assert_eq!(
-                (fa.read(), ffl),
-                (ha.read(), hfl),
-                "overflowing_add {a}+{b} @ width {width_bits}"
-            );
+            let (fa, ffl) = OverflowingAdd::overflowing_add(f(sa), f(sb));
+            let (ha, hfl) = OverflowingAdd::overflowing_add(h(sa), h(sb));
+            assert_eq!(ffl, hfl, "overflowing_add flag @ width {width_bytes}B");
+            eq(&fa, &ha, "overflowing_add value");
 
-            let (fs, fsb) = OverflowingSub::overflowing_sub(f(a), f(b));
-            let (hs, hsb) = OverflowingSub::overflowing_sub(h(a), h(b));
-            assert_eq!(
-                (fs.read(), fsb),
-                (hs.read(), hsb),
-                "overflowing_sub {a}-{b} @ width {width_bits}"
-            );
+            let (fs, fsb) = OverflowingSub::overflowing_sub(f(sa), f(sb));
+            let (hs, hsb) = OverflowingSub::overflowing_sub(h(sa), h(sb));
+            assert_eq!(fsb, hsb, "overflowing_sub flag @ width {width_bytes}B");
+            eq(&fs, &hs, "overflowing_sub value");
 
-            let (fp, fpo) = OverflowingMul::overflowing_mul(f(a), f(b));
-            let (hp, hpo) = OverflowingMul::overflowing_mul(h(a), h(b));
-            assert_eq!(
-                (fp.read(), fpo),
-                (hp.read(), hpo),
-                "overflowing_mul {a}*{b} @ width {width_bits}"
-            );
+            let (fp, fpo) = OverflowingMul::overflowing_mul(f(sa), f(sb));
+            let (hp, hpo) = OverflowingMul::overflowing_mul(h(sa), h(sb));
+            assert_eq!(fpo, hpo, "overflowing_mul flag @ width {width_bytes}B");
+            eq(&fp, &hp, "overflowing_mul value");
+
+            // carrying_mul (WideMul): both halves must match. This is the
+            // op modmath's wide-REDC reduces through.
+            let (flo, fhi) = CarryingMul::carrying_mul(f(sa), f(sb), zero_f);
+            let (hlo, hhi) = CarryingMul::carrying_mul(h(sa), h(sb), zero_h);
+            eq(&flo, &hlo, "carrying_mul lo");
+            eq(&fhi, &hhi, "carrying_mul hi");
 
             assert_eq!(
-                CheckedAdd::checked_add(f(a), f(b)).map(|x| x.read()),
-                CheckedAdd::checked_add(h(a), h(b)).map(|x| x.read()),
-                "checked_add {a}+{b} @ width {width_bits}"
+                CheckedAdd::checked_add(f(sa), f(sb)).is_some(),
+                CheckedAdd::checked_add(h(sa), h(sb)).is_some(),
+                "checked_add some @ width {width_bytes}B"
             );
             assert_eq!(
-                CheckedMul::checked_mul(f(a), f(b)).map(|x| x.read()),
-                CheckedMul::checked_mul(h(a), h(b)).map(|x| x.read()),
-                "checked_mul {a}*{b} @ width {width_bits}"
+                CheckedMul::checked_mul(f(sa), f(sb)).is_some(),
+                CheckedMul::checked_mul(h(sa), h(sb)).is_some(),
+                "checked_mul some @ width {width_bytes}B"
             );
 
-            assert_eq!(
-                (f(a) & f(b)).read(),
-                (h(a) & h(b)).read(),
-                "bitand {a}&{b} @ width {width_bits}"
-            );
-            assert_eq!(
-                (f(a) | f(b)).read(),
-                (h(a) | h(b)).read(),
-                "bitor {a}|{b} @ width {width_bits}"
-            );
+            eq(&(f(sa) & f(sb)), &(h(sa) & h(sb)), "bitand");
+            eq(&(f(sa) | f(sb)), &(h(sa) | h(sb)), "bitor");
 
             assert_eq!(
-                f(a).partial_cmp(&f(b)),
-                h(a).partial_cmp(&h(b)),
-                "cmp {a} ? {b} @ width {width_bits}"
+                f(sa).partial_cmp(&f(sb)),
+                h(sa).partial_cmp(&h(sb)),
+                "cmp @ width {width_bytes}B"
             );
 
-            // Div / Rem: skip the zero divisor.
-            if b != 0 {
-                assert_eq!(
-                    (f(a) / f(b)).read(),
-                    (h(a) / h(b)).read(),
-                    "div {a}/{b} @ width {width_bits}"
-                );
-                assert_eq!(
-                    (f(a) % f(b)).read(),
-                    (h(a) % h(b)).read(),
-                    "rem {a}%{b} @ width {width_bits}"
-                );
+            if !is_zero(sb, width_bytes) {
+                eq(&(f(sa) / f(sb)), &(h(sa) / h(sb)), "div");
+                eq(&(f(sa) % f(sb)), &(h(sa) % h(sb)), "rem");
             }
         }
     }
 
-    // Anchor: at least one comparison actually distinguished ordering.
-    assert_ne!(
-        f(vals[0] & mask).partial_cmp(&f(vals[4] & mask)),
-        Some(Ordering::Equal)
-    );
+    let _ = (zero_f, zero_h);
 }
 
-// u8 backing: widths 1, 2, 4, 8 (8 … 64 bits) in a capacity-24 carrier.
+// u8 backing in a capacity-24 carrier: widths 1, 2, 8, 16, 24 (up to len==CAP).
 #[test]
 fn u8_backed_widths_match_fixeduint() {
     assert_carrier_parity::<FixedUInt<u8, 1>, HeaplessBigInt<u8, 24, Nct>>(1);
     assert_carrier_parity::<FixedUInt<u8, 2>, HeaplessBigInt<u8, 24, Nct>>(2);
-    assert_carrier_parity::<FixedUInt<u8, 4>, HeaplessBigInt<u8, 24, Nct>>(4);
     assert_carrier_parity::<FixedUInt<u8, 8>, HeaplessBigInt<u8, 24, Nct>>(8);
+    assert_carrier_parity::<FixedUInt<u8, 16>, HeaplessBigInt<u8, 24, Nct>>(16);
+    assert_carrier_parity::<FixedUInt<u8, 24>, HeaplessBigInt<u8, 24, Nct>>(24);
 }
 
-// u16 backing: widths 1, 2, 4 (16 … 64 bits) in a capacity-12 carrier.
+// u16 backing in a capacity-16 carrier: widths 1, 4, 8, 16.
 #[test]
 fn u16_backed_widths_match_fixeduint() {
-    assert_carrier_parity::<FixedUInt<u16, 1>, HeaplessBigInt<u16, 12, Nct>>(1);
-    assert_carrier_parity::<FixedUInt<u16, 2>, HeaplessBigInt<u16, 12, Nct>>(2);
-    assert_carrier_parity::<FixedUInt<u16, 4>, HeaplessBigInt<u16, 12, Nct>>(4);
+    assert_carrier_parity::<FixedUInt<u16, 1>, HeaplessBigInt<u16, 16, Nct>>(1);
+    assert_carrier_parity::<FixedUInt<u16, 4>, HeaplessBigInt<u16, 16, Nct>>(4);
+    assert_carrier_parity::<FixedUInt<u16, 8>, HeaplessBigInt<u16, 16, Nct>>(8);
+    assert_carrier_parity::<FixedUInt<u16, 16>, HeaplessBigInt<u16, 16, Nct>>(16);
 }
 
-// u32 backing: widths 1, 2 (32 … 64 bits) in a capacity-6 carrier.
+// u32 backing in a capacity-16 carrier: widths 1, 2, 4, and 8 — the last is
+// the Ed25519 verify config (255/256-bit value at len 8, sub-CAP 16, Nct).
 #[test]
 fn u32_backed_widths_match_fixeduint() {
-    assert_carrier_parity::<FixedUInt<u32, 1>, HeaplessBigInt<u32, 6, Nct>>(1);
-    assert_carrier_parity::<FixedUInt<u32, 2>, HeaplessBigInt<u32, 6, Nct>>(2);
+    assert_carrier_parity::<FixedUInt<u32, 1>, HeaplessBigInt<u32, 16, Nct>>(1);
+    assert_carrier_parity::<FixedUInt<u32, 2>, HeaplessBigInt<u32, 16, Nct>>(2);
+    assert_carrier_parity::<FixedUInt<u32, 4>, HeaplessBigInt<u32, 16, Nct>>(4);
+    assert_carrier_parity::<FixedUInt<u32, 8>, HeaplessBigInt<u32, 16, Nct>>(8);
 }

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -1,22 +1,21 @@
-//! Carrier-parity regression: `HeaplessBigInt<T, CAP>` must behave as a
-//! fixed-`CAP`-width integer, matching `FixedUInt<T, CAP>` and being a
-//! function of operand *values* only — never of how an operand's `len`
-//! was carried.
+//! Width-model regression: a `HeaplessBigInt<u8, CAP>` value carried at
+//! `len = k` has **width `k · word_bits`** (per the bit-vocabulary
+//! canon), so it must behave like the fixed-width `FixedUInt<u8, k>` —
+//! *not* like `FixedUInt<u8, CAP>`. `CAP` is capacity, invisible to
+//! arithmetic; the operating width is the constructed `len`.
 //!
-//! Grew out of a Montgomery-multiply divergence hunt: the carrier bug
-//! that surfaced was subtraction wrapping at `max(operand_len)` instead
-//! of `CAP`, making `wrapping_sub` representation-dependent. These tests
-//! lock the fixed-width, value-deterministic contract for every op a
-//! modular-arithmetic consumer leans on.
+//! This is the corrected form of an earlier test that wrongly expected
+//! CAP-width / FixedUInt<u8,CAP> parity at every len. Grew out of a
+//! Montgomery-multiply hunt whose real lesson was the width vs capacity
+//! distinction.
 
 #![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
 
-use const_num_traits::{CheckedMul, Nct, OverflowingAdd, OverflowingSub};
-use core::ops::RemAssign;
+use const_num_traits::{Nct, OverflowingSub};
 use fixed_bigint::{FixedUInt, HeaplessBigInt};
+use num_traits::ToPrimitive;
 
 type H = HeaplessBigInt<u8, 4, Nct>;
-type F = FixedUInt<u8, 4>;
 
 fn h_val(v: &H) -> u64 {
     let mut buf = [0u8; 4];
@@ -28,88 +27,48 @@ fn h_val(v: &H) -> u64 {
     acc
 }
 
-fn f_val(v: &F) -> u64 {
-    use num_traits::ToPrimitive;
-    v.to_u64().unwrap()
+// A value carried at width = k bytes.
+fn h(val: u32, k: u16) -> H {
+    let b = val.to_le_bytes();
+    let mut limbs = [0u8; 4];
+    limbs[..k as usize].copy_from_slice(&b[..k as usize]);
+    H::from_limbs(limbs, k)
 }
 
-// Same value, chosen len (zero-tail invariant holds for both).
-fn h(val: u8, len: u16) -> H {
-    H::from_limbs([val, 0, 0, 0], len)
-}
-
-#[test]
-fn ops_are_len_invariant() {
-    // op(value @ len 1) must equal op(value @ len 2/4) in VALUE.
-    for val in [0u8, 1, 5, 8, 11, 13, 16, 100, 200, 255] {
-        for sh in [0usize, 1, 3, 4, 7, 8, 9] {
-            let s = [
-                h_val(&(h(val, 1) << sh)),
-                h_val(&(h(val, 2) << sh)),
-                h_val(&(h(val, 4) << sh)),
-            ];
-            assert_eq!(s[0], s[1], "Shl val={val} sh={sh}");
-            assert_eq!(s[0], s[2], "Shl val={val} sh={sh}");
-            let r1 = h_val(&(h(val, 1) >> sh));
-            let r4 = h_val(&(h(val, 4) >> sh));
-            assert_eq!(r1, r4, "Shr val={val} sh={sh}");
-        }
-    }
-    for a in [0u8, 5, 8, 15, 100, 200, 255] {
-        for mask in [1u8, 15, 0xFF] {
-            let mut vals = [0u64; 9];
-            let mut k = 0;
-            for al in [1u16, 2, 4] {
-                for ml in [1u16, 2, 4] {
-                    vals[k] = h_val(&(&h(a, al) & &h(mask, ml)));
-                    k += 1;
-                }
-            }
-            for w in vals.windows(2) {
-                assert_eq!(w[0], w[1], "BitAnd a={a} mask={mask}");
-            }
-        }
-    }
-}
-
-#[test]
-fn per_op_matches_fixeduint() {
-    // Every op's result (value + flag) matches FixedUInt<u8,4>, over
-    // operands carried at len 1, 2, and 4.
-    let ff = |v: u8| F::from(v as u32);
-    for a in [0u8, 1, 5, 7, 8, 11, 12] {
-        for b in [1u8, 5, 7, 11, 13] {
-            for al in [1u16, 2, 4] {
-                let (hs, ho) = OverflowingAdd::overflowing_add(h(a, al), h(b, al));
-                let (fs, fo) = OverflowingAdd::overflowing_add(ff(a), ff(b));
-                assert_eq!((h_val(&hs), ho), (f_val(&fs), fo), "add {a}+{b} al={al}");
-
-                let (hd, hb) = OverflowingSub::overflowing_sub(h(a, al), h(b, al));
-                let (fd, fb) = OverflowingSub::overflowing_sub(ff(a), ff(b));
-                assert_eq!((h_val(&hd), hb), (f_val(&fd), fb), "sub {a}-{b} al={al}");
-
-                let hm = CheckedMul::checked_mul(h(a, al), h(b, al)).map(|x| h_val(&x));
-                let fm = CheckedMul::checked_mul(ff(a), ff(b)).map(|x| f_val(&x));
-                assert_eq!(hm, fm, "mul {a}*{b} al={al}");
-
+// Subtraction wraps at the operand width, so it matches the same-width
+// FixedUInt. (Add/mul are *growing* ops on this carrier — a+b can need
+// width+1 rather than wrapping — so they intentionally do NOT match a
+// fixed-width add; only sub's underflow-wrap is a fixed-width behavior.)
+macro_rules! sub_width_parity {
+    ($k:literal, $fixed:ty) => {{
+        let mask: u32 = if $k == 4 {
+            u32::MAX
+        } else {
+            (1u32 << (8 * $k)) - 1
+        };
+        let vals: [u32; 6] = [0, 1, 5, 7, 0x7F, 0xFF];
+        for &a in &vals {
+            for &b in &vals {
+                let (a, b) = (a & mask, b & mask);
+                let (hd, hb) = OverflowingSub::overflowing_sub(h(a, $k), h(b, $k));
+                let (fd, fb) =
+                    OverflowingSub::overflowing_sub(<$fixed>::from(a), <$fixed>::from(b));
                 assert_eq!(
-                    h_val(&(&h(a, al) % &h(b, al))),
-                    f_val(&(&ff(a) % &ff(b))),
-                    "rem {a}%{b} al={al}"
-                );
-
-                let mut hra = h(a, al);
-                hra.rem_assign(&h(b, al));
-                let mut fra = ff(a);
-                fra %= ff(b);
-                assert_eq!(h_val(&hra), f_val(&fra), "rem_assign {a}%{b} al={al}");
-
-                assert_eq!(
-                    h(a, al).partial_cmp(&h(b, al)),
-                    ff(a).partial_cmp(&ff(b)),
-                    "cmp {a}?{b} al={al}"
+                    (h_val(&hd), hb),
+                    (fd.to_u64().unwrap(), fb),
+                    "sub {a}-{b} width={} bytes",
+                    $k
                 );
             }
         }
-    }
+    }};
+}
+
+#[test]
+fn heapless_sub_at_len_k_matches_fixeduint_of_width_k() {
+    // width = len·8: HeaplessBigInt<u8,4> subtraction at len 1/2/4 wraps
+    // like FixedUInt<u8,1>/<u8,2>/<u8,4> — capacity 4 never enters.
+    sub_width_parity!(1u16, FixedUInt<u8, 1>);
+    sub_width_parity!(2u16, FixedUInt<u8, 2>);
+    sub_width_parity!(4u16, FixedUInt<u8, 4>);
 }

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -1,130 +1,167 @@
-//! Width-model regression: a `HeaplessBigInt<u8, CAP>` value carried at
-//! `len = k` is a `k`-word integer of width `k · word_bits`, so every
-//! arithmetic op must return bit-for-bit what `FixedUInt<u8, k>` returns
-//! — wrapped value AND overflow/borrow flag alike. `CAP` is allocation,
-//! invisible to arithmetic; the words beyond `len` do not exist. This
-//! pins that equivalence across sub / wrapping_add / wrapping_mul /
-//! overflowing_add / overflowing_mul / checked_add / checked_mul at
-//! widths 1, 2, 4 inside a capacity-4 carrier.
+//! Differential oracle: a `HeaplessBigInt<u8, CAP>` carried at `len = k`
+//! is a `k`-word integer of width `k · word_bits`, so every arithmetic op
+//! must return bit-for-bit what `FixedUInt<u8, k>` returns — wrapped value
+//! AND overflow/borrow flag alike. `CAP` is allocation; the words beyond
+//! `len` do not exist for arithmetic.
+//!
+//! This is the payoff of that equivalence: the op surface is written ONCE
+//! in [`assert_carrier_parity`], and both a fixed-width `FixedUInt<u8, k>`
+//! and a runtime-width `HeaplessBigInt<u8, 24>` constructed at `len = k`
+//! flow through it. The carrier's capacity (24) is deliberately far wider
+//! than the widths under test (1, 2, 4) — if any op leaked capacity into
+//! its answer, the two sides would diverge here.
 
 #![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
 
 use const_num_traits::{
     CheckedAdd, CheckedMul, Nct, OverflowingAdd, OverflowingMul, OverflowingSub, WrappingAdd,
-    WrappingMul,
+    WrappingMul, WrappingSub,
 };
 use fixed_bigint::{FixedUInt, HeaplessBigInt};
 use num_traits::ToPrimitive;
 
-type H = HeaplessBigInt<u8, 4, Nct>;
+/// A fixed-width unsigned these differential tests can drive: build a value
+/// at a chosen word-width and read it back as `u64`. `FixedUInt<u8, N>`'s
+/// width is its `N` (the requested width must match); `HeaplessBigInt`
+/// constructs at `len = width`.
+trait WidthCarrier:
+    Copy
+    + WrappingAdd<Output = Self>
+    + WrappingSub<Output = Self>
+    + WrappingMul<Output = Self>
+    + OverflowingAdd<Output = Self>
+    + OverflowingSub<Output = Self>
+    + OverflowingMul<Output = Self>
+    + CheckedAdd<Output = Self>
+    + CheckedMul<Output = Self>
+{
+    fn make(v: u32, width_words: usize) -> Self;
+    fn read(&self) -> u64;
+}
 
-fn h_val(v: &H) -> u64 {
-    let mut buf = [0u8; 4];
-    let s = v.to_le_bytes(&mut buf);
-    let mut acc = 0u64;
-    for (i, b) in s.iter().enumerate() {
-        acc |= (*b as u64) << (8 * i);
+impl<const N: usize> WidthCarrier for FixedUInt<u8, N> {
+    fn make(v: u32, width_words: usize) -> Self {
+        assert_eq!(width_words, N, "FixedUInt<u8, N> width is fixed at N");
+        FixedUInt::<u8, N>::from(v)
     }
-    acc
+    fn read(&self) -> u64 {
+        ToPrimitive::to_u64(self).unwrap()
+    }
 }
 
-// A value carried at width = k bytes.
-fn h(val: u32, k: u16) -> H {
-    let b = val.to_le_bytes();
-    let mut limbs = [0u8; 4];
-    limbs[..k as usize].copy_from_slice(&b[..k as usize]);
-    H::from_limbs(limbs, k)
-}
-
-// The wrapping/overflowing ops all wrap at the operand value width, so
-// each matches the same-width FixedUInt: sub's underflow-wrap,
-// wrapping_add's carry-out discard, and wrapping_mul's high-half
-// truncation are all fixed-width-at-`len` behaviors. (The *growing*
-// variants — core::ops::+/*, checked_* — are a separate carrier feature,
-// not exercised here; this file pins the value-width equivalence.)
-macro_rules! width_parity {
-    ($k:literal, $fixed:ty) => {{
-        let mask: u32 = if $k == 4 {
-            u32::MAX
-        } else {
-            (1u32 << (8 * $k)) - 1
-        };
-        let vals: [u32; 6] = [0, 1, 5, 7, 0x7F, 0xFF];
-        for &a in &vals {
-            for &b in &vals {
-                let (a, b) = (a & mask, b & mask);
-
-                let (hd, hb) = OverflowingSub::overflowing_sub(h(a, $k), h(b, $k));
-                let (fd, fb) =
-                    OverflowingSub::overflowing_sub(<$fixed>::from(a), <$fixed>::from(b));
-                assert_eq!(
-                    (h_val(&hd), hb),
-                    (fd.to_u64().unwrap(), fb),
-                    "sub {a}-{b} width={} bytes",
-                    $k
-                );
-
-                let hs = WrappingAdd::wrapping_add(h(a, $k), h(b, $k));
-                let fs = WrappingAdd::wrapping_add(<$fixed>::from(a), <$fixed>::from(b));
-                assert_eq!(
-                    h_val(&hs),
-                    fs.to_u64().unwrap(),
-                    "wrapping_add {a}+{b} width={} bytes",
-                    $k
-                );
-
-                let hm = WrappingMul::wrapping_mul(h(a, $k), h(b, $k));
-                let fm = WrappingMul::wrapping_mul(<$fixed>::from(a), <$fixed>::from(b));
-                assert_eq!(
-                    h_val(&hm),
-                    fm.to_u64().unwrap(),
-                    "wrapping_mul {a}*{b} width={} bytes",
-                    $k
-                );
-
-                // Overflowing add/mul: wrapped value AND the overflow flag
-                // must both match the same-width FixedUInt.
-                let (ha, hac) = OverflowingAdd::overflowing_add(h(a, $k), h(b, $k));
-                let (fa, fac) =
-                    OverflowingAdd::overflowing_add(<$fixed>::from(a), <$fixed>::from(b));
-                assert_eq!(
-                    (h_val(&ha), hac),
-                    (fa.to_u64().unwrap(), fac),
-                    "overflowing_add {a}+{b} width={} bytes",
-                    $k
-                );
-
-                let (hp, hpo) = OverflowingMul::overflowing_mul(h(a, $k), h(b, $k));
-                let (fp, fpo) =
-                    OverflowingMul::overflowing_mul(<$fixed>::from(a), <$fixed>::from(b));
-                assert_eq!(
-                    (h_val(&hp), hpo),
-                    (fp.to_u64().unwrap(), fpo),
-                    "overflowing_mul {a}*{b} width={} bytes",
-                    $k
-                );
-
-                // Checked add/mul: None iff FixedUInt is None, else equal.
-                let hca = CheckedAdd::checked_add(h(a, $k), h(b, $k)).map(|v| h_val(&v));
-                let fca = CheckedAdd::checked_add(<$fixed>::from(a), <$fixed>::from(b))
-                    .map(|v| v.to_u64().unwrap());
-                assert_eq!(hca, fca, "checked_add {a}+{b} width={} bytes", $k);
-
-                let hcm = CheckedMul::checked_mul(h(a, $k), h(b, $k)).map(|v| h_val(&v));
-                let fcm = CheckedMul::checked_mul(<$fixed>::from(a), <$fixed>::from(b))
-                    .map(|v| v.to_u64().unwrap());
-                assert_eq!(hcm, fcm, "checked_mul {a}*{b} width={} bytes", $k);
-            }
+impl<const CAP: usize> WidthCarrier for HeaplessBigInt<u8, CAP, Nct> {
+    fn make(v: u32, width_words: usize) -> Self {
+        let bytes = v.to_le_bytes();
+        let mut limbs = [0u8; CAP];
+        limbs[..width_words].copy_from_slice(&bytes[..width_words]);
+        HeaplessBigInt::from_limbs(limbs, width_words as u16)
+    }
+    fn read(&self) -> u64 {
+        let mut buf = [0u8; CAP];
+        let s = self.to_le_bytes(&mut buf);
+        // Values under test fit in u64; guard the shift past 8 bytes (the
+        // high bytes are zero at these widths).
+        let mut acc = 0u64;
+        for (i, b) in s.iter().enumerate().take(8) {
+            acc |= (*b as u64) << (8 * i);
         }
-    }};
+        acc
+    }
+}
+
+/// Assert `Fixed` and `Heapless` agree on every op at `width` words. `Fixed`
+/// is the trusted fixed-width reference; `Heapless` is the carrier under
+/// test. Both wrapped value and flag must match.
+fn assert_carrier_parity<Fixed, Heapless>(width: usize, mask: u32)
+where
+    Fixed: WidthCarrier,
+    Heapless: WidthCarrier,
+{
+    // A spread that exercises cross-limb carries at widths 2 and 4.
+    let vals: [u32; 10] = [
+        0,
+        1,
+        5,
+        7,
+        0x7F,
+        0xFF,
+        0x0100,
+        0xFFFF,
+        0x0001_0000,
+        0xFFFF_FFFF,
+    ];
+
+    for &ra in &vals {
+        for &rb in &vals {
+            let (a, b) = (ra & mask, rb & mask);
+            let f = |v| Fixed::make(v, width);
+            let h = |v| Heapless::make(v, width);
+
+            assert_eq!(
+                WrappingAdd::wrapping_add(f(a), f(b)).read(),
+                WrappingAdd::wrapping_add(h(a), h(b)).read(),
+                "wrapping_add {a}+{b} @ width {width}"
+            );
+            assert_eq!(
+                WrappingSub::wrapping_sub(f(a), f(b)).read(),
+                WrappingSub::wrapping_sub(h(a), h(b)).read(),
+                "wrapping_sub {a}-{b} @ width {width}"
+            );
+            assert_eq!(
+                WrappingMul::wrapping_mul(f(a), f(b)).read(),
+                WrappingMul::wrapping_mul(h(a), h(b)).read(),
+                "wrapping_mul {a}*{b} @ width {width}"
+            );
+
+            let (fa, ffl) = OverflowingAdd::overflowing_add(f(a), f(b));
+            let (ha, hfl) = OverflowingAdd::overflowing_add(h(a), h(b));
+            assert_eq!(
+                (fa.read(), ffl),
+                (ha.read(), hfl),
+                "overflowing_add {a}+{b} @ width {width}"
+            );
+
+            let (fs, fsb) = OverflowingSub::overflowing_sub(f(a), f(b));
+            let (hs, hsb) = OverflowingSub::overflowing_sub(h(a), h(b));
+            assert_eq!(
+                (fs.read(), fsb),
+                (hs.read(), hsb),
+                "overflowing_sub {a}-{b} @ width {width}"
+            );
+
+            let (fp, fpo) = OverflowingMul::overflowing_mul(f(a), f(b));
+            let (hp, hpo) = OverflowingMul::overflowing_mul(h(a), h(b));
+            assert_eq!(
+                (fp.read(), fpo),
+                (hp.read(), hpo),
+                "overflowing_mul {a}*{b} @ width {width}"
+            );
+
+            assert_eq!(
+                CheckedAdd::checked_add(f(a), f(b)).map(|x| x.read()),
+                CheckedAdd::checked_add(h(a), h(b)).map(|x| x.read()),
+                "checked_add {a}+{b} @ width {width}"
+            );
+            assert_eq!(
+                CheckedMul::checked_mul(f(a), f(b)).map(|x| x.read()),
+                CheckedMul::checked_mul(h(a), h(b)).map(|x| x.read()),
+                "checked_mul {a}*{b} @ width {width}"
+            );
+        }
+    }
 }
 
 #[test]
-fn heapless_at_len_k_matches_fixeduint_of_width_k() {
-    // width = len·8: HeaplessBigInt<u8,4> sub / wrapping_add / wrapping_mul
-    // at len 1/2/4 wrap like FixedUInt<u8,1>/<u8,2>/<u8,4> — capacity 4
-    // never enters.
-    width_parity!(1u16, FixedUInt<u8, 1>);
-    width_parity!(2u16, FixedUInt<u8, 2>);
-    width_parity!(4u16, FixedUInt<u8, 4>);
+fn heapless_at_width_1_matches_fixeduint_u8_1() {
+    assert_carrier_parity::<FixedUInt<u8, 1>, HeaplessBigInt<u8, 24, Nct>>(1, 0xFF);
+}
+
+#[test]
+fn heapless_at_width_2_matches_fixeduint_u8_2() {
+    assert_carrier_parity::<FixedUInt<u8, 2>, HeaplessBigInt<u8, 24, Nct>>(2, 0xFFFF);
+}
+
+#[test]
+fn heapless_at_width_4_matches_fixeduint_u8_4() {
+    assert_carrier_parity::<FixedUInt<u8, 4>, HeaplessBigInt<u8, 24, Nct>>(4, 0xFFFF_FFFF);
 }

--- a/tests/heapless_carrier_parity.rs
+++ b/tests/heapless_carrier_parity.rs
@@ -1,29 +1,32 @@
-//! Differential oracle: a `HeaplessBigInt<u8, CAP>` carried at `len = k`
-//! is a `k`-word integer of width `k · word_bits`, so every arithmetic op
-//! must return bit-for-bit what `FixedUInt<u8, k>` returns — wrapped value
-//! AND overflow/borrow flag alike. `CAP` is allocation; the words beyond
-//! `len` do not exist for arithmetic.
+//! `HeaplessBigInt` inherits `FixedUInt`'s tested behavior by construction.
 //!
-//! This is the payoff of that equivalence: the op surface is written ONCE
-//! in [`assert_carrier_parity`], and both a fixed-width `FixedUInt<u8, k>`
-//! and a runtime-width `HeaplessBigInt<u8, 24>` constructed at `len = k`
-//! flow through it. The carrier's capacity (24) is deliberately far wider
-//! than the widths under test (1, 2, 4) — if any op leaked capacity into
-//! its answer, the two sides would diverge here.
+//! A value carried at `len = k` is a `k`-word integer of width
+//! `k · word_bits`, so it must return bit-for-bit what the same-width
+//! `FixedUInt` returns — value AND flag — on every op. `CAP` is
+//! allocation; the words beyond `len` do not exist for arithmetic.
+//!
+//! This inverts the usual "test the type" setup: `FixedUInt` is the
+//! trusted reference (it carries fixed-bigint's own large arithmetic
+//! suite), and every op is checked ONCE in [`assert_carrier_parity`] with
+//! `HeaplessBigInt` driven against `FixedUInt`'s answer. Any behavior that
+//! is correct for the fixed-width type is thereby demanded of the carrier
+//! too, across u8/u16/u32 backings and widths up to 64 bits, inside a
+//! capacity far wider than the width under test — so a capacity leak into
+//! any answer diverges here.
 
 #![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
 
 use const_num_traits::{
-    CheckedAdd, CheckedMul, Nct, OverflowingAdd, OverflowingMul, OverflowingSub, WrappingAdd,
-    WrappingMul, WrappingSub,
+    BitWidth, CheckedAdd, CheckedMul, FromByteSlice, Nct, OverflowingAdd, OverflowingMul,
+    OverflowingSub, WrappingAdd, WrappingMul, WrappingSub,
 };
+use core::cmp::Ordering;
 use fixed_bigint::{FixedUInt, HeaplessBigInt};
 use num_traits::ToPrimitive;
 
 /// A fixed-width unsigned these differential tests can drive: build a value
-/// at a chosen word-width and read it back as `u64`. `FixedUInt<u8, N>`'s
-/// width is its `N` (the requested width must match); `HeaplessBigInt`
-/// constructs at `len = width`.
+/// at a chosen word-width and read it back as `u64`. `FixedUInt<T, N>`'s
+/// width is its `N`; `HeaplessBigInt<T, CAP>` constructs at `len = width`.
 trait WidthCarrier:
     Copy
     + WrappingAdd<Output = Self>
@@ -34,83 +37,134 @@ trait WidthCarrier:
     + OverflowingMul<Output = Self>
     + CheckedAdd<Output = Self>
     + CheckedMul<Output = Self>
+    + core::ops::Div<Output = Self>
+    + core::ops::Rem<Output = Self>
+    + core::ops::Shl<usize, Output = Self>
+    + core::ops::Shr<usize, Output = Self>
+    + core::ops::BitAnd<Output = Self>
+    + core::ops::BitOr<Output = Self>
+    + PartialOrd
+    + BitWidth
 {
-    fn make(v: u32, width_words: usize) -> Self;
+    const WORD_BYTES: usize;
+    fn make(v: u64, width_words: usize) -> Self;
     fn read(&self) -> u64;
 }
 
-impl<const N: usize> WidthCarrier for FixedUInt<u8, N> {
-    fn make(v: u32, width_words: usize) -> Self {
-        assert_eq!(width_words, N, "FixedUInt<u8, N> width is fixed at N");
-        FixedUInt::<u8, N>::from(v)
-    }
-    fn read(&self) -> u64 {
-        ToPrimitive::to_u64(self).unwrap()
-    }
-}
-
-impl<const CAP: usize> WidthCarrier for HeaplessBigInt<u8, CAP, Nct> {
-    fn make(v: u32, width_words: usize) -> Self {
-        let bytes = v.to_le_bytes();
-        let mut limbs = [0u8; CAP];
-        limbs[..width_words].copy_from_slice(&bytes[..width_words]);
-        HeaplessBigInt::from_limbs(limbs, width_words as u16)
-    }
-    fn read(&self) -> u64 {
-        let mut buf = [0u8; CAP];
-        let s = self.to_le_bytes(&mut buf);
-        // Values under test fit in u64; guard the shift past 8 bytes (the
-        // high bytes are zero at these widths).
-        let mut acc = 0u64;
-        for (i, b) in s.iter().enumerate().take(8) {
-            acc |= (*b as u64) << (8 * i);
+macro_rules! impl_carrier {
+    (fixed $t:ty) => {
+        impl<const N: usize> WidthCarrier for FixedUInt<$t, N, Nct> {
+            const WORD_BYTES: usize = core::mem::size_of::<$t>();
+            fn make(v: u64, width_words: usize) -> Self {
+                assert_eq!(width_words, N, "FixedUInt<T, N> width is fixed at N");
+                let bytes = v.to_le_bytes();
+                FromByteSlice::from_le_slice(&bytes[..N * Self::WORD_BYTES]).unwrap()
+            }
+            fn read(&self) -> u64 {
+                ToPrimitive::to_u64(self).unwrap()
+            }
         }
-        acc
-    }
+    };
+    (heapless $t:ty) => {
+        impl<const CAP: usize> WidthCarrier for HeaplessBigInt<$t, CAP, Nct> {
+            const WORD_BYTES: usize = core::mem::size_of::<$t>();
+            fn make(v: u64, width_words: usize) -> Self {
+                let bytes = v.to_le_bytes();
+                HeaplessBigInt::from_le_bytes(&bytes[..width_words * Self::WORD_BYTES])
+            }
+            fn read(&self) -> u64 {
+                let mut buf = [0u8; 64];
+                let s = self.to_le_bytes(&mut buf);
+                let mut acc = 0u64;
+                for (i, b) in s.iter().enumerate().take(8) {
+                    acc |= (*b as u64) << (8 * i);
+                }
+                acc
+            }
+        }
+    };
 }
 
-/// Assert `Fixed` and `Heapless` agree on every op at `width` words. `Fixed`
-/// is the trusted fixed-width reference; `Heapless` is the carrier under
-/// test. Both wrapped value and flag must match.
-fn assert_carrier_parity<Fixed, Heapless>(width: usize, mask: u32)
-where
-    Fixed: WidthCarrier,
-    Heapless: WidthCarrier,
-{
-    // A spread that exercises cross-limb carries at widths 2 and 4.
-    let vals: [u32; 10] = [
+impl_carrier!(fixed u8);
+impl_carrier!(fixed u16);
+impl_carrier!(fixed u32);
+impl_carrier!(heapless u8);
+impl_carrier!(heapless u16);
+impl_carrier!(heapless u32);
+
+fn value_set(mask: u64) -> [u64; 9] {
+    [
         0,
         1,
-        5,
+        2,
         7,
-        0x7F,
-        0xFF,
-        0x0100,
-        0xFFFF,
-        0x0001_0000,
-        0xFFFF_FFFF,
-    ];
+        mask,                               // all ones
+        mask >> 1,                          // 0b0111..1
+        (mask >> 1).wrapping_add(1) & mask, // high bit only
+        0xA5A5_A5A5_A5A5_A5A5 & mask,       // alternating
+        0x0F1E_2D3C_4B5A_6978 & mask,       // arbitrary spread
+    ]
+}
 
+/// Assert `F` (fixed-width reference) and `H` (carrier under test) agree on
+/// every op at `width_words`. Both value and flag must match.
+fn assert_carrier_parity<F, H>(width_words: usize)
+where
+    F: WidthCarrier,
+    H: WidthCarrier,
+{
+    assert_eq!(F::WORD_BYTES, H::WORD_BYTES);
+    let width_bits = width_words * F::WORD_BYTES * 8;
+    let mask = if width_bits >= 64 {
+        u64::MAX
+    } else {
+        (1u64 << width_bits) - 1
+    };
+    let vals = value_set(mask);
+    let f = |v| F::make(v, width_words);
+    let h = |v| H::make(v, width_words);
+
+    // Unary ops.
+    for &ra in &vals {
+        let a = ra & mask;
+        assert_eq!(
+            BitWidth::bit_width(f(a)),
+            BitWidth::bit_width(h(a)),
+            "bit_width {a} @ width {width_bits}"
+        );
+        for &sh in &[0usize, 1, width_bits / 2, width_bits.saturating_sub(1)] {
+            assert_eq!(
+                (f(a) << sh).read(),
+                (h(a) << sh).read(),
+                "shl {a} << {sh} @ width {width_bits}"
+            );
+            assert_eq!(
+                (f(a) >> sh).read(),
+                (h(a) >> sh).read(),
+                "shr {a} >> {sh} @ width {width_bits}"
+            );
+        }
+    }
+
+    // Binary ops.
     for &ra in &vals {
         for &rb in &vals {
             let (a, b) = (ra & mask, rb & mask);
-            let f = |v| Fixed::make(v, width);
-            let h = |v| Heapless::make(v, width);
 
             assert_eq!(
                 WrappingAdd::wrapping_add(f(a), f(b)).read(),
                 WrappingAdd::wrapping_add(h(a), h(b)).read(),
-                "wrapping_add {a}+{b} @ width {width}"
+                "wrapping_add {a}+{b} @ width {width_bits}"
             );
             assert_eq!(
                 WrappingSub::wrapping_sub(f(a), f(b)).read(),
                 WrappingSub::wrapping_sub(h(a), h(b)).read(),
-                "wrapping_sub {a}-{b} @ width {width}"
+                "wrapping_sub {a}-{b} @ width {width_bits}"
             );
             assert_eq!(
                 WrappingMul::wrapping_mul(f(a), f(b)).read(),
                 WrappingMul::wrapping_mul(h(a), h(b)).read(),
-                "wrapping_mul {a}*{b} @ width {width}"
+                "wrapping_mul {a}*{b} @ width {width_bits}"
             );
 
             let (fa, ffl) = OverflowingAdd::overflowing_add(f(a), f(b));
@@ -118,7 +172,7 @@ where
             assert_eq!(
                 (fa.read(), ffl),
                 (ha.read(), hfl),
-                "overflowing_add {a}+{b} @ width {width}"
+                "overflowing_add {a}+{b} @ width {width_bits}"
             );
 
             let (fs, fsb) = OverflowingSub::overflowing_sub(f(a), f(b));
@@ -126,7 +180,7 @@ where
             assert_eq!(
                 (fs.read(), fsb),
                 (hs.read(), hsb),
-                "overflowing_sub {a}-{b} @ width {width}"
+                "overflowing_sub {a}-{b} @ width {width_bits}"
             );
 
             let (fp, fpo) = OverflowingMul::overflowing_mul(f(a), f(b));
@@ -134,34 +188,80 @@ where
             assert_eq!(
                 (fp.read(), fpo),
                 (hp.read(), hpo),
-                "overflowing_mul {a}*{b} @ width {width}"
+                "overflowing_mul {a}*{b} @ width {width_bits}"
             );
 
             assert_eq!(
                 CheckedAdd::checked_add(f(a), f(b)).map(|x| x.read()),
                 CheckedAdd::checked_add(h(a), h(b)).map(|x| x.read()),
-                "checked_add {a}+{b} @ width {width}"
+                "checked_add {a}+{b} @ width {width_bits}"
             );
             assert_eq!(
                 CheckedMul::checked_mul(f(a), f(b)).map(|x| x.read()),
                 CheckedMul::checked_mul(h(a), h(b)).map(|x| x.read()),
-                "checked_mul {a}*{b} @ width {width}"
+                "checked_mul {a}*{b} @ width {width_bits}"
             );
+
+            assert_eq!(
+                (f(a) & f(b)).read(),
+                (h(a) & h(b)).read(),
+                "bitand {a}&{b} @ width {width_bits}"
+            );
+            assert_eq!(
+                (f(a) | f(b)).read(),
+                (h(a) | h(b)).read(),
+                "bitor {a}|{b} @ width {width_bits}"
+            );
+
+            assert_eq!(
+                f(a).partial_cmp(&f(b)),
+                h(a).partial_cmp(&h(b)),
+                "cmp {a} ? {b} @ width {width_bits}"
+            );
+
+            // Div / Rem: skip the zero divisor.
+            if b != 0 {
+                assert_eq!(
+                    (f(a) / f(b)).read(),
+                    (h(a) / h(b)).read(),
+                    "div {a}/{b} @ width {width_bits}"
+                );
+                assert_eq!(
+                    (f(a) % f(b)).read(),
+                    (h(a) % h(b)).read(),
+                    "rem {a}%{b} @ width {width_bits}"
+                );
+            }
         }
     }
+
+    // Anchor: at least one comparison actually distinguished ordering.
+    assert_ne!(
+        f(vals[0] & mask).partial_cmp(&f(vals[4] & mask)),
+        Some(Ordering::Equal)
+    );
 }
 
+// u8 backing: widths 1, 2, 4, 8 (8 … 64 bits) in a capacity-24 carrier.
 #[test]
-fn heapless_at_width_1_matches_fixeduint_u8_1() {
-    assert_carrier_parity::<FixedUInt<u8, 1>, HeaplessBigInt<u8, 24, Nct>>(1, 0xFF);
+fn u8_backed_widths_match_fixeduint() {
+    assert_carrier_parity::<FixedUInt<u8, 1>, HeaplessBigInt<u8, 24, Nct>>(1);
+    assert_carrier_parity::<FixedUInt<u8, 2>, HeaplessBigInt<u8, 24, Nct>>(2);
+    assert_carrier_parity::<FixedUInt<u8, 4>, HeaplessBigInt<u8, 24, Nct>>(4);
+    assert_carrier_parity::<FixedUInt<u8, 8>, HeaplessBigInt<u8, 24, Nct>>(8);
 }
 
+// u16 backing: widths 1, 2, 4 (16 … 64 bits) in a capacity-12 carrier.
 #[test]
-fn heapless_at_width_2_matches_fixeduint_u8_2() {
-    assert_carrier_parity::<FixedUInt<u8, 2>, HeaplessBigInt<u8, 24, Nct>>(2, 0xFFFF);
+fn u16_backed_widths_match_fixeduint() {
+    assert_carrier_parity::<FixedUInt<u16, 1>, HeaplessBigInt<u16, 12, Nct>>(1);
+    assert_carrier_parity::<FixedUInt<u16, 2>, HeaplessBigInt<u16, 12, Nct>>(2);
+    assert_carrier_parity::<FixedUInt<u16, 4>, HeaplessBigInt<u16, 12, Nct>>(4);
 }
 
+// u32 backing: widths 1, 2 (32 … 64 bits) in a capacity-6 carrier.
 #[test]
-fn heapless_at_width_4_matches_fixeduint_u8_4() {
-    assert_carrier_parity::<FixedUInt<u8, 4>, HeaplessBigInt<u8, 24, Nct>>(4, 0xFFFF_FFFF);
+fn u32_backed_widths_match_fixeduint() {
+    assert_carrier_parity::<FixedUInt<u32, 1>, HeaplessBigInt<u32, 6, Nct>>(1);
+    assert_carrier_parity::<FixedUInt<u32, 2>, HeaplessBigInt<u32, 6, Nct>>(2);
 }

--- a/tests/heapless_cios.rs
+++ b/tests/heapless_cios.rs
@@ -1,0 +1,148 @@
+//! Sanity tests for the `CiosRowOps` impl on `HeaplessBigInt`.
+//!
+//! Verifies the trait's contract at the primitive level (small numeric
+//! examples where the expected value is checked by hand) — the full
+//! CIOS driver is exercised in modmath's own integration.
+
+#![cfg(all(feature = "heapless-runtime-len", feature = "cios"))]
+
+use const_num_traits::Nct;
+use fixed_bigint::HeaplessBigInt;
+use modmath_cios::CiosRowOps;
+
+type H4u32 = HeaplessBigInt<u32, 4, Nct>;
+type H2u32 = HeaplessBigInt<u32, 2, Nct>;
+
+#[test]
+fn word_count_matches_len() {
+    let v = H4u32::from_limbs([1, 2, 3, 0], 3);
+    assert_eq!(v.word_count(), 3);
+}
+
+#[test]
+fn word_reads_the_indexed_limb() {
+    let v = H4u32::from_limbs([100, 200, 300, 0], 3);
+    assert_eq!(v.word(0), 100);
+    assert_eq!(v.word(1), 200);
+    assert_eq!(v.word(2), 300);
+}
+
+#[test]
+fn cios_accumulator_matches_operand_width_and_is_zero() {
+    // Runtime-width carrier: accumulator len must equal operand len,
+    // not fall back to `Default` (which is len=0).
+    let modulus = H4u32::from_limbs([0xFFFF_FFFF, 0xFFFF_FFFF, 0xFFFF_FFFF, 0], 3);
+    let acc = modulus.cios_accumulator();
+    assert_eq!(acc.word_count(), 3);
+    for i in 0..acc.word_count() {
+        assert_eq!(acc.word(i), 0);
+    }
+}
+
+#[test]
+fn mul_acc_row_single_limb_no_carry() {
+    // W=1: acc = 0 + 3*4 + 0 = 12, carry = 0.
+    let mult = H2u32::from_limbs([3, 0], 1);
+    let mut acc = mult.cios_accumulator();
+    let carry_out = <H2u32 as CiosRowOps>::mul_acc_row(4, &mult, &mut acc, 0);
+    assert_eq!(acc.word(0), 12);
+    assert_eq!(carry_out, 0);
+}
+
+#[test]
+fn mul_acc_row_single_limb_produces_carry() {
+    // W=1: acc = 0 + u32::MAX * 2 + 0 = 2^33 - 2.
+    // Low: 0xFFFFFFFE. High (carry): 1.
+    let mult = H2u32::from_limbs([u32::MAX, 0], 1);
+    let mut acc = mult.cios_accumulator();
+    let carry_out = <H2u32 as CiosRowOps>::mul_acc_row(2, &mult, &mut acc, 0);
+    assert_eq!(acc.word(0), 0xFFFF_FFFE);
+    assert_eq!(carry_out, 1);
+}
+
+#[test]
+fn mul_acc_row_multi_limb_carries_across() {
+    // mult = 0xFFFF_FFFF_FFFF_FFFF (two u32 limbs).
+    // scalar = 2. Product = 2^33 - 2 spans both limbs into a third position.
+    // acc = 0 + 2 * (2^64 - 1) = 2^65 - 2 → 3 * 2^32 words:
+    //   limb[0] = 0xFFFF_FFFE
+    //   limb[1] = 0xFFFF_FFFF
+    //   carry_out = 1
+    let mult = H2u32::from_limbs([u32::MAX, u32::MAX], 2);
+    let mut acc = mult.cios_accumulator();
+    let carry_out = <H2u32 as CiosRowOps>::mul_acc_row(2, &mult, &mut acc, 0);
+    assert_eq!(acc.word(0), 0xFFFF_FFFE);
+    assert_eq!(acc.word(1), 0xFFFF_FFFF);
+    assert_eq!(carry_out, 1);
+}
+
+#[test]
+fn mul_acc_row_uses_carry_in() {
+    // W=1: acc = 5 + 3*4 + 7 = 24. No overflow.
+    let mult = H2u32::from_limbs([3, 0], 1);
+    let mut acc = H2u32::from_limbs([5, 0], 1);
+    let carry_out = <H2u32 as CiosRowOps>::mul_acc_row(4, &mult, &mut acc, 7);
+    assert_eq!(acc.word(0), 24);
+    assert_eq!(carry_out, 0);
+}
+
+#[test]
+fn mul_acc_shift_row_single_limb() {
+    // Match modmath-cios's primitive-impl semantics.
+    // scalar=2, mult=3, acc=1, acc_hi=0.
+    // product = 6. total = acc + product = 7. total_hi = 0.
+    // sum = total_hi + acc_hi = 0. acc = 0. return (sum >> b) = 0.
+    let mult = H2u32::from_limbs([3, 0], 1);
+    let mut acc = H2u32::from_limbs([1, 0], 1);
+    let ret = <H2u32 as CiosRowOps>::mul_acc_shift_row(2, &mult, &mut acc, 0);
+    assert_eq!(acc.word(0), 0);
+    assert_eq!(ret, 0);
+}
+
+#[test]
+fn mul_acc_shift_row_produces_nonzero_top() {
+    // scalar=u32::MAX, mult=u32::MAX, acc=0, acc_hi=0.
+    // product = (2^32 - 1)^2 = 2^64 - 2^33 + 1. Split as (t_lo, t_hi) =
+    // (1, 2^32 - 2). total (acc + product) same. total_hi = t_hi + c_from_lo_add.
+    // c_from_lo_add = (0 + 1 >= 2^32)? no, so c = 0. total_hi = 2^32 - 2.
+    // sum = total_hi + acc_hi = 2^32 - 2. top_hi_bit = 0.
+    // acc[0] = top_low = 2^32 - 2. Return 0.
+    let mult = H2u32::from_limbs([u32::MAX, 0], 1);
+    let mut acc = H2u32::from_limbs([0, 0], 1);
+    let ret = <H2u32 as CiosRowOps>::mul_acc_shift_row(u32::MAX, &mult, &mut acc, 0);
+    assert_eq!(acc.word(0), 0xFFFF_FFFE);
+    assert_eq!(ret, 0);
+}
+
+#[test]
+fn mul_acc_shift_row_multi_limb_shifts_low_limb_out() {
+    // W=2 mult = [1, 0], scalar = 1, acc = [0, 0], acc_hi = 0.
+    // Phase 1: acc[0] += 1*1 = 1. acc[1] += 1*0 = 0 (with carry from mul: 0).
+    // carry after phase 1: 0.
+    // top_low = 0 + acc_hi = 0. top_hi_bit = 0.
+    // Shift: acc[0] = acc[1] = 0. acc[1] = top_low = 0.
+    // Result: acc = [0, 0], ret = 0.
+    let mult = H2u32::from_limbs([1, 0], 2);
+    let mut acc = H2u32::from_limbs([0, 0], 2);
+    let ret = <H2u32 as CiosRowOps>::mul_acc_shift_row(1, &mult, &mut acc, 0);
+    assert_eq!(acc.word(0), 0);
+    assert_eq!(acc.word(1), 0);
+    assert_eq!(ret, 0);
+}
+
+#[test]
+fn mul_acc_shift_row_carries_top_bit() {
+    // scalar=u32::MAX, mult=[u32::MAX], acc=[0, 0], acc_hi=u32::MAX.
+    // W=1 (mult len).
+    // Phase 1: (t_lo, t_hi) = MAX * MAX + 0 = (1, MAX - 1). acc[0]+t_lo: sum=1, c=0.
+    // acc[0] = 1. carry = t_hi + c = MAX - 1.
+    // Combine: top_low, top_hi_bit = (MAX - 1) + MAX = 2 * MAX - 1 = 2^33 - 3.
+    //   → top_low = 2^32 - 3 = 0xFFFF_FFFD, top_hi_bit = 1.
+    // Shift: n=1, no shuffling. acc[0] = top_low = 0xFFFF_FFFD.
+    // Return: 1.
+    let mult = H2u32::from_limbs([u32::MAX, 0], 1);
+    let mut acc = H2u32::from_limbs([0, 0], 1);
+    let ret = <H2u32 as CiosRowOps>::mul_acc_shift_row(u32::MAX, &mult, &mut acc, u32::MAX);
+    assert_eq!(acc.word(0), 0xFFFF_FFFD);
+    assert_eq!(ret, 1);
+}

--- a/tests/heapless_cios.rs
+++ b/tests/heapless_cios.rs
@@ -4,7 +4,7 @@
 //! examples where the expected value is checked by hand) — the full
 //! CIOS driver is exercised in modmath's own integration.
 
-#![cfg(all(feature = "heapless-runtime-len", feature = "cios"))]
+#![cfg(feature = "cios")]
 
 use const_num_traits::Nct;
 use fixed_bigint::HeaplessBigInt;

--- a/tests/heapless_widemul_diag.rs
+++ b/tests/heapless_widemul_diag.rs
@@ -9,8 +9,6 @@
 //! at N, HeaplessBigInt splits at the value width. So we check the split
 //! shape directly, not limb-for-limb parity with FixedUInt.
 
-#![cfg(feature = "heapless-runtime-len")]
-
 use const_num_traits::{CarryingMul, Nct, Zero};
 use fixed_bigint::HeaplessBigInt;
 

--- a/tests/heapless_widemul_diag.rs
+++ b/tests/heapless_widemul_diag.rs
@@ -1,67 +1,65 @@
-//! Diagnostic: HeaplessBigInt<T,CAP>.wide_mul must match FixedUInt<T,CAP>
-//! for ALL operand lens — WideMul splits at the carrier's fixed width,
-//! and wide-REDC reconstructs `hi·2^(carrier_width) + lo` against that.
-//! ed25519's field-param setup does wide_mul(small, small) (e.g.
-//! r2_mod_n = 38*38), where a max(operand-len) split diverges.
+//! `HeaplessBigInt::wide_mul` (CarryingMul) splits its (lo, hi) product
+//! at the operands' VALUE width (`max(len)` words = `bits_precision`),
+//! NOT at CAP. modmath's wide-REDC reconstructs `hi·2^(len·word_bits) +
+//! lo`, so a CAP split on a sub-capacity field (`len < CAP`) would
+//! strand the high half in `lo` and break the REDC (the RSA bug).
+//!
+//! The full-product VALUE matches FixedUInt, but the (lo, hi) *split
+//! boundary* does not for sub-CAP operands — FixedUInt<N> always splits
+//! at N, HeaplessBigInt splits at the value width. So we check the split
+//! shape directly, not limb-for-limb parity with FixedUInt.
 
-#![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
+#![cfg(feature = "heapless-runtime-len")]
 
 use const_num_traits::{CarryingMul, Nct, Zero};
-use fixed_bigint::{FixedUInt, HeaplessBigInt};
-use num_traits::ToPrimitive;
+use fixed_bigint::HeaplessBigInt;
 
-type H = HeaplessBigInt<u32, 8, Nct>;
-type F = FixedUInt<u32, 8, Nct>;
+type H8 = HeaplessBigInt<u32, 8, Nct>;
+type H4 = HeaplessBigInt<u32, 4, Nct>;
 
-// (lo, hi) of both carriers must agree limb-for-limb over the full CAP.
-fn assert_wide_mul_matches(a: u32, b: u32, alen: u16, blen: u16) {
-    let ha = H::from_limbs(
-        {
-            let mut l = [0u32; 8];
-            l[0] = a;
-            l
-        },
-        alen,
-    );
-    let hb = H::from_limbs(
-        {
-            let mut l = [0u32; 8];
-            l[0] = b;
-            l
-        },
-        blen,
-    );
-    let (hlo, hhi) = ha.carrying_mul(hb, <H as Zero>::zero());
+#[test]
+fn wide_mul_splits_at_value_width_rsa_repro() {
+    // RSA repro: two len-2 operands in an 8-word carrier.
+    // a = 0x1000_0000_0000_0003, b = 0x2_0000_0005.
+    // full product = [15, 1342177286, 536870912, 0] (128-bit).
+    let a = H8::from_limbs([0x0000_0003, 0x1000_0000, 0, 0, 0, 0, 0, 0], 2);
+    let b = H8::from_limbs([0x5, 0x2, 0, 0, 0, 0, 0, 0], 2);
+    let (lo, hi) = a.carrying_mul(b, <H8 as Zero>::zero());
 
-    let fa = F::from(a);
-    let fb = F::from(b);
-    let (flo, fhi) = fa.carrying_mul(fb, <F as Zero>::zero());
-
-    // Compare each half limb-for-limb across the whole container.
-    for i in 0..8 {
-        assert_eq!(
-            hlo.all_limbs()[i],
-            flo.words()[i],
-            "lo limb {i}: wide_mul({a}@{alen} * {b}@{blen})"
-        );
-        assert_eq!(
-            hhi.all_limbs()[i],
-            fhi.words()[i],
-            "hi limb {i}: wide_mul({a}@{alen} * {b}@{blen})"
-        );
-    }
-    let _ = (flo.to_u64(), fhi.to_u64());
+    // Split at value width W=2: low 2 words in lo, high 2 words in hi.
+    assert_eq!(lo.len(), 2, "lo width == value width (2 words)");
+    assert_eq!(hi.len(), 2);
+    assert_eq!(lo.limbs(), &[15, 1342177286]);
+    assert_eq!(hi.limbs(), &[536870912, 0]);
 }
 
 #[test]
-fn wide_mul_matches_fixeduint_for_small_operands() {
-    // The ed25519 r2_mod_n shape: 38 * 38 = 1444, both operands len 1.
-    assert_wide_mul_matches(38, 38, 1, 1);
-    // And a range of sub-width / mixed-width pairs.
-    for &(a, b) in &[(7u32, 7u32), (1444, 1), (0xFFFF_FFFF, 2), (100, 200)] {
-        assert_wide_mul_matches(a, b, 1, 1);
-        assert_wide_mul_matches(a, b, 8, 1);
-        assert_wide_mul_matches(a, b, 1, 8);
-        assert_wide_mul_matches(a, b, 8, 8);
-    }
+fn wide_mul_split_follows_len_not_cap() {
+    // Same len-2 operands in a len-4 vs len-8 carrier must give the SAME
+    // split (at value width 2) — the boundary tracks len, not CAP.
+    let a8 = H8::from_limbs([7, 3, 0, 0, 0, 0, 0, 0], 2);
+    let b8 = H8::from_limbs([9, 5, 0, 0, 0, 0, 0, 0], 2);
+    let (lo8, hi8) = a8.carrying_mul(b8, <H8 as Zero>::zero());
+
+    let a4 = H4::from_limbs([7, 3, 0, 0], 2);
+    let b4 = H4::from_limbs([9, 5, 0, 0], 2);
+    let (lo4, hi4) = a4.carrying_mul(b4, <H4 as Zero>::zero());
+
+    assert_eq!(lo8.len(), 2);
+    assert_eq!(hi8.len(), 2);
+    assert_eq!(lo8.limbs(), lo4.limbs());
+    assert_eq!(hi8.limbs(), hi4.limbs());
+}
+
+#[test]
+fn wide_mul_high_half_lands_in_hi() {
+    // 0xFFFF_FFFF * 2 at len 1 = 0x1_FFFF_FFFE. Value width 1 → the
+    // carry bit is the high half → hi = 1 (not stranded in lo).
+    let a = H8::from_limbs([0xFFFF_FFFF, 0, 0, 0, 0, 0, 0, 0], 1);
+    let b = H8::from_limbs([2, 0, 0, 0, 0, 0, 0, 0], 1);
+    let (lo, hi) = a.carrying_mul(b, <H8 as Zero>::zero());
+    assert_eq!(lo.len(), 1);
+    assert_eq!(hi.len(), 1);
+    assert_eq!(lo.limbs()[0], 0xFFFF_FFFE);
+    assert_eq!(hi.limbs()[0], 1);
 }

--- a/tests/heapless_widemul_diag.rs
+++ b/tests/heapless_widemul_diag.rs
@@ -1,0 +1,67 @@
+//! Diagnostic: HeaplessBigInt<T,CAP>.wide_mul must match FixedUInt<T,CAP>
+//! for ALL operand lens — WideMul splits at the carrier's fixed width,
+//! and wide-REDC reconstructs `hi·2^(carrier_width) + lo` against that.
+//! ed25519's field-param setup does wide_mul(small, small) (e.g.
+//! r2_mod_n = 38*38), where a max(operand-len) split diverges.
+
+#![cfg(all(feature = "heapless-runtime-len", feature = "num-traits"))]
+
+use const_num_traits::{CarryingMul, Nct, Zero};
+use fixed_bigint::{FixedUInt, HeaplessBigInt};
+use num_traits::ToPrimitive;
+
+type H = HeaplessBigInt<u32, 8, Nct>;
+type F = FixedUInt<u32, 8, Nct>;
+
+// (lo, hi) of both carriers must agree limb-for-limb over the full CAP.
+fn assert_wide_mul_matches(a: u32, b: u32, alen: u16, blen: u16) {
+    let ha = H::from_limbs(
+        {
+            let mut l = [0u32; 8];
+            l[0] = a;
+            l
+        },
+        alen,
+    );
+    let hb = H::from_limbs(
+        {
+            let mut l = [0u32; 8];
+            l[0] = b;
+            l
+        },
+        blen,
+    );
+    let (hlo, hhi) = ha.carrying_mul(hb, <H as Zero>::zero());
+
+    let fa = F::from(a);
+    let fb = F::from(b);
+    let (flo, fhi) = fa.carrying_mul(fb, <F as Zero>::zero());
+
+    // Compare each half limb-for-limb across the whole container.
+    for i in 0..8 {
+        assert_eq!(
+            hlo.all_limbs()[i],
+            flo.words()[i],
+            "lo limb {i}: wide_mul({a}@{alen} * {b}@{blen})"
+        );
+        assert_eq!(
+            hhi.all_limbs()[i],
+            fhi.words()[i],
+            "hi limb {i}: wide_mul({a}@{alen} * {b}@{blen})"
+        );
+    }
+    let _ = (flo.to_u64(), fhi.to_u64());
+}
+
+#[test]
+fn wide_mul_matches_fixeduint_for_small_operands() {
+    // The ed25519 r2_mod_n shape: 38 * 38 = 1444, both operands len 1.
+    assert_wide_mul_matches(38, 38, 1, 1);
+    // And a range of sub-width / mixed-width pairs.
+    for &(a, b) in &[(7u32, 7u32), (1444, 1), (0xFFFF_FFFF, 2), (100, 200)] {
+        assert_wide_mul_matches(a, b, 1, 1);
+        assert_wide_mul_matches(a, b, 8, 1);
+        assert_wide_mul_matches(a, b, 1, 8);
+        assert_wide_mul_matches(a, b, 8, 8);
+    }
+}

--- a/tests/heapless_widemul_diag.rs
+++ b/tests/heapless_widemul_diag.rs
@@ -1,8 +1,8 @@
 //! `HeaplessBigInt::wide_mul` (CarryingMul) splits its (lo, hi) product
 //! at the operands' VALUE width (`max(len)` words = `bits_precision`),
-//! NOT at CAP. modmath's wide-REDC reconstructs `hi·2^(len·word_bits) +
-//! lo`, so a CAP split on a sub-capacity field (`len < CAP`) would
-//! strand the high half in `lo` and break the REDC (the RSA bug).
+//! NOT at CAP. A wide Montgomery reduction reconstructs
+//! `hi·2^(len·word_bits) + lo`, so a CAP split on a sub-capacity field
+//! (`len < CAP`) would strand the high half in `lo` and break the REDC.
 //!
 //! The full-product VALUE matches FixedUInt, but the (lo, hi) *split
 //! boundary* does not for sub-CAP operands — FixedUInt<N> always splits
@@ -19,7 +19,7 @@ type H4 = HeaplessBigInt<u32, 4, Nct>;
 
 #[test]
 fn wide_mul_splits_at_value_width_rsa_repro() {
-    // RSA repro: two len-2 operands in an 8-word carrier.
+    // Two len-2 operands in an 8-word carrier.
     // a = 0x1000_0000_0000_0003, b = 0x2_0000_0005.
     // full product = [15, 1342177286, 536870912, 0] (128-bit).
     let a = H8::from_limbs([0x0000_0003, 0x1000_0000, 0, 0, 0, 0, 0, 0], 2);


### PR DESCRIPTION
Draft PR for the fixed-capacity, runtime-length bignum sketch. Everything is behind feature flags off by default — FixedUInt-only consumers see no surface change.

## What's in it

`HeaplessBigInt<T, CAP, P>`: a sibling type to `FixedUInt`. Same `T: MachineWord` bound, same `Personality` typestate (`Nct` / `Ct`), but `CAP` is compile-time while `len` is a runtime shape parameter treated as **public** — every op iterates `0..self.len`, not `0..CAP`. The design record is at `notes/HEAPLESS_BIGINT_SPEC_v3.md` (gitignored / local).

Surface, per commit:

- **d25afbe** — struct + `AssertCapFits`, constructors (`new_zero_with_len`, `zero_full_cap`, `from_limbs`), accessors, Copy/Clone/Debug, slice-kernel Add/Sub/Mul + `core::ops`, PartialEq/PartialOrd/Ord/Hash, `subtle::ConstantTimeEq`, Zero/One/Default (= Zero, post `modmath-cios 0.1.2`), ConstZero/ConstOne.
- **17c6264** — `subtle::ConditionallySelectable` (output `len = max(a.len, b.len)`), `const_num_traits::CtIsZero`, `subtle::ConstantTimeGreater/Less` (MSB-to-LSB scan with running `undecided` bit), `core::ops::Shl<usize>` / `Shr<usize>`.
- **9df463a** — byte serialization (`to/from_{be,le}_bytes`, zip byte-loop discipline landed in 0.5.2), `bit_length` / `leading_zeros`, `modmath_cios::CiosRowOps` with runtime-width `cios_accumulator` override.
- **5b827ea** — version bump to `0.6.0-alpha.1`.

## Features

- `heapless-runtime-len` — gates the module + `HeaplessBigInt` re-export at the crate root.
- `cios` — additionally required for the CIOS row-ops impl. Bumps `modmath-cios` requirement to `0.1.2`.

## Draft status

Marked **draft** because:
- Full trait surface still incomplete (no division, no Barrett/Montgomery drivers, no bit-ops beyond shifts, no CT-verify fixtures).
- Downstream test-integration into `modmath` hasn't happened yet — this branch is the substrate for that.
- API shapes may still shift once modmath actually consumes the surface.

## Test plan

- [ ] `cargo test --features heapless-runtime-len` (73 sanity tests on the surface)
- [ ] `cargo test --features heapless-runtime-len,cios` (adds 11 `CiosRowOps` tests)
- [ ] modmath integrates against this branch's `HeaplessBigInt` at 2048-bit RSA-scale shapes and reports back

## Summary by Sourcery

Introduce an experimental fixed-capacity, runtime-length big integer type behind a feature flag and validate its core arithmetic and serialization via new tests.

New Features:
- Add a HeaplessBigInt type providing fixed-capacity, runtime-length big integers gated by the heapless-runtime-len feature.
- Expose HeaplessBigInt at the crate root and integrate it with const_num_traits, subtle, and modmath-cios for arithmetic, comparison, shifting, and byte serialization.

Enhancements:
- Implement CIOS row-operations for HeaplessBigInt to support Montgomery multiplication when the cios feature is enabled.
- Add bit-length and leading-zeros helpers for HeaplessBigInt to support higher-level arithmetic algorithms.

Build:
- Bump crate version to 0.6.0-alpha.1 and update the modmath-cios dependency to 0.1.2.

Tests:
- Add sanity test suites covering HeaplessBigInt constructors, arithmetic, comparison, constant-time traits, shifting, byte serialization, and CIOS row operations under appropriate feature gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime-width `HeaplessBigInt` (feature-gated) with wrapping/checked/overflowing add/sub/mul, shifts, bitwise AND/OR, parity, division/remainder, and bit-length/precision helpers.
  * Added endian byte serialization/deserialization plus `u8/u16/u32` constructors.
  * Added optional `zeroize` support and feature-gated CIOS row-ops integration.
  * Added `FixedUInt` bit-precision support and internal byte-holder exposure for cross-module use.
* **Documentation**
  * Expanded constant-time vs non-constant-time guidance and clarified doctest wording.
* **Tests**
  * Added comprehensive heapless sanity, carrier-parity, CIOS, and wide-mul coverage.
* **Chores**
  * Bumped `fixed-bigint` version and tightened dependency versions/feature wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->