### PR TITLE
Reword "load-bearing" black_box comments

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -249,7 +249,7 @@ impl<T: MachineWord, const N: usize> FixedUInt<T, N, Ct> {
         for _ in 0..u32::BITS {
             // `black_box` opacifies the per-iteration bit so LLVM can't
             // recognize the XOR-select as a cmov-on-secret-flag — see
-            // `const_ct_select` for the load-bearing explanation.
+            // `const_ct_select` for the full explanation.
             let bit = core::hint::black_box((e & 1) as u8);
             let (candidate, mul_ov) = <Self as OverflowingMul>::overflowing_mul(result, base);
             // Multiply overflow matters iff bit_k is set.
@@ -884,8 +884,8 @@ c0nst::c0nst! {
             let mut shifted = *target;
             const_shl_impl(&mut shifted, amount);
             // Spread bit k of `bits` to a full-T mask: 0 if cleared, T::MAX if set.
-            // `black_box` is load-bearing — see `const_ct_select` for the
-            // address-select rewrite it defeats.
+            // `black_box` defeats the address-select rewrite here — see
+            // `const_ct_select` for the full explanation.
             let bit_k = core::hint::black_box(((bits >> k) & 1) as u8);
             let bit_k_t = <T as core::convert::From<u8>>::from(bit_k);
             let mask = <T as core::ops::Mul>::mul(bit_k_t, <T as Bounded>::max_value());
@@ -1055,7 +1055,7 @@ c0nst::c0nst! {
             let v_lz = <T as PrimBits>::leading_zeros(v);
             // Add this limb's lz contribution iff we haven't decided yet.
             // `black_box` defeats the LLVM XOR/AND-select → cmov rewrite —
-            // see `const_ct_select` for the load-bearing explanation.
+            // see `const_ct_select` for the full explanation.
             let undecided = core::hint::black_box(!decided);
             total += undecided & v_lz;
             // Lock the decision the moment we see a non-zero limb.
@@ -1632,8 +1632,8 @@ c0nst::c0nst! {
     /// Branchless per-limb select: returns `if_zero` when `choice == 0`,
     /// `if_one` when `choice == 1`.
     ///
-    /// The `black_box` on `choice` is load-bearing. Without it, LLVM
-    /// recognizes the algebraic identity `a ^ (mask & (a ^ b))` ==
+    /// The `black_box` on `choice` is required for correctness. Without it,
+    /// LLVM recognizes the algebraic identity `a ^ (mask & (a ^ b))` ==
     /// `if mask == 0 { a } else { b }` and rewrites the loop into a
     /// `csel` of the source ADDRESS followed by a load — a secret-
     /// dependent memory access that the asm-grep gate can't see but

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -1632,8 +1632,9 @@ c0nst::c0nst! {
     /// Branchless per-limb select: returns `if_zero` when `choice == 0`,
     /// `if_one` when `choice == 1`.
     ///
-    /// The `black_box` on `choice` is required for correctness. Without it,
-    /// LLVM recognizes the algebraic identity `a ^ (mask & (a ^ b))` ==
+    /// The `black_box` on `choice` is required to keep this select
+    /// constant-time. Without it, LLVM recognizes the algebraic identity
+    /// `a ^ (mask & (a ^ b))` ==
     /// `if mask == 0 { a } else { b }` and rewrites the loop into a
     /// `csel` of the source ADDRESS followed by a load — a secret-
     /// dependent memory access that the asm-grep gate can't see but

--- a/src/fixeduint/bit_ops_impl.rs
+++ b/src/fixeduint/bit_ops_impl.rs
@@ -387,7 +387,7 @@ c0nst::c0nst! {
 
     /// Branchless CT-safe `min(bits, cap)` for u32, used to clamp Ct
     /// shift amounts to `BIT_SIZE` before casting to usize. The
-    /// `black_box` on the mask is load-bearing — without it, LLVM
+    /// `black_box` on the mask is required — without it, LLVM
     /// recognises the XOR-AND-XOR select idiom and rewrites it into a
     /// `cmov` whose flag depends on the secret `bits`. Same defence as
     /// `const_ct_select` (PR #118).


### PR DESCRIPTION
Comment-only pass. The five CT `black_box` sites described themselves as "load-bearing"; reword each to state what the barrier actually does — it blocks LLVM from proving the XOR-select algebraic identity and lowering it to a secret-dependent `cmov`/address-select. The three cross-references now point to `const_ct_select` for "the full explanation".

No behavior change.

Split out of the #138 tidy pass as agreed; the heapless-feature clippy cleanup follows once #138 lands.

## Summary by Sourcery

Enhancements:
- Update `black_box`-related documentation comments to describe the specific LLVM optimization they block and point to `const_ct_select` for the full explanation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation for constant-time arithmetic and bit-operation implementations.
  * Updated comments describing masking, selection, exponentiation, leading-zero calculations, and minimum-value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->