### PR TITLE
Bridge HeaplessBigInt onto the num_traits foundation traits

### DIFF
--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -7,7 +7,7 @@
 
 use super::{AssertCapFits, HeaplessBigInt, zero};
 use crate::MachineWord;
-use const_num_traits::{ConstOne, ConstZero, One, Personality, PersonalityTag, Zero};
+use const_num_traits::{Bounded, ConstOne, ConstZero, One, Personality, PersonalityTag, Zero};
 use core::marker::PhantomData;
 
 // ── const_num_traits::Zero / One ──
@@ -145,4 +145,25 @@ impl<T: MachineWord, const CAP: usize, P: Personality> ConstZero for HeaplessBig
 
 impl<T: MachineWord, const CAP: usize, P: Personality> ConstOne for HeaplessBigInt<T, CAP, P> {
     const ONE: Self = Self::const_one();
+}
+
+// ── const_num_traits::Bounded ──
+//
+// `min = 0` (len 0). `max` is the capacity bound: every one of `CAP` limbs
+// saturated, `len = CAP`. This is the one answer `CAP` legitimately sets —
+// it is the widest value the storage can represent, not a value width.
+impl<T: MachineWord, const CAP: usize, P: Personality> Bounded for HeaplessBigInt<T, CAP, P> {
+    #[inline]
+    fn min_value() -> Self {
+        <Self as ConstZero>::ZERO
+    }
+
+    #[inline]
+    fn max_value() -> Self {
+        Self {
+            limbs: [<T as Bounded>::max_value(); CAP],
+            len: CAP as u16,
+            _p: PhantomData,
+        }
+    }
 }

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -160,6 +160,9 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Bounded for HeaplessBigIn
 
     #[inline]
     fn max_value() -> Self {
+        // `len = CAP` here, so CAP must fit u16 — assert it the same way the
+        // shape-setting constructors do, rather than silently truncating.
+        let () = <Self as AssertCapFits>::CHECK;
         Self {
             limbs: [<T as Bounded>::max_value(); CAP],
             len: CAP as u16,

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -72,6 +72,8 @@ mod div_rem;
 mod from_prim;
 mod has_personality;
 mod identities;
+#[cfg(feature = "num-traits")]
+mod num_traits_bridge;
 mod parity;
 mod shift;
 #[cfg(any(feature = "nightly", feature = "use-unsafe"))]

--- a/src/heapless/num_traits_bridge.rs
+++ b/src/heapless/num_traits_bridge.rs
@@ -121,7 +121,9 @@ impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::NumCast
 #[cfg(test)]
 mod tests {
     use super::*;
-    use num_traits::{FromPrimitive, NumCast, One, ToPrimitive, Zero};
+    // Alias so the assertions exercise the *num_traits* bridge, not the
+    // `const_num_traits::Bounded` pulled in by `super::*`.
+    use num_traits::{Bounded as NumBounded, FromPrimitive, NumCast, One, ToPrimitive, Zero};
 
     type H8x4 = HeaplessBigInt<u8, 4>; // 32-bit carrier
     type H32x8 = HeaplessBigInt<u32, 8>; // 256-bit carrier
@@ -131,9 +133,9 @@ mod tests {
         assert!(<H8x4 as Zero>::zero().is_zero());
         assert!(!<H8x4 as One>::one().is_zero());
         // max is capacity-wide (all CAP limbs saturated).
-        let max = <H8x4 as Bounded>::max_value();
+        let max = <H8x4 as NumBounded>::max_value();
         assert_eq!(max.to_u64(), Some(0xFFFF_FFFF));
-        assert!(<H8x4 as Bounded>::min_value().is_zero());
+        assert!(<H8x4 as NumBounded>::min_value().is_zero());
     }
 
     #[test]

--- a/src/heapless/num_traits_bridge.rs
+++ b/src/heapless/num_traits_bridge.rs
@@ -1,0 +1,188 @@
+//! `num_traits` bridge for `HeaplessBigInt` (feature = "num-traits").
+//!
+//! Thin forwards onto the const-num-traits identity/bounds impls plus
+//! byte-based primitive extraction, mirroring `FixedUInt`'s bridge so a
+//! `HeaplessBigInt` satisfies the classic `num_traits` bounds
+//! (`Zero`/`One`/`Bounded`/`NumCast`/`ToPrimitive`/`FromPrimitive`). All
+//! are personality-generic — no `Nct` gate, matching `FixedUInt`.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{Bounded, CarryingMul, ConstOne, ConstZero, Personality, Zero};
+
+impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::Zero
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn zero() -> Self {
+        <Self as ConstZero>::ZERO
+    }
+
+    fn is_zero(&self) -> bool {
+        <Self as Zero>::is_zero(self)
+    }
+}
+
+// `num_traits::One: Mul<Self>`, and heapless multiplication needs
+// `CarryingMul` on the word (unlike `FixedUInt`, which widens via
+// `DoubleWord`), so this impl carries the same bound its `Mul` does.
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P: Personality>
+    num_traits::One for HeaplessBigInt<T, CAP, P>
+{
+    fn one() -> Self {
+        <Self as ConstOne>::ONE
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::Bounded
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn min_value() -> Self {
+        <Self as Bounded>::min_value()
+    }
+
+    fn max_value() -> Self {
+        <Self as Bounded>::max_value()
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::ToPrimitive
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn to_i64(&self) -> Option<i64> {
+        // Unsigned carrier: mirror `FixedUInt`, which never claims `i64`.
+        None
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        let word_size = core::mem::size_of::<T>();
+        let len = self.len as usize;
+        // Words that can reach the low 64 bits.
+        let iter_limit = core::cmp::min(8 / word_size, len);
+        // Anything set above bit 63 overflows a u64. Limbs beyond `len` are
+        // zero by the zero-tail invariant, so scanning `iter_limit..len`
+        // is enough.
+        for i in iter_limit..len {
+            if !super::is_zero(&self.limbs[i]) {
+                return None;
+            }
+        }
+        let mut ret: u64 = 0;
+        for (i, word) in self.limbs.iter().take(iter_limit).enumerate() {
+            let bytes = word.to_le_bytes();
+            for (j, &byte) in bytes.as_ref().iter().enumerate() {
+                let bit_shift = (i * word_size + j) * 8;
+                if bit_shift < 64 {
+                    ret |= (byte as u64) << bit_shift;
+                }
+            }
+        }
+        Some(ret)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::FromPrimitive
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn from_i64(_: i64) -> Option<Self> {
+        None
+    }
+
+    fn from_u64(input: u64) -> Option<Self> {
+        // Reject values the carrier can't hold. When `max` itself overflows
+        // a u64 the carrier is >= 64 bits wide, so every u64 fits.
+        if let Some(max) =
+            num_traits::ToPrimitive::to_u64(&<Self as num_traits::Bounded>::max_value())
+        {
+            if input > max {
+                return None;
+            }
+        }
+        // Construct at natural width: trim trailing zero bytes so a small
+        // value in a small-`CAP` carrier stays in bounds. (Unlike `From`,
+        // which asserts on oversize — the trait contract here is to return
+        // `None`, never panic, and the size check above already did that.)
+        let bytes = input.to_le_bytes();
+        let mut sig = bytes.len();
+        while sig > 0 && bytes[sig - 1] == 0 {
+            sig -= 1;
+        }
+        Some(Self::from_le_bytes(&bytes[..sig]))
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::NumCast
+    for HeaplessBigInt<T, CAP, P>
+{
+    fn from<X: num_traits::ToPrimitive>(arg: X) -> Option<Self> {
+        <Self as num_traits::FromPrimitive>::from_u64(arg.to_u64()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_traits::{FromPrimitive, NumCast, One, ToPrimitive, Zero};
+
+    type H8x4 = HeaplessBigInt<u8, 4>; // 32-bit carrier
+    type H32x8 = HeaplessBigInt<u32, 8>; // 256-bit carrier
+
+    #[test]
+    fn zero_one_bounded() {
+        assert!(<H8x4 as Zero>::zero().is_zero());
+        assert!(!<H8x4 as One>::one().is_zero());
+        // max is capacity-wide (all CAP limbs saturated).
+        let max = <H8x4 as Bounded>::max_value();
+        assert_eq!(max.to_u64(), Some(0xFFFF_FFFF));
+        assert!(<H8x4 as Bounded>::min_value().is_zero());
+    }
+
+    #[test]
+    fn to_u64_roundtrips_and_overflows() {
+        // Fits.
+        assert_eq!(
+            H32x8::from_u64(0x1234_5678_9ABC).unwrap().to_u64(),
+            Some(0x1234_5678_9ABC)
+        );
+        // 32-bit carrier can't hold a value above u32::MAX → to_u64 None path
+        // is only reachable when higher limbs are set; here the value is built
+        // from_u64 so overflow surfaces at construction instead.
+        assert_eq!(H8x4::from_u64(0x1_0000_0000), None); // > u32::MAX
+        assert_eq!(
+            H8x4::from_u64(0xFFFF_FFFF).unwrap().to_u64(),
+            Some(0xFFFF_FFFF)
+        );
+        assert_eq!(H8x4::from_u64(0).unwrap().to_u64(), Some(0));
+    }
+
+    #[test]
+    fn numcast_between_widths() {
+        let a: H32x8 = NumCast::from(255u32).unwrap();
+        assert_eq!(a.to_u64(), Some(255));
+        assert!(<H8x4 as NumCast>::from(0x1_0000_0000u64).is_none());
+    }
+
+    #[test]
+    fn matches_fixeduint_reference() {
+        // The bridge mirrors `FixedUInt`'s; at equal width the primitive
+        // casts must agree value-for-value.
+        type F32x8 = crate::FixedUInt<u32, 8>;
+        for v in [0u64, 1, 0xFF, 0x1_0000, 0x1234_5678_9ABC_DEF0] {
+            assert_eq!(
+                H32x8::from_u64(v).unwrap().to_u64(),
+                F32x8::from_u64(v).unwrap().to_u64(),
+                "to_u64 mismatch for {v:#x}"
+            );
+        }
+        // Overflow verdict agrees on a narrow (32-bit) carrier.
+        assert!(H8x4::from_u64(0x1_0000_0000).is_none());
+        assert!(crate::FixedUInt::<u8, 4>::from_u64(0x1_0000_0000).is_none());
+    }
+
+    #[test]
+    fn from_u64_is_natural_width() {
+        // A small value in a wide carrier constructs at its own width, not CAP.
+        use const_num_traits::BitsPrecision;
+        let small = H32x8::from_u64(1).unwrap();
+        assert_eq!(small.bits_precision(), 32); // one u32 limb, not 8
+    }
+}


### PR DESCRIPTION
First PR of the HeaplessBigInt feature-completion series (roadmap: notes/HEAPLESS_COMPLETION.md; gap inventory: notes/HEAPLESS_PARITY_INVENTORY.md — both gitignored).

**Why:** HeaplessBigInt satisfied *zero* `num_traits` bounds, so no generic `num_traits` consumer could accept it even though it already had the const-num-traits equivalents. This lands the foundation layer that `Num`/`PrimInt`/`Integer` all build on.

**What:**
- `const_num_traits::Bounded` — `min = 0`; `max` = the capacity bound (all `CAP` limbs saturated, `len = CAP`). This is the one answer `CAP` legitimately sets: the widest value the storage can hold, not a value width.
- `num_traits` `Zero`/`One`/`Bounded`/`ToPrimitive`/`FromPrimitive`/`NumCast` (`feature = "num-traits"`, personality-generic), thin forwards onto the const-num-traits impls plus a byte-based primitive extraction mirroring FixedUInt's bridge.

**Two carrier-specific wrinkles vs the FixedUInt bridge:**
- `num_traits::One` requires `Mul`, and heapless `Mul` needs `CarryingMul` on the word (FixedUInt widens via `DoubleWord`), so `One` carries that bound.
- `FromPrimitive::from_u64` trims trailing zero bytes before `from_le_bytes`, so a small value in a small-`CAP` carrier returns `None` on overflow rather than tripping the oversize assert — the trait contract is `None`, never panic.

**Tests:** identity/bounds, to_u64 round-trip + overflow, NumCast across widths, natural-width construction, and a value-for-value parity check against the same-width `FixedUInt` (the type this mirrors). Verified across default / --no-default-features / nightly; clippy clean.

Follow-ups in the series: PrimBits/PrimInt (carries the value-width decision — Not/count_zeros/etc. over `len·word_bits`) and num_integer::Integer (gcd/lcm/...).

## Summary by Sourcery

Bridge HeaplessBigInt onto the standard num_traits foundation traits so it can participate in generic numeric code.

New Features:
- Implement const_num_traits::Bounded for HeaplessBigInt to expose its capacity-based numeric bounds.
- Add a num-traits feature-gated bridge module wiring HeaplessBigInt into num_traits::Zero, One, Bounded, ToPrimitive, FromPrimitive, and NumCast.

Tests:
- Add tests covering Zero/One/Bounded behavior, u64 round-trip and overflow handling, NumCast across carrier widths, parity with FixedUInt behavior, and natural-width construction semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `num-traits` compatibility for heapless big integers.
  * Added zero, one, minimum, and maximum value support.
  * Added conversion to and from unsigned 64-bit values, including overflow checks.
  * Added numeric casting support across compatible integer widths.

* **Tests**
  * Added coverage for numeric identities, bounds, conversions, casting, overflow handling, and precision behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->