### PR TITLE
Refresh README and bump to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ incremental = false
 
 [package]
 name = "fixed-bigint"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["kaidokert <kaidokert@gmail.com>"]
 documentation = "https://docs.rs/fixed-bigint"
 edition = "2024"

--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ Unsigned BigInt implementation, backed by a fixed-size array.
 `FixedUInt<u8,4>`,`FixedUInt<u16,2>` or `FixedUInt<u32,1>` all create a 32-bit unsigned integer, that behaves mostly the same as builtin `u32`.
 `FixedUInt<u32, 64>` creates a 2048-bit value, that uses native 32-bit math. If running on 8-bit CPU, `FixedUInt<u8, 2048>` would work the same, just very much slower.
 
+When the width isn't known until runtime, `HeaplessBigInt<T, CAP>` keeps a runtime length in the same fixed-size storage: the `CAP`-word buffer holds any value up to that width, and at each width it behaves like the equivalent `FixedUInt`. That lets a single buffer be sized for the largest case while smaller values still work.
+
 The crate is written for `no_std` and `no_alloc` environments with option for panic-free operation, i.e. embedded MCUs. At least for now, focus is on correctness first and then generated code size, performance comes last. The aim is not to bring in 64-bit math dependencies on 32-bit CPU, to save code space.
 
-The arithmetic operands ( +, -, .add() ) panic on overflow, just like native integer types. Panic-free alternatives like `overlowing_add` and `wrapping_add` are supported.
+The arithmetic operands ( +, -, .add() ) panic on overflow, just like native integer types. Panic-free alternatives like `overflowing_add` and `wrapping_add` are supported.
 
 In addition to basic arithmetic, two main traits are implemented: [num_traits::PrimInt](https://docs.rs/num-traits/latest/num_traits/int/trait.PrimInt.html) and [num_integer::Integer](https://docs.rs/num/latest/num/integer/trait.Integer.html).
+
+An optional `zeroize` feature wipes a value's backing store on drop, for handling sensitive data.
 
 ## Const Support
 
@@ -25,11 +29,6 @@ Most arithmetic operations are const-compatible via the [c0nst](https://crates.i
 ## Constant time
 
 Constant-time execution is implemented for a subset of core operations. Ct mode is selected by a type parameter, allowing individual calling contexts to use either mode. This is purely experimental, not audited or thoroughly verified.
-
-_TODO list_:
- * Implement experimental `unchecked_math` operands, unchecked_mul, unchecked_div etc.
- * Probably needs its own error structs instead of reusing core::fmt::Error and core::num::ParseIntError
- * Maybe implement signed version as well.
 
 _Note:_ This crate is mostly written as an exercise for learning the Rust type system and understanding how well it works on microcontrollers, its fitness for any particular purpose or quality has precisely zero guarantees.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The arithmetic operands ( +, -, .add() ) panic on overflow, just like native int
 
 In addition to basic arithmetic, two main traits are implemented: [num_traits::PrimInt](https://docs.rs/num-traits/latest/num_traits/int/trait.PrimInt.html) and [num_integer::Integer](https://docs.rs/num/latest/num/integer/trait.Integer.html).
 
-An optional `zeroize` feature wipes a value's backing store on drop, for handling sensitive data.
+An optional `zeroize` feature implements the `Zeroize` trait, so sensitive values can be cleared explicitly with `.zeroize()`, or wiped on scope exit by wrapping them in `zeroize::Zeroizing`. (The integer types are `Copy`, so they do not wipe on drop by themselves.)
 
 ## Const Support
 


### PR DESCRIPTION
README-only refresh, plus a patch bump to publish it.

- Introduce `HeaplessBigInt<T, CAP>` — the runtime-length carrier has been unconditional since 0.6.0 but never appeared in the readme.
- Note the optional `zeroize` feature.
- Fix the `overlowing_add` → `overflowing_add` typo.
- Drop the TODO list that had accreted under the "Constant time" heading; none of the items were constant-time related, and dev roadmap belongs in issues rather than the crates.io front page.

Kept the "written as an exercise / zero guarantees" note deliberately — it doubles as a liability disclaimer.

Version → 0.6.1 (docs-only release).

## Summary by Sourcery

Refresh documentation to cover runtime-width HeaplessBigInt usage and optional zeroize support, and bump the crate version for a docs-only release.

Build:
- Bump crate version from 0.6.0 to 0.6.1 for a documentation-only release.

Documentation:
- Document HeaplessBigInt<T, CAP> for runtime-width big integers using fixed-size storage.
- Mention the optional zeroize feature for wiping backing storage on drop.
- Fix the overflowing_add method name typo and remove the non-constant-time TODO list from the constant-time section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the feature overview with runtime-length big integers using fixed-size storage.
  * Clarified `no_std`/`no_alloc` support, overflow behavior, panic-free alternatives, and optional memory wiping.
  * Removed an outdated TODO section and corrected terminology.

* **Chores**
  * Updated the crate version from 0.6.0 to 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->