### PR TITLE
const_to_from_bytes: document viral generic_const_exprs requirement + cross-crate coverage

### DIFF
--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -16,6 +16,35 @@
 //!
 //! This module requires the `nightly` feature and uses `generic_const_exprs`
 //! to compute byte array sizes at compile time without unsafe code.
+//!
+//! # Downstream usage — `generic_const_exprs` is viral
+//!
+//! The associated `Bytes` type of these impls is sized with a
+//! `generic_const_exprs` bound (`where [(); byte_len::<T, N>()]:`). That bound
+//! is **viral**: a downstream crate that monomorphizes
+//! `<FixedUInt<T, N, P> as const_num_traits::ToBytes>` (or `FromBytes`) must
+//! itself enable the feature — `#![feature(generic_const_exprs)]` — or the
+//! compiler cannot finish the associated type's well-formedness check and
+//! reports the unhelpful `error[E0275]: overflow evaluating whether [...] is
+//! well-formed`. With the feature enabled downstream it compiles and works.
+//! (This is why the `num_traits` impls live in `to_from_bytes.rs` instead —
+//! they avoid propagating a `generic_const_exprs` bound to callers.)
+//!
+//! The correct-usage doctest below (which, as a doctest, compiles as its own
+//! downstream crate) is the cross-crate coverage; `E0275` here shipped latent
+//! only because no cross-crate test previously monomorphized this path.
+//!
+//! ```
+//! # #![feature(generic_const_exprs)]
+//! # #![allow(incomplete_features)]
+//! use const_num_traits::{FromBytes, ToBytes};
+//! use fixed_bigint::FixedUInt;
+//!
+//! let n = FixedUInt::<u32, 4>::from(0x1234_5678u32);
+//! let be = <FixedUInt<u32, 4> as ToBytes>::to_be_bytes(n);
+//! assert_eq!(be.as_ref().len(), 16);
+//! assert_eq!(<FixedUInt<u32, 4> as FromBytes>::from_be_bytes(&be), n);
+//! ```
 
 use super::{FixedUInt, MachineWord, impl_from_be_bytes_slice, impl_from_le_bytes_slice};
 use crate::machineword::ConstMachineWord;

--- a/src/fixeduint/const_to_from_bytes.rs
+++ b/src/fixeduint/const_to_from_bytes.rs
@@ -30,9 +30,8 @@
 //! (This is why the `num_traits` impls live in `to_from_bytes.rs` instead —
 //! they avoid propagating a `generic_const_exprs` bound to callers.)
 //!
-//! The correct-usage doctest below (which, as a doctest, compiles as its own
-//! downstream crate) is the cross-crate coverage; `E0275` here shipped latent
-//! only because no cross-crate test previously monomorphized this path.
+//! The correct-usage doctest below (a doctest compiles as its own downstream
+//! crate) is the cross-crate coverage.
 //!
 //! ```
 //! # #![feature(generic_const_exprs)]

--- a/tests/const_tobytes_trait_roundtrip.rs
+++ b/tests/const_tobytes_trait_roundtrip.rs
@@ -1,0 +1,43 @@
+//! Cross-crate coverage for `FixedUInt`'s const `ToBytes`/`FromBytes`
+//! (the nightly `generic_const_exprs` path).
+//!
+//! This is a *downstream* crate, so it must enable `generic_const_exprs`
+//! itself — the associated-type bound is viral. Without the feature the
+//! compiler cannot finish the well-formedness check and emits a confusing
+//! `error[E0275]`. This file is the coverage that was missing: the impls'
+//! in-crate tests never exercised the cross-crate path, so the viral-feature
+//! requirement (and the misleading `E0275` when it's forgotten) shipped
+//! undocumented. See `src/fixeduint/const_to_from_bytes.rs`.
+#![cfg(feature = "nightly")]
+#![feature(generic_const_exprs)]
+#![allow(incomplete_features)]
+
+use const_num_traits::{FromBytes, ToBytes};
+use fixed_bigint::FixedUInt;
+
+#[test]
+fn cross_crate_roundtrip_u8() {
+    let n = FixedUInt::<u8, 4>::from(0x0403_0201u32);
+    let le = <FixedUInt<u8, 4> as ToBytes>::to_le_bytes(n);
+    assert_eq!(le.as_ref(), &[0x01, 0x02, 0x03, 0x04]);
+    let be = <FixedUInt<u8, 4> as ToBytes>::to_be_bytes(n);
+    assert_eq!(be.as_ref(), &[0x04, 0x03, 0x02, 0x01]);
+    assert_eq!(<FixedUInt<u8, 4> as FromBytes>::from_le_bytes(&le), n);
+    assert_eq!(<FixedUInt<u8, 4> as FromBytes>::from_be_bytes(&be), n);
+}
+
+#[test]
+fn cross_crate_roundtrip_u16() {
+    let n = FixedUInt::<u16, 4>::from(0x0403_0201u32);
+    let le = <FixedUInt<u16, 4> as ToBytes>::to_le_bytes(n);
+    assert_eq!(le.as_ref().len(), 8);
+    assert_eq!(<FixedUInt<u16, 4> as FromBytes>::from_le_bytes(&le), n);
+}
+
+#[test]
+fn cross_crate_roundtrip_u32() {
+    let n = FixedUInt::<u32, 4>::from(0x1234_5678u32);
+    let be = <FixedUInt<u32, 4> as ToBytes>::to_be_bytes(n);
+    assert_eq!(be.as_ref().len(), 16);
+    assert_eq!(<FixedUInt<u32, 4> as FromBytes>::from_be_bytes(&be), n);
+}

--- a/tests/const_tobytes_trait_roundtrip.rs
+++ b/tests/const_tobytes_trait_roundtrip.rs
@@ -1,16 +1,13 @@
 //! Cross-crate coverage for `FixedUInt`'s const `ToBytes`/`FromBytes`
-//! (the nightly `generic_const_exprs` path).
+//! (nightly `generic_const_exprs`).
 //!
-//! This is a *downstream* crate, so it must enable `generic_const_exprs`
-//! itself — the associated-type bound is viral. Without the feature the
-//! compiler cannot finish the well-formedness check and emits a confusing
-//! `error[E0275]`. This file is the coverage that was missing: the impls'
-//! in-crate tests never exercised the cross-crate path, so the viral-feature
-//! requirement (and the misleading `E0275` when it's forgotten) shipped
-//! undocumented. See `src/fixeduint/const_to_from_bytes.rs`.
+//! As a downstream crate it must enable `generic_const_exprs` itself — the
+//! associated-type bound is viral; without it the well-formedness check can't
+//! complete and rustc emits a confusing `error[E0275]`. See
+//! `src/fixeduint/const_to_from_bytes.rs`.
 #![cfg(feature = "nightly")]
-#![feature(generic_const_exprs)]
-#![allow(incomplete_features)]
+#![cfg_attr(feature = "nightly", feature(generic_const_exprs))]
+#![cfg_attr(feature = "nightly", allow(incomplete_features))]
 
 use const_num_traits::{FromBytes, ToBytes};
 use fixed_bigint::FixedUInt;
@@ -30,14 +27,26 @@ fn cross_crate_roundtrip_u8() {
 fn cross_crate_roundtrip_u16() {
     let n = FixedUInt::<u16, 4>::from(0x0403_0201u32);
     let le = <FixedUInt<u16, 4> as ToBytes>::to_le_bytes(n);
-    assert_eq!(le.as_ref().len(), 8);
+    assert_eq!(le.as_ref(), &[0x01, 0x02, 0x03, 0x04, 0, 0, 0, 0]);
+    let be = <FixedUInt<u16, 4> as ToBytes>::to_be_bytes(n);
+    assert_eq!(be.as_ref(), &[0, 0, 0, 0, 0x04, 0x03, 0x02, 0x01]);
     assert_eq!(<FixedUInt<u16, 4> as FromBytes>::from_le_bytes(&le), n);
+    assert_eq!(<FixedUInt<u16, 4> as FromBytes>::from_be_bytes(&be), n);
 }
 
 #[test]
 fn cross_crate_roundtrip_u32() {
     let n = FixedUInt::<u32, 4>::from(0x1234_5678u32);
+    let mut le_expected = [0u8; 16];
+    le_expected[..4].copy_from_slice(&[0x78, 0x56, 0x34, 0x12]);
+    let le = <FixedUInt<u32, 4> as ToBytes>::to_le_bytes(n);
+    assert_eq!(le.as_ref(), &le_expected);
+
+    let mut be_expected = [0u8; 16];
+    be_expected[12..].copy_from_slice(&[0x12, 0x34, 0x56, 0x78]);
     let be = <FixedUInt<u32, 4> as ToBytes>::to_be_bytes(n);
-    assert_eq!(be.as_ref().len(), 16);
+    assert_eq!(be.as_ref(), &be_expected);
+
+    assert_eq!(<FixedUInt<u32, 4> as FromBytes>::from_le_bytes(&le), n);
     assert_eq!(<FixedUInt<u32, 4> as FromBytes>::from_be_bytes(&be), n);
 }


### PR DESCRIPTION
## What this is

The `E0275: overflow evaluating whether […] is well-formed` that a downstream
crate hits when it uses `<FixedUInt<..> as const_num_traits::ToBytes>` on
nightly is **not a compiler cycle in this crate's impl** — it's the viral
`generic_const_exprs` bound. The associated `Bytes` type is sized with
`where [(); byte_len::<T, N>()]:`, and a downstream crate that monomorphizes
the trait must itself enable `#![feature(generic_const_exprs)]`. Without it,
rustc can't finish the associated type's well-formedness check and reports the
misleading `E0275`. **With** the feature it compiles and round-trips correctly.

## Why it shipped latent

Every existing test monomorphizes this path only in-crate, where
`generic_const_exprs` is already enabled — so the requirement (and the
confusing error when a downstream forgets it) was never surfaced. The
diagnostic hunt that produced this PR spent a long time treating the `E0275`
as a cross-crate solver cycle; it reproduced in an integration test that
lacked the feature and *not* in doctests / minimal repros that had it — which
is exactly the tell.

## Change

- **No impl logic change**; const-callability is unchanged.
- Module "Downstream usage" note documenting the viral-feature requirement,
  with a **passing doctest** — a doctest compiles as its own downstream crate,
  so it is itself the cross-crate demonstration.
- `tests/const_tobytes_trait_roundtrip.rs` — cross-crate round-trip coverage
  (u8/u16/u32) with the feature enabled; inert on stable via the `nightly`
  cfg gate.

Verified: nightly `--features nightly` — in-crate 10, cross-crate 3, doctest 1,
all pass; stable — cfg-gated inert, lib builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for downstream use of const byte conversions, including required feature configuration.
  * Added an example demonstrating big-endian byte conversion and round-trip reconstruction.

* **Tests**
  * Added cross-crate coverage for little- and big-endian conversions across multiple integer element sizes.
  * Verified encoded byte sequences, buffer lengths, and successful value round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->