### PR TITLE
ci: baseline probe — does main fail the nightly generic_const_exprs lane?

### DIFF
--- a/CI_BASELINE_PROBE.md
+++ b/CI_BASELINE_PROBE.md
@@ -1,0 +1,8 @@
+# CI baseline probe (temporary)
+
+This branch adds only this file on top of `origin/main`. Its sole purpose
+is to fire the CI matrix — in particular the `nightly` leg's
+`cargo test --features nightly` — to establish whether the released
+`main` tree already fails on the `generic_const_exprs` path
+(`FixedUInt::const_to_from_bytes` `E0275`), independent of any in-flight
+`heapless-runtime-len` work. Delete once the question is answered.

--- a/tests/probe_const_tobytes.rs
+++ b/tests/probe_const_tobytes.rs
@@ -1,0 +1,15 @@
+// Temporary diagnostic (see CI_BASELINE_PROBE.md). Monomorphizes
+// FixedUInt<u32,4>'s const_num_traits::ToBytes under the `nightly`
+// (generic_const_exprs) feature — the exact call the local run hit
+// E0275 on. On main + crates.io const-num-traits, this tells us whether
+// that overflow is a latent library defect or something downstream.
+#![cfg(feature = "nightly")]
+use const_num_traits::ToBytes;
+use fixed_bigint::FixedUInt;
+
+#[test]
+fn probe_fixeduint_u32x4_const_tobytes() {
+    let f = FixedUInt::<u32, 4>::from(0x1234_5678u32);
+    let bytes = <FixedUInt<u32, 4> as ToBytes>::to_be_bytes(f);
+    assert_eq!(bytes.as_ref().len(), 16);
+}


### PR DESCRIPTION
**Temporary probe — do not merge.**

Adds a single stamp file on top of `origin/main` (v0.5.2, crates.io
`const-num-traits = "0.2"`, no `heapless-runtime-len` work) purely to fire
the CI matrix.

The question: the `nightly` leg runs `cargo test --features nightly`, which
compiles `FixedUInt::const_to_from_bytes` via `generic_const_exprs`. A local
run (`nightly-2026-06-18`) hits `E0275: overflow evaluating whether [...]
const_to_from_bytes::{impl#17}::{constant#0} is well-formed`, reproducible
standalone with **no** heapless code. This PR establishes whether that
failure is already present on released `main` + current nightly, independent
of any in-flight work.

- **Red nightly leg** → the `E0275` is pre-existing on `main`.
- **Green** → it is introduced downstream (a branch / dependency bump), and
  I own it.

Close after reading the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add a short markdown note documenting the CI baseline probe branch whose only purpose is to run the nightly CI leg and be deleted afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a temporary CI baseline probe, including how to run the nightly CI job to investigate a potential `generic_const_exprs` issue.
  * Notes guidance to remove the documentation after the investigation is complete.
* **Tests**
  * Added a nightly-gated test that verifies constant conversion to big-endian bytes produces the expected 16-byte output for a `FixedUInt` value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->