### PR TITLE
Add HeaplessBigInt operator parity (assign ops, BitXor, CheckedSub)

### DIFF
--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -15,9 +15,9 @@
 use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
-    BorrowingSub, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, Nct, OverflowingAdd,
-    OverflowingMul, OverflowingSub, Personality, PersonalityTag, WrappingAdd, WrappingMul,
-    WrappingSub,
+    BorrowingSub, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, CheckedSub, Nct,
+    OverflowingAdd, OverflowingMul, OverflowingSub, Personality, PersonalityTag, WrappingAdd,
+    WrappingMul, WrappingSub,
 };
 use core::marker::PhantomData;
 
@@ -251,6 +251,16 @@ where
     }
 }
 
+impl<T, const CAP: usize> CheckedSub for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = Self;
+    fn checked_sub(self, v: Self) -> Option<Self> {
+        Self::checked_sub(&self, &v)
+    }
+}
+
 // Trim trailing-zero limbs — NCT-implicit content scan sets `len` to
 // `1 + index of highest non-zero limb` (or 0 for the mathematical zero).
 // Called only from Nct code paths; exposed as a public method on the
@@ -407,6 +417,62 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     type Output = HeaplessBigInt<T, CAP, P>;
     fn mul(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
         self.mul(&other)
+    }
+}
+
+// ── Compound-assign forms (delegate to the operator, same panic/wrap rule) ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::AddAssign
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn add_assign(&mut self, other: Self) {
+        self.add_assign(&other);
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality>
+    core::ops::AddAssign<&HeaplessBigInt<T, CAP, P>> for HeaplessBigInt<T, CAP, P>
+{
+    fn add_assign(&mut self, other: &Self) {
+        let (res, overflow) = OverflowingAdd::overflowing_add(*self, *other);
+        panic_on_overflow_if_nct::<P>(overflow, "HeaplessBigInt::add overflow");
+        *self = res;
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> core::ops::SubAssign
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn sub_assign(&mut self, other: Self) {
+        self.sub_assign(&other);
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality>
+    core::ops::SubAssign<&HeaplessBigInt<T, CAP, P>> for HeaplessBigInt<T, CAP, P>
+{
+    fn sub_assign(&mut self, other: &Self) {
+        let (res, borrow) = OverflowingSub::overflowing_sub(*self, *other);
+        panic_on_overflow_if_nct::<P>(borrow, "HeaplessBigInt::sub underflow");
+        *self = res;
+    }
+}
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
+    core::ops::MulAssign for HeaplessBigInt<T, CAP, P>
+{
+    fn mul_assign(&mut self, other: Self) {
+        self.mul_assign(&other);
+    }
+}
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
+    core::ops::MulAssign<&HeaplessBigInt<T, CAP, P>> for HeaplessBigInt<T, CAP, P>
+{
+    fn mul_assign(&mut self, other: &Self) {
+        let (res, overflow) = OverflowingMul::overflowing_mul(*self, *other);
+        panic_on_overflow_if_nct::<P>(overflow, "HeaplessBigInt::mul overflow");
+        *self = res;
     }
 }
 

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -434,9 +434,11 @@ impl<T: MachineWord, const CAP: usize, P: Personality>
     core::ops::AddAssign<&HeaplessBigInt<T, CAP, P>> for HeaplessBigInt<T, CAP, P>
 {
     fn add_assign(&mut self, other: &Self) {
-        let (res, overflow) = OverflowingAdd::overflowing_add(*self, *other);
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        let overflow = add_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
         panic_on_overflow_if_nct::<P>(overflow, "HeaplessBigInt::add overflow");
-        *self = res;
+        *self = out;
     }
 }
 
@@ -452,9 +454,11 @@ impl<T: MachineWord, const CAP: usize, P: Personality>
     core::ops::SubAssign<&HeaplessBigInt<T, CAP, P>> for HeaplessBigInt<T, CAP, P>
 {
     fn sub_assign(&mut self, other: &Self) {
-        let (res, borrow) = OverflowingSub::overflowing_sub(*self, *other);
+        let out_len = core::cmp::max(self.len as usize, other.len as usize);
+        let mut out = Self::new_zero_with_len(out_len as u16);
+        let borrow = sub_slice(&self.limbs, &other.limbs, &mut out.limbs, out_len);
         panic_on_overflow_if_nct::<P>(borrow, "HeaplessBigInt::sub underflow");
-        *self = res;
+        *self = out;
     }
 }
 
@@ -470,9 +474,13 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     core::ops::MulAssign<&HeaplessBigInt<T, CAP, P>> for HeaplessBigInt<T, CAP, P>
 {
     fn mul_assign(&mut self, other: &Self) {
-        let (res, overflow) = OverflowingMul::overflowing_mul(*self, *other);
+        // Mirrors `overflowing_mul`: `carrying_mul` takes `Self` by value, so
+        // this one copy is inherent to the primitive (same as the operator).
+        let zero_v = <Self as const_num_traits::Zero>::zero();
+        let (lo, hi) = <Self as CarryingMul>::carrying_mul(*self, *other, zero_v);
+        let overflow = !<Self as const_num_traits::Zero>::is_zero(&hi);
         panic_on_overflow_if_nct::<P>(overflow, "HeaplessBigInt::mul overflow");
-        *self = res;
+        *self = lo;
     }
 }
 

--- a/src/heapless/bitwise.rs
+++ b/src/heapless/bitwise.rs
@@ -26,11 +26,14 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd<&HeaplessBigInt<T,
     type Output = HeaplessBigInt<T, CAP, P>;
     fn bitand(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
         let out_len = core::cmp::min(self.len, other.len);
+        let n = out_len as usize;
         let mut limbs = [zero::<T>(); CAP];
-        let mut i = 0;
-        while i < out_len as usize {
-            limbs[i] = self.limbs[i] & other.limbs[i];
-            i += 1;
+        for ((&ai, &bi), oi) in self.limbs[..n]
+            .iter()
+            .zip(&other.limbs[..n])
+            .zip(&mut limbs[..n])
+        {
+            *oi = ai & bi;
         }
         HeaplessBigInt {
             limbs,
@@ -72,11 +75,14 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitOr<&HeaplessBigInt<T, 
     type Output = HeaplessBigInt<T, CAP, P>;
     fn bitor(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
         let out_len = core::cmp::max(self.len, other.len);
+        let n = out_len as usize;
         let mut limbs = [zero::<T>(); CAP];
-        let mut i = 0;
-        while i < out_len as usize {
-            limbs[i] = self.limbs[i] | other.limbs[i];
-            i += 1;
+        for ((&ai, &bi), oi) in self.limbs[..n]
+            .iter()
+            .zip(&other.limbs[..n])
+            .zip(&mut limbs[..n])
+        {
+            *oi = ai | bi;
         }
         HeaplessBigInt {
             limbs,
@@ -118,11 +124,14 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitXor<&HeaplessBigInt<T,
     type Output = HeaplessBigInt<T, CAP, P>;
     fn bitxor(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
         let out_len = core::cmp::max(self.len, other.len);
+        let n = out_len as usize;
         let mut limbs = [zero::<T>(); CAP];
-        let mut i = 0;
-        while i < out_len as usize {
-            limbs[i] = self.limbs[i] ^ other.limbs[i];
-            i += 1;
+        for ((&ai, &bi), oi) in self.limbs[..n]
+            .iter()
+            .zip(&other.limbs[..n])
+            .zip(&mut limbs[..n])
+        {
+            *oi = ai ^ bi;
         }
         HeaplessBigInt {
             limbs,
@@ -157,11 +166,11 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitXor<HeaplessBigInt<T, 
     }
 }
 
-// ── Compound-assign forms (delegate to the binary op) ──
+// ── Compound-assign forms (in-place on `self.limbs`) ──
 
 impl<T: MachineWord, const CAP: usize, P: Personality> BitAndAssign for HeaplessBigInt<T, CAP, P> {
     fn bitand_assign(&mut self, other: Self) {
-        *self = (&*self).bitand(&other);
+        self.bitand_assign(&other);
     }
 }
 
@@ -169,13 +178,26 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitAndAssign<&HeaplessBig
     for HeaplessBigInt<T, CAP, P>
 {
     fn bitand_assign(&mut self, other: &Self) {
-        *self = (&*self).bitand(other);
+        // Result width is `min(len)`: AND the overlap, then clear `self`'s
+        // limbs above `min` (they AND with `other`'s zero-tail = 0).
+        let min_len = core::cmp::min(self.len, other.len) as usize;
+        let self_len = self.len as usize;
+        for (si, &oi) in self.limbs[..min_len]
+            .iter_mut()
+            .zip(&other.limbs[..min_len])
+        {
+            *si &= oi;
+        }
+        for si in &mut self.limbs[min_len..self_len] {
+            *si = zero::<T>();
+        }
+        self.len = min_len as u16;
     }
 }
 
 impl<T: MachineWord, const CAP: usize, P: Personality> BitOrAssign for HeaplessBigInt<T, CAP, P> {
     fn bitor_assign(&mut self, other: Self) {
-        *self = (&*self).bitor(&other);
+        self.bitor_assign(&other);
     }
 }
 
@@ -183,13 +205,30 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitOrAssign<&HeaplessBigI
     for HeaplessBigInt<T, CAP, P>
 {
     fn bitor_assign(&mut self, other: &Self) {
-        *self = (&*self).bitor(other);
+        // Result width is `max(len)`: OR the overlap, then copy `other`'s
+        // high limbs (they OR with `self`'s zero-tail = `other`). The copy
+        // range is empty when `self` is the wider operand.
+        let self_len = self.len as usize;
+        let max_len = core::cmp::max(self_len, other.len as usize);
+        for (si, &oi) in self.limbs[..self_len]
+            .iter_mut()
+            .zip(&other.limbs[..self_len])
+        {
+            *si |= oi;
+        }
+        for (si, &oi) in self.limbs[self_len..max_len]
+            .iter_mut()
+            .zip(&other.limbs[self_len..max_len])
+        {
+            *si = oi;
+        }
+        self.len = max_len as u16;
     }
 }
 
 impl<T: MachineWord, const CAP: usize, P: Personality> BitXorAssign for HeaplessBigInt<T, CAP, P> {
     fn bitxor_assign(&mut self, other: Self) {
-        *self = (&*self).bitxor(&other);
+        self.bitxor_assign(&other);
     }
 }
 
@@ -197,6 +236,23 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitXorAssign<&HeaplessBig
     for HeaplessBigInt<T, CAP, P>
 {
     fn bitxor_assign(&mut self, other: &Self) {
-        *self = (&*self).bitxor(other);
+        // Result width is `max(len)`: XOR the overlap, then copy `other`'s
+        // high limbs (they XOR with `self`'s zero-tail = `other`). The copy
+        // range is empty when `self` is the wider operand.
+        let self_len = self.len as usize;
+        let max_len = core::cmp::max(self_len, other.len as usize);
+        for (si, &oi) in self.limbs[..self_len]
+            .iter_mut()
+            .zip(&other.limbs[..self_len])
+        {
+            *si ^= oi;
+        }
+        for (si, &oi) in self.limbs[self_len..max_len]
+            .iter_mut()
+            .zip(&other.limbs[self_len..max_len])
+        {
+            *si = oi;
+        }
+        self.len = max_len as u16;
     }
 }

--- a/src/heapless/bitwise.rs
+++ b/src/heapless/bitwise.rs
@@ -1,23 +1,23 @@
-//! `BitAnd` / `BitOr` for `HeaplessBigInt` (all four receiver forms each).
+//! `BitAnd` / `BitOr` / `BitXor` for `HeaplessBigInt` (all four receiver
+//! forms each), plus the compound-assign forms.
 //!
 //! Limb-wise, width-based, `CAP` never enters:
 //! - `BitAnd` → `len = min(a.len, b.len)`: at or above that bound one
 //!   operand is in its zero-tail, so the AND is zero — `min` is
 //!   value-tight and satisfies the zero-tail invariant.
-//! - `BitOr` → `len = max(a.len, b.len)`: OR *sets* bits, so the result
-//!   spans the wider operand; the shorter operand's zero-tail leaves the
-//!   wider operand's limbs unchanged there.
+//! - `BitOr` / `BitXor` → `len = max(a.len, b.len)`: they leave a bit set
+//!   wherever exactly one operand has it, so the result spans the wider
+//!   operand; the shorter operand's zero-tail leaves the wider operand's
+//!   limbs unchanged there.
 //!
 //! Both lens are public shape parameters, so the body is identical for
-//! Nct and Ct. `BitAnd` serves Montgomery's `from_montgomery` mask;
-//! `BitOr` serves the sign path's blinding-inverse (`InvertCt`).
-//! `BitXor` is omitted — no consumer needs it.
+//! Nct and Ct. The compound-assign forms delegate to the binary op.
 
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
 use const_num_traits::Personality;
 use core::marker::PhantomData;
-use core::ops::{BitAnd, BitOr};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
 
 // Core: `&Self & &Self`. The value + mixed receiver forms delegate here.
 impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd<&HeaplessBigInt<T, CAP, P>>
@@ -108,5 +108,95 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitOr<HeaplessBigInt<T, C
     type Output = HeaplessBigInt<T, CAP, P>;
     fn bitor(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
         self.bitor(&other)
+    }
+}
+
+// Core: `&Self ^ &Self`. The value + mixed receiver forms delegate here.
+impl<T: MachineWord, const CAP: usize, P: Personality> BitXor<&HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn bitxor(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        let out_len = core::cmp::max(self.len, other.len);
+        let mut limbs = [zero::<T>(); CAP];
+        let mut i = 0;
+        while i < out_len as usize {
+            limbs[i] = self.limbs[i] ^ other.limbs[i];
+            i += 1;
+        }
+        HeaplessBigInt {
+            limbs,
+            len: out_len,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitXor for HeaplessBigInt<T, CAP, P> {
+    type Output = Self;
+    fn bitxor(self, other: Self) -> Self {
+        (&self).bitxor(&other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitXor<&HeaplessBigInt<T, CAP, P>>
+    for HeaplessBigInt<T, CAP, P>
+{
+    type Output = Self;
+    fn bitxor(self, other: &Self) -> Self {
+        (&self).bitxor(other)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitXor<HeaplessBigInt<T, CAP, P>>
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn bitxor(self, other: HeaplessBigInt<T, CAP, P>) -> Self::Output {
+        self.bitxor(&other)
+    }
+}
+
+// ── Compound-assign forms (delegate to the binary op) ──
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitAndAssign for HeaplessBigInt<T, CAP, P> {
+    fn bitand_assign(&mut self, other: Self) {
+        *self = (&*self).bitand(&other);
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitAndAssign<&HeaplessBigInt<T, CAP, P>>
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn bitand_assign(&mut self, other: &Self) {
+        *self = (&*self).bitand(other);
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitOrAssign for HeaplessBigInt<T, CAP, P> {
+    fn bitor_assign(&mut self, other: Self) {
+        *self = (&*self).bitor(&other);
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitOrAssign<&HeaplessBigInt<T, CAP, P>>
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn bitor_assign(&mut self, other: &Self) {
+        *self = (&*self).bitor(other);
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitXorAssign for HeaplessBigInt<T, CAP, P> {
+    fn bitxor_assign(&mut self, other: Self) {
+        *self = (&*self).bitxor(&other);
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> BitXorAssign<&HeaplessBigInt<T, CAP, P>>
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn bitxor_assign(&mut self, other: &Self) {
+        *self = (&*self).bitxor(other);
     }
 }

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1736,3 +1736,51 @@ fn ct_magnitude_and_reference_bit_width() {
     let z = <HeaplessBigInt<u32, 4, Ct> as Zero>::zero();
     assert!(!<HeaplessBigInt<u32, 4, Ct> as One>::is_one(&z));
 }
+
+// ── Parity ops added to match FixedUInt's surface ──
+
+#[test]
+fn arith_assign_ops_match_binary() {
+    let mut x: H4u32Nct = 100u32.into();
+    x += H4u32Nct::from(50u32);
+    assert_eq!(x, 150u32.into());
+    x -= &H4u32Nct::from(30u32);
+    assert_eq!(x, 120u32.into());
+    x *= H4u32Nct::from(2u32);
+    assert_eq!(x, 240u32.into());
+    let mut y: H4u32Nct = 7u32.into();
+    y *= &H4u32Nct::from(3u32);
+    assert_eq!(y, 21u32.into());
+}
+
+#[test]
+fn bitxor_and_bitwise_assign_ops() {
+    let a = H4u32Nct::from(0xF0F0_F0F0u32);
+    let b = H4u32Nct::from(0x00FF_00FFu32);
+    assert_eq!(a ^ b, 0xF00F_F00Fu32.into());
+    assert_eq!(&a ^ &b, 0xF00F_F00Fu32.into());
+    assert_eq!(a ^ &b, 0xF00F_F00Fu32.into());
+    assert!(<H4u32Nct as Zero>::is_zero(&(a ^ a)));
+
+    let mut x = a;
+    x ^= b;
+    assert_eq!(x, 0xF00F_F00Fu32.into());
+    let mut y = a;
+    y &= &b;
+    assert_eq!(y, 0x00F0_00F0u32.into());
+    let mut z = a;
+    z |= b;
+    assert_eq!(z, 0xF0FF_F0FFu32.into());
+}
+
+#[test]
+fn checked_sub_trait_matches_inherent() {
+    use const_num_traits::CheckedSub;
+    let a = H4u32Nct::from(100u32);
+    let b = H4u32Nct::from(40u32);
+    assert_eq!(CheckedSub::checked_sub(a, b), Some(60u32.into()));
+    // Underflow at width 1 → None, like FixedUInt<u32, 1>.
+    let one = H4u32Nct::from(1u32);
+    let two = H4u32Nct::from(2u32);
+    assert_eq!(CheckedSub::checked_sub(one, two), None);
+}

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1784,3 +1784,44 @@ fn checked_sub_trait_matches_inherent() {
     let two = H4u32Nct::from(2u32);
     assert_eq!(CheckedSub::checked_sub(one, two), None);
 }
+
+#[test]
+fn bitwise_assign_ops_cross_width() {
+    // The in-place assigns must reshape `len` like the binary ops:
+    // `&=` shrinks to min, `|=`/`^=` grow to max.
+    let wide = H4u32Nct::from_limbs([0xFFFF_FFFF, 0xFFFF_FFFF, 0, 0], 2);
+    let narrow = H4u32Nct::from_limbs([0x0F0F_0F0F, 0, 0, 0], 1);
+
+    let mut a = wide;
+    a &= narrow;
+    assert_eq!(a.len(), 1);
+    assert_eq!(a.limbs()[0], 0x0F0F_0F0F);
+
+    let mut b = narrow;
+    b |= wide;
+    assert_eq!(b.len(), 2);
+    assert_eq!(b.limbs()[0], 0xFFFF_FFFF);
+    assert_eq!(b.limbs()[1], 0xFFFF_FFFF);
+
+    let mut c = narrow;
+    c ^= wide;
+    assert_eq!(c.len(), 2);
+    assert_eq!(c.limbs()[0], 0xF0F0_F0F0);
+    assert_eq!(c.limbs()[1], 0xFFFF_FFFF);
+
+    // Each assign matches the corresponding binary op exactly.
+    assert_eq!(a, wide & narrow);
+    assert_eq!(b, narrow | wide);
+    assert_eq!(c, narrow ^ wide);
+
+    // The other direction (self wider than other) must not index a
+    // start-past-end range.
+    let mut d = wide;
+    d |= narrow;
+    assert_eq!(d, wide | narrow);
+    assert_eq!(d.len(), 2);
+    let mut e = wide;
+    e ^= narrow;
+    assert_eq!(e, wide ^ narrow);
+    assert_eq!(e.len(), 2);
+}


### PR DESCRIPTION
Closes the operator-surface gaps between `HeaplessBigInt` and the same-width `FixedUInt`, surfaced while unifying the two test suites into generic-over-carrier form.

**Added:**
- `AddAssign` / `SubAssign` / `MulAssign` (owned + ref) — delegate to the overflowing op + the same Nct-panic / Ct-wrap rule the `+`/`-`/`*` operators use.
- `BitXor` (all four receiver forms, `len = max` like `BitOr`) + the bitwise compound-assigns `BitAndAssign` / `BitOrAssign` / `BitXorAssign`.
- `CheckedSub` (Nct-only, mirroring `CheckedAdd`/`CheckedMul`), completing the checked add/sub/mul trio.

**Intentionally absent:** `Bounded` and `ToPrimitive` have no single-width meaning for a runtime-len carrier; `Saturating*` deferred.

These unblock rewriting the FixedUInt-only `num_assign`/`bit_ops` test bodies as generic bodies run for both carriers (the follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-place compound assignment support for heapless big integers: `+=`, `-=`, and `*=`.
  * Added bitwise XOR (`^`) plus `^=` along with compound bitwise assignment for `&=` and `|=`.
  * Added standard checked subtraction support (`checked_sub`) for detecting underflow.
  * Arithmetic assignments now enforce consistent overflow/underflow behavior.
* **Tests**
  * Added regression coverage for arithmetic and bitwise operators (including owned and reference forms), compound assignments, and `checked_sub` underflow/valid cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->