### PR TITLE
Generic-over-carrier test suite for shared FixedUInt/HeaplessBigInt behavior

### DIFF
--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -1,0 +1,293 @@
+//! Behavior shared by every carrier — written once as a generic body and run
+//! for both `FixedUInt` and `HeaplessBigInt`.
+//!
+//! Both carriers here are pinned to the same 32-bit width (`u8 × 4`) so the
+//! overflow / carry / wrap boundaries line up: `FixedUInt<u8, 4>` is 32-bit by
+//! construction, and `HeaplessBigInt<u8, 4>` is built from four bytes and
+//! `widened` to len 4 (its `From<small>` would otherwise be minimal-width).
+//!
+//! Tests that reach into a carrier's internals (limbs / len / CAP, personality,
+//! the runtime-length width vocabulary) live in each carrier's own suite; this
+//! file is only the surface both share.
+
+#![cfg(feature = "num-traits")]
+
+use const_num_traits::{
+    CarryingMul, CheckedAdd, CheckedMul, CheckedSub, FromByteSlice, Nct, OverflowingAdd,
+    OverflowingMul, OverflowingSub, Parity, WrappingAdd, WrappingMul, WrappingSub, Zero,
+};
+use core::ops::{
+    Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
+    Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
+};
+use fixed_bigint::{FixedUInt, HeaplessBigInt};
+
+/// The 32-bit unsigned surface both carriers implement. `from_u32` pins the
+/// value to the carrier's full 32-bit width so overflow behavior matches.
+trait Carrier:
+    Copy
+    + core::fmt::Debug
+    + PartialEq
+    + PartialOrd
+    + Zero
+    + Parity
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + Rem<Output = Self>
+    + BitAnd<Output = Self>
+    + BitOr<Output = Self>
+    + BitXor<Output = Self>
+    + Shl<usize, Output = Self>
+    + Shr<usize, Output = Self>
+    + AddAssign
+    + SubAssign
+    + MulAssign
+    + DivAssign
+    + RemAssign
+    + BitAndAssign
+    + BitOrAssign
+    + BitXorAssign
+    + ShlAssign<usize>
+    + ShrAssign<usize>
+    + WrappingAdd<Output = Self>
+    + WrappingSub<Output = Self>
+    + WrappingMul<Output = Self>
+    + OverflowingAdd<Output = Self>
+    + OverflowingSub<Output = Self>
+    + OverflowingMul<Output = Self>
+    + CheckedAdd<Output = Self>
+    + CheckedSub<Output = Self>
+    + CheckedMul<Output = Self>
+    + CarryingMul<Unsigned = Self, Output = Self>
+{
+    fn from_u32(v: u32) -> Self;
+}
+
+macro_rules! impl_carrier {
+    ($t:ty, $n:expr) => {
+        impl Carrier for FixedUInt<$t, $n, Nct> {
+            fn from_u32(v: u32) -> Self {
+                FromByteSlice::from_le_slice(&v.to_le_bytes()).unwrap()
+            }
+        }
+        impl Carrier for HeaplessBigInt<$t, $n, Nct> {
+            fn from_u32(v: u32) -> Self {
+                HeaplessBigInt::from_le_bytes(&v.to_le_bytes()).widened($n)
+            }
+        }
+    };
+}
+
+// Three backings of the same 32-bit width; each runs on both carriers.
+impl_carrier!(u8, 4);
+impl_carrier!(u16, 2);
+impl_carrier!(u32, 1);
+
+/// Run a generic body for both carriers across all three backings.
+macro_rules! for_both_carriers {
+    ($body:ident) => {{
+        $body::<FixedUInt<u8, 4, Nct>>();
+        $body::<HeaplessBigInt<u8, 4, Nct>>();
+        $body::<FixedUInt<u16, 2, Nct>>();
+        $body::<HeaplessBigInt<u16, 2, Nct>>();
+        $body::<FixedUInt<u32, 1, Nct>>();
+        $body::<HeaplessBigInt<u32, 1, Nct>>();
+    }};
+}
+
+const MAX32: u32 = u32::MAX;
+
+#[test]
+fn add() {
+    fn body<C: Carrier>() {
+        let a = C::from_u32(100);
+        let b = C::from_u32(50);
+        assert_eq!(a + b, C::from_u32(150));
+        assert_eq!(WrappingAdd::wrapping_add(a, b), C::from_u32(150));
+        assert_eq!(
+            OverflowingAdd::overflowing_add(a, b),
+            (C::from_u32(150), false)
+        );
+        assert_eq!(CheckedAdd::checked_add(a, b), Some(C::from_u32(150)));
+        let mut m = a;
+        m += b;
+        assert_eq!(m, C::from_u32(150));
+
+        // Overflow at the shared 32-bit width.
+        let max = C::from_u32(MAX32);
+        let one = C::from_u32(1);
+        assert_eq!(WrappingAdd::wrapping_add(max, one), C::from_u32(0));
+        assert_eq!(
+            OverflowingAdd::overflowing_add(max, one),
+            (C::from_u32(0), true)
+        );
+        assert_eq!(CheckedAdd::checked_add(max, one), None);
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn sub() {
+    fn body<C: Carrier>() {
+        let a = C::from_u32(500);
+        let b = C::from_u32(200);
+        assert_eq!(a - b, C::from_u32(300));
+        assert_eq!(WrappingSub::wrapping_sub(a, b), C::from_u32(300));
+        assert_eq!(
+            OverflowingSub::overflowing_sub(a, b),
+            (C::from_u32(300), false)
+        );
+        assert_eq!(CheckedSub::checked_sub(a, b), Some(C::from_u32(300)));
+        let mut m = a;
+        m -= b;
+        assert_eq!(m, C::from_u32(300));
+
+        // Underflow wraps at 32 bits and reports a borrow.
+        let one = C::from_u32(1);
+        let two = C::from_u32(2);
+        assert_eq!(WrappingSub::wrapping_sub(one, two), C::from_u32(MAX32));
+        assert_eq!(
+            OverflowingSub::overflowing_sub(one, two),
+            (C::from_u32(MAX32), true)
+        );
+        assert_eq!(CheckedSub::checked_sub(one, two), None);
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn mul() {
+    fn body<C: Carrier>() {
+        let a = C::from_u32(13);
+        let b = C::from_u32(17);
+        assert_eq!(a * b, C::from_u32(221));
+        assert_eq!(WrappingMul::wrapping_mul(a, b), C::from_u32(221));
+        assert_eq!(CheckedMul::checked_mul(a, b), Some(C::from_u32(221)));
+        let mut m = a;
+        m *= b;
+        assert_eq!(m, C::from_u32(221));
+
+        // 0x10000 * 0x10000 = 2^32 overflows 32 bits.
+        let x = C::from_u32(0x1_0000);
+        assert_eq!(WrappingMul::wrapping_mul(x, x), C::from_u32(0));
+        assert_eq!(
+            OverflowingMul::overflowing_mul(x, x),
+            (C::from_u32(0), true)
+        );
+        assert_eq!(CheckedMul::checked_mul(x, x), None);
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn carrying_mul_high_half() {
+    fn body<C: Carrier>() {
+        // 0x10000 * 0x10000 = 2^32: low half 0, high half 1.
+        let x = C::from_u32(0x1_0000);
+        let (lo, hi) = CarryingMul::carrying_mul(x, x, C::from_u32(0));
+        assert_eq!(lo, C::from_u32(0));
+        assert_eq!(hi, C::from_u32(1));
+        // No overflow: 5 * 7 + 3 = 38, high half 0.
+        let (lo, hi) = CarryingMul::carrying_mul(C::from_u32(5), C::from_u32(7), C::from_u32(3));
+        assert_eq!(lo, C::from_u32(38));
+        assert_eq!(hi, C::from_u32(0));
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn bitwise() {
+    fn body<C: Carrier>() {
+        let a = C::from_u32(0xF0F0_F0F0);
+        let b = C::from_u32(0x00FF_00FF);
+        assert_eq!(a & b, C::from_u32(0x00F0_00F0));
+        assert_eq!(a | b, C::from_u32(0xF0FF_F0FF));
+        assert_eq!(a ^ b, C::from_u32(0xF00F_F00F));
+        assert!(Zero::is_zero(&(a ^ a)));
+
+        let mut x = a;
+        x &= b;
+        assert_eq!(x, C::from_u32(0x00F0_00F0));
+        let mut y = a;
+        y |= b;
+        assert_eq!(y, C::from_u32(0xF0FF_F0FF));
+        let mut z = a;
+        z ^= b;
+        assert_eq!(z, C::from_u32(0xF00F_F00F));
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn shifts() {
+    fn body<C: Carrier>() {
+        let v = C::from_u32(0x0000_00AB);
+        assert_eq!(v << 8, C::from_u32(0x0000_AB00));
+        assert_eq!(v << 0, v);
+        // Shifting past the 32-bit width truncates to zero.
+        assert_eq!(C::from_u32(0x8000_0000) << 1, C::from_u32(0));
+
+        let w = C::from_u32(0x0000_AB00);
+        assert_eq!(w >> 8, C::from_u32(0x0000_00AB));
+        assert_eq!(C::from_u32(0xDEAD_BEEF) >> 64, C::from_u32(0));
+
+        let mut s = C::from_u32(0x0000_00AB);
+        s <<= 8;
+        assert_eq!(s, C::from_u32(0x0000_AB00));
+        s >>= 8;
+        assert_eq!(s, C::from_u32(0x0000_00AB));
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn compare() {
+    fn body<C: Carrier>() {
+        let a = C::from_u32(100);
+        let b = C::from_u32(200);
+        assert!(a < b);
+        assert!(b > a);
+        assert_eq!(a, C::from_u32(100));
+        assert_ne!(a, b);
+        assert_eq!(a.partial_cmp(&b), Some(core::cmp::Ordering::Less));
+        assert_eq!(b.partial_cmp(&a), Some(core::cmp::Ordering::Greater));
+        assert_eq!(a.partial_cmp(&a), Some(core::cmp::Ordering::Equal));
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn parity() {
+    fn body<C: Carrier>() {
+        assert!(C::from_u32(0).is_even());
+        assert!(C::from_u32(4).is_even());
+        assert!(C::from_u32(5).is_odd());
+        assert!(C::from_u32(0xFFFF_FFFF).is_odd());
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn div_rem() {
+    fn body<C: Carrier>() {
+        let a = C::from_u32(100);
+        let b = C::from_u32(7);
+        assert_eq!(a / b, C::from_u32(14));
+        assert_eq!(a % b, C::from_u32(2));
+        // Round-trip: (a / b) * b + a % b == a.
+        assert_eq!((a / b) * b + a % b, a);
+        // Dividend < divisor.
+        assert_eq!(C::from_u32(3) / C::from_u32(10), C::from_u32(0));
+        assert_eq!(C::from_u32(3) % C::from_u32(10), C::from_u32(3));
+
+        let mut q = a;
+        q /= b;
+        assert_eq!(q, C::from_u32(14));
+        let mut r = a;
+        r %= b;
+        assert_eq!(r, C::from_u32(2));
+    }
+    for_both_carriers!(body);
+}

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -10,8 +10,6 @@
 //! the runtime-length width vocabulary) live in each carrier's own suite; this
 //! file is only the surface both share.
 
-#![cfg(feature = "num-traits")]
-
 use const_num_traits::{
     CarryingMul, CheckedAdd, CheckedMul, CheckedSub, FromByteSlice, Nct, OverflowingAdd,
     OverflowingMul, OverflowingSub, Parity, WrappingAdd, WrappingMul, WrappingSub, Zero,

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -230,11 +230,17 @@ fn shifts() {
         let v = C::from_u32(0x0000_00AB);
         assert_eq!(v << 8, C::from_u32(0x0000_AB00));
         assert_eq!(v << 0, v);
-        // Shifting past the 32-bit width truncates to zero.
+        // Around the 32-bit width boundary: the top bit stays, shifting by
+        // exactly the width (or more) truncates to zero. `shift == word_bits`
+        // is the classic edge (a native `<<` there would be UB).
+        assert_eq!(C::from_u32(1) << 31, C::from_u32(0x8000_0000));
         assert_eq!(C::from_u32(0x8000_0000) << 1, C::from_u32(0));
+        assert_eq!(C::from_u32(1) << 32, C::from_u32(0));
+        assert_eq!(C::from_u32(1) << 33, C::from_u32(0));
 
         let w = C::from_u32(0x0000_AB00);
         assert_eq!(w >> 8, C::from_u32(0x0000_00AB));
+        assert_eq!(C::from_u32(0xDEAD_BEEF) >> 32, C::from_u32(0));
         assert_eq!(C::from_u32(0xDEAD_BEEF) >> 64, C::from_u32(0));
 
         let mut s = C::from_u32(0x0000_00AB);
@@ -290,6 +296,13 @@ fn div_rem() {
         // Dividend < divisor.
         assert_eq!(C::from_u32(3) / C::from_u32(10), C::from_u32(0));
         assert_eq!(C::from_u32(3) % C::from_u32(10), C::from_u32(3));
+        // Boundary identities at the max width.
+        let max = C::from_u32(MAX32);
+        let one = C::from_u32(1);
+        assert_eq!(max / one, max);
+        assert_eq!(max % one, C::from_u32(0));
+        assert_eq!(max / max, one);
+        assert_eq!(max % max, C::from_u32(0));
 
         let mut q = a;
         q /= b;

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -1,18 +1,19 @@
 //! Behavior shared by every carrier — written once as a generic body and run
 //! for both `FixedUInt` and `HeaplessBigInt`.
 //!
-//! Both carriers here are pinned to the same 32-bit width (`u8 × 4`) so the
-//! overflow / carry / wrap boundaries line up: `FixedUInt<u8, 4>` is 32-bit by
-//! construction, and `HeaplessBigInt<u8, 4>` is built from four bytes and
-//! `widened` to len 4 (its `From<small>` would otherwise be minimal-width).
+//! Both carriers are pinned to the same 32-bit width so the overflow / carry /
+//! wrap boundaries line up. Construction goes through the two traits both
+//! carriers share — `From<u32>` then `WithPrecision::widen_to_precision(32)` —
+//! because `From` alone is minimal-width on HeaplessBigInt and would otherwise
+//! not match FixedUInt's fixed width.
 //!
 //! Tests that reach into a carrier's internals (limbs / len / CAP, personality,
 //! the runtime-length width vocabulary) live in each carrier's own suite; this
 //! file is only the surface both share.
 
 use const_num_traits::{
-    CarryingMul, CheckedAdd, CheckedMul, CheckedSub, FromByteSlice, Nct, OverflowingAdd,
-    OverflowingMul, OverflowingSub, Parity, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    CarryingMul, CheckedAdd, CheckedMul, CheckedSub, Nct, OverflowingAdd, OverflowingMul,
+    OverflowingSub, Parity, WithPrecision, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
@@ -20,8 +21,7 @@ use core::ops::{
 };
 use fixed_bigint::{FixedUInt, HeaplessBigInt};
 
-/// The 32-bit unsigned surface both carriers implement. `from_u32` pins the
-/// value to the carrier's full 32-bit width so overflow behavior matches.
+/// The 32-bit unsigned surface both carriers implement.
 trait Carrier:
     Copy
     + core::fmt::Debug
@@ -29,6 +29,8 @@ trait Carrier:
     + PartialOrd
     + Zero
     + Parity
+    + From<u32>
+    + WithPrecision
     + Add<Output = Self>
     + Sub<Output = Self>
     + Mul<Output = Self>
@@ -60,21 +62,19 @@ trait Carrier:
     + CheckedMul<Output = Self>
     + CarryingMul<Unsigned = Self, Output = Self>
 {
-    fn from_u32(v: u32) -> Self;
+    /// Build `v` pinned to the carrier's full 32-bit width. `From<u32>`
+    /// alone is minimal-width on HeaplessBigInt (100 → one limb), so
+    /// `widen_to_precision` pins it to 32 bits — an identity on FixedUInt,
+    /// a grow on HeaplessBigInt — so the overflow boundaries line up.
+    fn from_u32(v: u32) -> Self {
+        <Self as From<u32>>::from(v).widen_to_precision(32)
+    }
 }
 
 macro_rules! impl_carrier {
     ($t:ty, $n:expr) => {
-        impl Carrier for FixedUInt<$t, $n, Nct> {
-            fn from_u32(v: u32) -> Self {
-                FromByteSlice::from_le_slice(&v.to_le_bytes()).unwrap()
-            }
-        }
-        impl Carrier for HeaplessBigInt<$t, $n, Nct> {
-            fn from_u32(v: u32) -> Self {
-                HeaplessBigInt::from_le_bytes(&v.to_le_bytes()).widened($n)
-            }
-        }
+        impl Carrier for FixedUInt<$t, $n, Nct> {}
+        impl Carrier for HeaplessBigInt<$t, $n, Nct> {}
     };
 }
 

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -164,6 +164,10 @@ fn mul() {
         let b = C::from_u32(17);
         assert_eq!(a * b, C::from_u32(221));
         assert_eq!(WrappingMul::wrapping_mul(a, b), C::from_u32(221));
+        assert_eq!(
+            OverflowingMul::overflowing_mul(a, b),
+            (C::from_u32(221), false)
+        );
         assert_eq!(CheckedMul::checked_mul(a, b), Some(C::from_u32(221)));
         let mut m = a;
         m *= b;
@@ -261,10 +265,15 @@ fn compare() {
 #[test]
 fn parity() {
     fn body<C: Carrier>() {
+        // Both directions, so an unconditional is_even/is_odd can't slip by.
         assert!(C::from_u32(0).is_even());
+        assert!(!C::from_u32(0).is_odd());
         assert!(C::from_u32(4).is_even());
+        assert!(!C::from_u32(4).is_odd());
         assert!(C::from_u32(5).is_odd());
+        assert!(!C::from_u32(5).is_even());
         assert!(C::from_u32(0xFFFF_FFFF).is_odd());
+        assert!(!C::from_u32(0xFFFF_FFFF).is_even());
     }
     for_both_carriers!(body);
 }

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -19,7 +19,7 @@ use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
     Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
-use fixed_bigint::{FixedUInt, HeaplessBigInt};
+use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
 
 /// The 32-bit unsigned surface both carriers implement.
 trait Carrier:
@@ -71,19 +71,21 @@ trait Carrier:
     }
 }
 
-macro_rules! impl_carrier {
-    ($t:ty, $n:expr) => {
-        impl Carrier for FixedUInt<$t, $n, Nct> {}
-        impl Carrier for HeaplessBigInt<$t, $n, Nct> {}
-    };
+impl<
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T> + core::fmt::Debug + Parity,
+    const N: usize,
+> Carrier for FixedUInt<T, N, Nct>
+{
+}
+impl<
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T> + core::fmt::Debug + Parity,
+    const CAP: usize,
+> Carrier for HeaplessBigInt<T, CAP, Nct>
+{
 }
 
-// Three backings of the same 32-bit width; each runs on both carriers.
-impl_carrier!(u8, 4);
-impl_carrier!(u16, 2);
-impl_carrier!(u32, 1);
-
-/// Run a generic body for both carriers across all three backings.
+/// Run a generic body for both carriers across three backings of the same
+/// 32-bit width.
 macro_rules! for_both_carriers {
     ($body:ident) => {{
         $body::<FixedUInt<u8, 4, Nct>>();

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -928,6 +928,16 @@ fn parity_reads_only_lowest_limb() {
     // High limbs are non-zero; parity must still come from limb 0.
     let v = H4u32Nct::from_limbs([0xFFFF_FFFE, 0xFFFF_FFFF, 0, 0], 2);
     assert!(v.is_even()); // low bit of 0xFFFF_FFFE is 0
+    assert!(!v.is_odd());
+}
+
+#[test]
+fn parity_of_minimal_width_zero() {
+    // `zero()` is minimal-width (len 0) — parity must read even with no limb
+    // to inspect. The generic carrier suite only ever sees a widened zero.
+    let z = <H4u32Nct as Zero>::zero();
+    assert!(z.is_even());
+    assert!(!z.is_odd());
 }
 
 // ── Div / Rem ──
@@ -1288,6 +1298,21 @@ fn trait_checked_mul_matches_fixeduint_width_behavior() {
     let out = <H4u8Nct as CheckedMul>::checked_mul(a, b).expect("35 fits in width 4");
     assert_eq!(out.len(), 4);
     assert_eq!(out.limbs()[0], 35);
+}
+
+#[test]
+fn checked_sub_trait_underflow_with_spare_capacity() {
+    // Narrow len-1 values in a CAP-4 carrier: the trait-form underflow must
+    // report None / borrow even though upper capacity limbs exist. The
+    // generic carrier suite only runs carriers where width == CAP, so this
+    // covers the `CAP > len` shape it can't reach.
+    use const_num_traits::{CheckedSub, OverflowingSub};
+    let one = H4u32Nct::from(1u32);
+    let two = H4u32Nct::from(2u32);
+    assert_eq!(one.len(), 1);
+    assert_eq!(<H4u32Nct as CheckedSub>::checked_sub(one, two), None);
+    let (_, borrow) = <H4u32Nct as OverflowingSub>::overflowing_sub(one, two);
+    assert!(borrow);
 }
 
 #[test]

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -921,33 +921,7 @@ fn trait_overflowing_add_reports_overflow() {
     assert!(overflow);
 }
 
-#[test]
-fn trait_overflowing_sub_reports_borrow() {
-    use const_num_traits::OverflowingSub;
-    let a: H4u32Nct = 1u8.into();
-    let b: H4u32Nct = 2u8.into();
-    let (_, borrow) = <H4u32Nct as OverflowingSub>::overflowing_sub(a, b);
-    assert!(borrow);
-}
-
 // ── Parity ──
-
-#[test]
-fn parity_zero_is_even() {
-    let z = <H4u32Nct as Zero>::zero();
-    assert!(!z.is_odd());
-    assert!(z.is_even());
-}
-
-#[test]
-fn parity_reads_lowest_bit() {
-    let odd: H4u32Nct = 5u32.into();
-    let even: H4u32Nct = 4u32.into();
-    assert!(odd.is_odd());
-    assert!(!odd.is_even());
-    assert!(!even.is_odd());
-    assert!(even.is_even());
-}
 
 #[test]
 fn parity_reads_only_lowest_limb() {
@@ -959,30 +933,11 @@ fn parity_reads_only_lowest_limb() {
 // ── Div / Rem ──
 
 #[test]
-fn div_rem_dividend_less_than_divisor() {
-    let a: H4u32Nct = 3u8.into();
-    let b: H4u32Nct = 10u8.into();
-    assert_eq!(a / b, <H4u32Nct as Zero>::zero());
-    assert_eq!(a % b, a);
-}
-
-#[test]
 fn div_rem_equal() {
     let a: H4u32Nct = 42u32.into();
     let b: H4u32Nct = 42u32.into();
     assert_eq!(a / b, <H4u32Nct as One>::one());
     assert_eq!(a % b, <H4u32Nct as Zero>::zero());
-}
-
-#[test]
-fn div_rem_small_values() {
-    let a: H4u32Nct = 100u32.into();
-    let b: H4u32Nct = 7u8.into();
-    // 100 = 14*7 + 2.
-    let expected_q: H4u32Nct = 14u32.into();
-    let expected_r: H4u32Nct = 2u8.into();
-    assert_eq!(a / b, expected_q);
-    assert_eq!(a % b, expected_r);
 }
 
 #[test]
@@ -1140,19 +1095,6 @@ fn wrapping_mul_trait_matches_inherent() {
 }
 
 // ── CarryingMul at the bigint level ──
-
-#[test]
-fn carrying_mul_small_no_overflow() {
-    use const_num_traits::CarryingMul;
-    // 5 * 7 + 3 = 38. Fits in one limb, hi = 0.
-    let a: H4u32Nct = 5u8.into();
-    let b: H4u32Nct = 7u8.into();
-    let c: H4u32Nct = 3u8.into();
-    let (lo, hi) = a.carrying_mul(b, c);
-    let expected_lo: H4u32Nct = 38u8.into();
-    assert_eq!(lo, expected_lo);
-    assert!(<H4u32Nct as const_num_traits::Zero>::is_zero(&hi));
-}
 
 #[test]
 fn carrying_mul_produces_high_half() {
@@ -1771,18 +1713,6 @@ fn bitxor_and_bitwise_assign_ops() {
     let mut z = a;
     z |= b;
     assert_eq!(z, 0xF0FF_F0FFu32.into());
-}
-
-#[test]
-fn checked_sub_trait_matches_inherent() {
-    use const_num_traits::CheckedSub;
-    let a = H4u32Nct::from(100u32);
-    let b = H4u32Nct::from(40u32);
-    assert_eq!(CheckedSub::checked_sub(a, b), Some(60u32.into()));
-    // Underflow at width 1 → None, like FixedUInt<u32, 1>.
-    let one = H4u32Nct::from(1u32);
-    let two = H4u32Nct::from(2u32);
-    assert_eq!(CheckedSub::checked_sub(one, two), None);
 }
 
 #[test]


### PR DESCRIPTION
Writes the behavior both carriers share once as a generic `fn body<C: Carrier>()` and runs it for both, instead of maintaining parallel per-carrier copies.

- A `Carrier` trait bounds the shared 32-bit surface (arithmetic + assign + wrapping/overflowing/checked + carrying_mul, bitwise incl. xor + assigns, shifts, compare, parity, div/rem). Both `FixedUInt<_, _, Nct>` and `HeaplessBigInt<_, _, Nct>` satisfy it.
- Nine generic bodies run across three backings (`u8x4`/`u16x2`/`u32x1`) on both carriers — all pinned to the same 32-bit width so overflow/carry/wrap boundaries match.
- Construction uses a byte-based `from_u32` (widening HeaplessBigInt to the full width), since HeaplessBigInt's `From<small>` is minimal-width and wouldn't otherwise line up with FixedUInt's fixed width.

Enabled by #144 (the operator-parity gaps). Follow-up: the value-assertion halves of the corresponding HeaplessBigInt-only tests can be pruned now that they're covered here for both carriers.

## Summary by Sourcery

Introduce a shared generic test suite that validates common 32-bit behavior across FixedUInt and HeaplessBigInt carriers, and prune HeaplessBigInt-specific tests now covered by the shared suite.

Tests:
- Add generic carrier tests covering arithmetic, bitwise, shifting, comparison, parity, division/remainder, and carrying multiplication for both FixedUInt and HeaplessBigInt over aligned 32-bit widths.
- Remove redundant HeaplessBigInt-only tests whose behavior is now exercised via the shared generic carrier test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a reusable, parameterized test suite validating a shared 32-bit “surface API” across two backends and multiple aligned widths.
  * Coverage includes arithmetic (wrapping/checked/overflowing and assign variants), carry-splitting multiplication, bitwise ops, shifts (including correct truncation past 32 bits), comparisons/partial ordering, parity, and division/remainder identity checks.
  * Removed several older or redundant heapless-specific regression/sanity cases to streamline the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->