### PR TITLE
Not + const_num_traits::PrimBits for HeaplessBigInt

### DIFF
--- a/ct-verify/panic-free-audit/src/lib.rs
+++ b/ct-verify/panic-free-audit/src/lib.rs
@@ -33,7 +33,8 @@ use fixed_bigint::{FixedUInt, HeaplessBigInt};
 
 type U256 = FixedUInt<u32, 8>; // 32-byte / 256-bit, Curve25519-shaped
 
-// ── Ct branchless scans (shared `const_cmp_ct` / `const_leading_zeros_ct`) ──
+// ── Ct branchless scans (shared `const_cmp_ct` / `const_leading_zeros_ct` /
+//    `const_trailing_zeros_ct`) ──
 //
 // These moved from `&[T; N]` to `&[T]` so both carriers share one copy of the
 // `black_box`-guarded loop; lock down that the slice signature stays
@@ -64,9 +65,21 @@ pub extern "C" fn panic_audit__heapless_cmp_ct(a: u32, b: u32) -> i32 {
 }
 
 #[no_mangle]
-pub extern "C" fn panic_audit__heapless_leading_zeros_ct(a: u32) -> usize {
+pub extern "C" fn panic_audit__heapless_leading_zeros_ct(a: u32) -> u32 {
     let x = HeaplessU256Ct::from(black_box(a));
-    black_box(x.leading_zeros())
+    black_box(PrimBits::leading_zeros(x))
+}
+
+#[no_mangle]
+pub extern "C" fn panic_audit__fixed_trailing_zeros_ct(a: u32) -> u32 {
+    let x = U256Ct::from(black_box(a));
+    black_box(PrimBits::trailing_zeros(x))
+}
+
+#[no_mangle]
+pub extern "C" fn panic_audit__heapless_trailing_zeros_ct(a: u32) -> u32 {
+    let x = HeaplessU256Ct::from(black_box(a));
+    black_box(PrimBits::trailing_zeros(x))
 }
 
 #[no_mangle]

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -1096,15 +1096,17 @@ c0nst::c0nst! {
     /// CT variant of `const_trailing_zeros`: scans LSB-to-MSB without
     /// short-circuiting. Mirror of `const_leading_zeros_ct` — see that
     /// helper for the rationale. Used by the `Ct`-personality arm of
-    /// `PrimBits::trailing_zeros`.
-    pub(crate) c0nst fn const_trailing_zeros_ct<T: [c0nst] ConstMachineWord, const N: usize>(
-        array: &[T; N],
-    ) -> u32 {
+    /// `PrimBits::trailing_zeros` on both carriers (`FixedUInt` passes the
+    /// whole `&self.array`, `HeaplessBigInt` passes `&self.limbs[..len]`),
+    /// so it takes a slice; `#[inline]` keeps the length provable at each
+    /// call site.
+    #[inline]
+    pub(crate) c0nst fn const_trailing_zeros_ct<T: [c0nst] ConstMachineWord>(array: &[T]) -> u32 {
         let mut total: u32 = 0;
         // 0 while still in trailing-zero region; u32::MAX once a non-zero limb is seen.
         let mut decided: u32 = 0;
         let mut index = 0;
-        while index < N {
+        while index < array.len() {
             let v = array[index];
             let v_tz = <T as PrimBits>::trailing_zeros(v);
             // See `const_leading_zeros_ct` / `const_ct_select` for why

--- a/src/heapless/bitwise.rs
+++ b/src/heapless/bitwise.rs
@@ -17,7 +17,7 @@ use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
 use const_num_traits::Personality;
 use core::marker::PhantomData;
-use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign};
+use core::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not};
 
 // The value/mixed receiver forms of each bitwise op are uniform pure
 // delegation to the hand-written `&Self $op &Self` core.
@@ -125,6 +125,33 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitXor<&HeaplessBigInt<T,
 }
 
 forward_bitwise_receivers!(BitXor, bitxor);
+
+// Complement over the value width (`len` limbs); the result stays at `len`,
+// so `!x` matches the same-width `FixedUInt` bit-for-bit. `CAP` never enters
+// — the words beyond `len` do not exist. Data-independent, hence uniform
+// across personalities and inherently constant-time.
+impl<T: MachineWord, const CAP: usize, P: Personality> Not for HeaplessBigInt<T, CAP, P> {
+    type Output = Self;
+    fn not(self) -> Self {
+        let n = self.len as usize;
+        let mut limbs = [zero::<T>(); CAP];
+        for (o, &s) in limbs[..n].iter_mut().zip(&self.limbs[..n]) {
+            *o = !s;
+        }
+        HeaplessBigInt {
+            limbs,
+            len: self.len,
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> Not for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn not(self) -> Self::Output {
+        !*self
+    }
+}
 
 // ── Compound-assign forms (in-place on `self.limbs`) ──
 

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -75,6 +75,7 @@ mod identities;
 #[cfg(feature = "num-traits")]
 mod num_traits_bridge;
 mod parity;
+mod prim_bits;
 mod shift;
 #[cfg(any(feature = "nightly", feature = "use-unsafe"))]
 mod to_bytes;

--- a/src/heapless/prim_bits.rs
+++ b/src/heapless/prim_bits.rs
@@ -241,20 +241,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn parity_full_width() {
-        // 32 bytes, top byte non-zero → both carriers at 8 limbs.
-        let b = [
-            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x10, 0x32, 0x54, 0x76, 0x98, 0xBA,
-            0xDC, 0xFE, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB,
-            0xCC, 0xDD, 0xEE, 0xFF,
-        ];
-        assert_parity(
-            HeaplessBigInt::<u32, 8, Nct>::from_le_bytes(&b),
-            FixedUInt::<u32, 8, Nct>::from_le_bytes(&b),
-        );
-    }
-
+    // Full-width parity across both carriers lives in the generic
+    // `tests/carrier_generic.rs` harness (`prim_bits_bit_vocabulary`). What
+    // stays here is heapless-only: the sub-capacity value-width guarantee and
+    // the Ct-scan behavior, neither of which the fixed-width harness can reach.
     #[test]
     fn parity_sub_capacity_is_value_width() {
         // 8 bytes → len 2 inside a CAP-8 carrier. Must mirror FixedUInt<u32,2>,

--- a/src/heapless/prim_bits.rs
+++ b/src/heapless/prim_bits.rs
@@ -1,0 +1,289 @@
+//! `const_num_traits::PrimBits` for `HeaplessBigInt` — the bit-operation
+//! vocabulary (count / scan / rotate / reverse / byte-swap / shift),
+//! personality-generic.
+//!
+//! Every width-sensitive member operates over the value width
+//! (`len·word_bits`), never `CAP`: a value at `len = k` returns exactly
+//! what the same-width `FixedUInt<T, k>` returns. `count_ones`/`count_zeros`
+//! are uniform across personalities (any CT weakness in `T::count_ones` is
+//! inherited by both, same as `FixedUInt`); `leading_zeros`/`trailing_zeros`
+//! branch on `P::TAG` and share `FixedUInt`'s `black_box`-guarded Ct scans.
+//! `leading_ones`/`trailing_ones` use the trait defaults (`(!self).*_zeros()`),
+//! which are correct given the value-width `Not`.
+//!
+//! `pow` and the `num_traits::PrimInt` bridge are deliberately absent:
+//! `PrimInt` supertrait-requires `CheckedDiv`/`Saturating`/`Num`, which
+//! `HeaplessBigInt` does not implement yet.
+
+use super::{HeaplessBigInt, is_zero, zero};
+use crate::MachineWord;
+use const_num_traits::{Personality, PersonalityTag, PrimBits};
+use core::marker::PhantomData;
+
+impl<T: MachineWord, const CAP: usize, P: Personality> PrimBits for HeaplessBigInt<T, CAP, P> {
+    fn count_ones(self) -> u32 {
+        let n = self.len as usize;
+        let mut count = 0u32;
+        for &w in &self.limbs[..n] {
+            count += w.count_ones();
+        }
+        count
+    }
+
+    fn count_zeros(self) -> u32 {
+        let n = self.len as usize;
+        let mut count = 0u32;
+        for &w in &self.limbs[..n] {
+            count += w.count_zeros();
+        }
+        count
+    }
+
+    fn leading_zeros(self) -> u32 {
+        // Delegate to the inherent `leading_zeros` (bits.rs), which handles
+        // both personalities at value width. The `&self` borrow is required,
+        // not needless — it selects the inherent `&self` method; without it,
+        // method resolution picks this by-value trait method and recurses.
+        #[allow(clippy::needless_borrow)]
+        let lz = (&self).leading_zeros();
+        lz as u32
+    }
+
+    fn trailing_zeros(self) -> u32 {
+        let n = self.len as usize;
+        match P::TAG {
+            PersonalityTag::Nct => {
+                // LSB-to-MSB; stop at the first non-zero limb.
+                let mut ret = 0u32;
+                let mut i = 0;
+                while i < n {
+                    let v = self.limbs[i];
+                    ret += <T as PrimBits>::trailing_zeros(v);
+                    if !is_zero(&v) {
+                        break;
+                    }
+                    i += 1;
+                }
+                ret
+            }
+            // Shared full-width branchless scan (see `const_trailing_zeros_ct`).
+            PersonalityTag::Ct => crate::fixeduint::const_trailing_zeros_ct(&self.limbs[..n]),
+        }
+    }
+
+    fn swap_bytes(self) -> Self {
+        // Reverse limb order over the value width, each limb byte-swapped.
+        let n = self.len as usize;
+        let mut limbs = [zero::<T>(); CAP];
+        let mut i = 0;
+        while i < n {
+            limbs[i] = self.limbs[n - 1 - i].swap_bytes();
+            i += 1;
+        }
+        Self {
+            limbs,
+            len: self.len,
+            _p: PhantomData,
+        }
+    }
+
+    fn reverse_bits(self) -> Self {
+        // Reverse limb order and every limb's bits, over the value width.
+        let n = self.len as usize;
+        let mut limbs = [zero::<T>(); CAP];
+        let mut i = 0;
+        while i < n {
+            limbs[n - 1 - i] = self.limbs[i].reverse_bits();
+            i += 1;
+        }
+        Self {
+            limbs,
+            len: self.len,
+            _p: PhantomData,
+        }
+    }
+
+    fn rotate_left(self, n: u32) -> Self {
+        let bit_size = self.len as u32 * (core::mem::size_of::<T>() as u32 * 8);
+        if bit_size == 0 {
+            return self;
+        }
+        let shift = (n % bit_size) as usize;
+        let a = self << shift;
+        let b = self >> (bit_size as usize - shift);
+        a | b
+    }
+
+    fn rotate_right(self, n: u32) -> Self {
+        let bit_size = self.len as u32 * (core::mem::size_of::<T>() as u32 * 8);
+        if bit_size == 0 {
+            return self;
+        }
+        let shift = (n % bit_size) as usize;
+        let a = self >> shift;
+        let b = self << (bit_size as usize - shift);
+        a | b
+    }
+
+    fn unsigned_shl(self, n: u32) -> Self {
+        self << (n as usize)
+    }
+
+    fn unsigned_shr(self, n: u32) -> Self {
+        self >> (n as usize)
+    }
+
+    fn signed_shl(self, n: u32) -> Self {
+        // Unsigned carrier: identical to unsigned_shl.
+        self << (n as usize)
+    }
+
+    fn signed_shr(self, n: u32) -> Self {
+        // Unsigned carrier: the sign bit is always 0, so logical == arithmetic.
+        self >> (n as usize)
+    }
+
+    // Little-endian host: in-memory order already matches, so to/from_le are
+    // no-ops and to/from_be byte-swap. Big-endian hosts unsupported, same as
+    // FixedUInt.
+    fn from_be(x: Self) -> Self {
+        x.swap_bytes()
+    }
+
+    fn from_le(x: Self) -> Self {
+        x
+    }
+
+    fn to_be(self) -> Self {
+        self.swap_bytes()
+    }
+
+    fn to_le(self) -> Self {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FixedUInt;
+    use const_num_traits::{Ct, Nct};
+
+    // Differential: at width N, HeaplessBigInt<u32, CAP> carried at len = N
+    // must return exactly what FixedUInt<u32, N> returns for every PrimBits
+    // member. FixedUInt is the trusted reference.
+    fn assert_parity<const CAP: usize, const N: usize>(
+        h: HeaplessBigInt<u32, CAP, Nct>,
+        f: FixedUInt<u32, N, Nct>,
+    ) {
+        assert_eq!(h.len as usize, N, "test pattern must fill exactly N limbs");
+        assert_eq!(
+            PrimBits::count_ones(h),
+            PrimBits::count_ones(f),
+            "count_ones"
+        );
+        assert_eq!(
+            PrimBits::count_zeros(h),
+            PrimBits::count_zeros(f),
+            "count_zeros"
+        );
+        assert_eq!(PrimBits::leading_zeros(h), PrimBits::leading_zeros(f), "lz");
+        assert_eq!(
+            PrimBits::trailing_zeros(h),
+            PrimBits::trailing_zeros(f),
+            "tz"
+        );
+        assert_eq!(PrimBits::leading_ones(h), PrimBits::leading_ones(f), "lo");
+        assert_eq!(PrimBits::trailing_ones(h), PrimBits::trailing_ones(f), "to");
+        assert_eq!(
+            &PrimBits::swap_bytes(h).limbs[..N],
+            &PrimBits::swap_bytes(f).array[..]
+        );
+        assert_eq!(
+            &PrimBits::reverse_bits(h).limbs[..N],
+            &PrimBits::reverse_bits(f).array[..]
+        );
+        assert_eq!(
+            &PrimBits::to_be(h).limbs[..N],
+            &PrimBits::to_be(f).array[..]
+        );
+        assert_eq!(
+            &PrimBits::from_be(h).limbs[..N],
+            &PrimBits::from_be(f).array[..]
+        );
+        assert_eq!(&(!h).limbs[..N], &(!f).array[..], "not");
+        for k in [0u32, 1, 5, 31, 33, 100, 255] {
+            assert_eq!(
+                &PrimBits::rotate_left(h, k).limbs[..N],
+                &PrimBits::rotate_left(f, k).array[..],
+                "rotl {k}"
+            );
+            assert_eq!(
+                &PrimBits::rotate_right(h, k).limbs[..N],
+                &PrimBits::rotate_right(f, k).array[..],
+                "rotr {k}"
+            );
+            assert_eq!(
+                &PrimBits::unsigned_shl(h, k).limbs[..N],
+                &PrimBits::unsigned_shl(f, k).array[..],
+                "ushl {k}"
+            );
+            assert_eq!(
+                &PrimBits::unsigned_shr(h, k).limbs[..N],
+                &PrimBits::unsigned_shr(f, k).array[..],
+                "ushr {k}"
+            );
+            assert_eq!(
+                &PrimBits::signed_shr(h, k).limbs[..N],
+                &PrimBits::signed_shr(f, k).array[..],
+                "sshr {k}"
+            );
+        }
+    }
+
+    #[test]
+    fn parity_full_width() {
+        // 32 bytes, top byte non-zero → both carriers at 8 limbs.
+        let b = [
+            0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF, 0x10, 0x32, 0x54, 0x76, 0x98, 0xBA,
+            0xDC, 0xFE, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB,
+            0xCC, 0xDD, 0xEE, 0xFF,
+        ];
+        assert_parity(
+            HeaplessBigInt::<u32, 8, Nct>::from_le_bytes(&b),
+            FixedUInt::<u32, 8, Nct>::from_le_bytes(&b),
+        );
+    }
+
+    #[test]
+    fn parity_sub_capacity_is_value_width() {
+        // 8 bytes → len 2 inside a CAP-8 carrier. Must mirror FixedUInt<u32,2>,
+        // NOT the CAP-8 width: this is the value-width guarantee.
+        let b = [0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0x80];
+        assert_parity(
+            HeaplessBigInt::<u32, 8, Nct>::from_le_bytes(&b),
+            FixedUInt::<u32, 2, Nct>::from_le_bytes(&b),
+        );
+    }
+
+    #[test]
+    fn ct_scans_match_nct() {
+        // The Ct personality's full-width scans return the same magnitude as
+        // Nct for the same value (they differ only in timing).
+        let b = [0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x80];
+        let hn = HeaplessBigInt::<u32, 8, Nct>::from_le_bytes(&b);
+        let hc = HeaplessBigInt::<u32, 8, Ct>::from_le_bytes(&b);
+        assert_eq!(PrimBits::trailing_zeros(hc), PrimBits::trailing_zeros(hn));
+        assert_eq!(PrimBits::leading_zeros(hc), PrimBits::leading_zeros(hn));
+        assert_eq!(PrimBits::count_ones(hc), PrimBits::count_ones(hn));
+    }
+
+    #[test]
+    fn not_is_value_width() {
+        // !x over one limb: 0x0000_00FF → 0xFFFF_FF00, len stays 1.
+        let x = HeaplessBigInt::<u32, 8, Nct>::from_le_bytes(&[0xFF]);
+        let n = !x;
+        assert_eq!(n.len, 1);
+        assert_eq!(n.limbs[0], 0xFFFF_FF00);
+    }
+}

--- a/src/heapless/prim_bits.rs
+++ b/src/heapless/prim_bits.rs
@@ -20,6 +20,27 @@ use crate::MachineWord;
 use const_num_traits::{Personality, PersonalityTag, PrimBits};
 use core::marker::PhantomData;
 
+/// Value width in bits (`len·word_bits`) — the width every PrimBits member
+/// operates over. `len <= u16::MAX` and `word_bits <= 64`, so it fits `u32`.
+#[inline]
+fn value_bits<T: MachineWord, const CAP: usize, P: Personality>(
+    v: &HeaplessBigInt<T, CAP, P>,
+) -> u32 {
+    v.len as u32 * (core::mem::size_of::<T>() as u32 * 8)
+}
+
+/// Fixed-width zero at a given `len` (all `CAP` limbs zero).
+#[inline]
+fn zero_at<T: MachineWord, const CAP: usize, P: Personality>(
+    len: u16,
+) -> HeaplessBigInt<T, CAP, P> {
+    HeaplessBigInt {
+        limbs: [zero::<T>(); CAP],
+        len,
+        _p: PhantomData,
+    }
+}
+
 impl<T: MachineWord, const CAP: usize, P: Personality> PrimBits for HeaplessBigInt<T, CAP, P> {
     fn count_ones(self) -> u32 {
         let n = self.len as usize;
@@ -53,16 +74,14 @@ impl<T: MachineWord, const CAP: usize, P: Personality> PrimBits for HeaplessBigI
         let n = self.len as usize;
         match P::TAG {
             PersonalityTag::Nct => {
-                // LSB-to-MSB; stop at the first non-zero limb.
+                // LSB-to-MSB; stop at the first non-zero limb. Iterating the
+                // slice keeps the loop bounds-check-free.
                 let mut ret = 0u32;
-                let mut i = 0;
-                while i < n {
-                    let v = self.limbs[i];
+                for &v in &self.limbs[..n] {
                     ret += <T as PrimBits>::trailing_zeros(v);
                     if !is_zero(&v) {
                         break;
                     }
-                    i += 1;
                 }
                 ret
             }
@@ -75,10 +94,8 @@ impl<T: MachineWord, const CAP: usize, P: Personality> PrimBits for HeaplessBigI
         // Reverse limb order over the value width, each limb byte-swapped.
         let n = self.len as usize;
         let mut limbs = [zero::<T>(); CAP];
-        let mut i = 0;
-        while i < n {
-            limbs[i] = self.limbs[n - 1 - i].swap_bytes();
-            i += 1;
+        for (o, i) in limbs[..n].iter_mut().zip(self.limbs[..n].iter().rev()) {
+            *o = i.swap_bytes();
         }
         Self {
             limbs,
@@ -91,10 +108,8 @@ impl<T: MachineWord, const CAP: usize, P: Personality> PrimBits for HeaplessBigI
         // Reverse limb order and every limb's bits, over the value width.
         let n = self.len as usize;
         let mut limbs = [zero::<T>(); CAP];
-        let mut i = 0;
-        while i < n {
-            limbs[n - 1 - i] = self.limbs[i].reverse_bits();
-            i += 1;
+        for (o, i) in limbs[..n].iter_mut().rev().zip(self.limbs[..n].iter()) {
+            *o = i.reverse_bits();
         }
         Self {
             limbs,
@@ -104,43 +119,66 @@ impl<T: MachineWord, const CAP: usize, P: Personality> PrimBits for HeaplessBigI
     }
 
     fn rotate_left(self, n: u32) -> Self {
-        let bit_size = self.len as u32 * (core::mem::size_of::<T>() as u32 * 8);
-        if bit_size == 0 {
+        let bits = value_bits(&self);
+        if bits == 0 {
             return self;
         }
-        let shift = (n % bit_size) as usize;
-        let a = self << shift;
-        let b = self >> (bit_size as usize - shift);
+        let shift = n % bits;
+        if shift == 0 {
+            return self;
+        }
+        // `shift` and `bits - shift` are both in `1..bits` (< u16::MAX·64),
+        // so the usize casts are lossless even where `usize` is 16-bit.
+        let a = self << shift as usize;
+        let b = self >> (bits - shift) as usize;
         a | b
     }
 
     fn rotate_right(self, n: u32) -> Self {
-        let bit_size = self.len as u32 * (core::mem::size_of::<T>() as u32 * 8);
-        if bit_size == 0 {
+        let bits = value_bits(&self);
+        if bits == 0 {
             return self;
         }
-        let shift = (n % bit_size) as usize;
-        let a = self >> shift;
-        let b = self << (bit_size as usize - shift);
+        let shift = n % bits;
+        if shift == 0 {
+            return self;
+        }
+        let a = self >> shift as usize;
+        let b = self << (bits - shift) as usize;
         a | b
     }
 
     fn unsigned_shl(self, n: u32) -> Self {
-        self << (n as usize)
+        // Shifting by >= the value width clears it. The guard also keeps the
+        // `as usize` cast below lossless on a 16-bit-`usize` target.
+        if n >= value_bits(&self) {
+            return zero_at(self.len);
+        }
+        self << n as usize
     }
 
     fn unsigned_shr(self, n: u32) -> Self {
-        self >> (n as usize)
+        if n >= value_bits(&self) {
+            return zero_at(self.len);
+        }
+        // `>>` narrows `len` on whole-word shifts, but PrimBits is fixed-width:
+        // restore the operand width so downstream width-sensitive ops
+        // (count_zeros, leading_zeros) match FixedUInt. The freed high limbs
+        // are already zero, so bumping `len` back is value-preserving.
+        let mut r = self >> n as usize;
+        r.len = self.len;
+        r
     }
 
     fn signed_shl(self, n: u32) -> Self {
-        // Unsigned carrier: identical to unsigned_shl.
-        self << (n as usize)
+        // Unsigned carrier: identical to unsigned_shl (mirrors FixedUInt).
+        <Self as PrimBits>::unsigned_shl(self, n)
     }
 
     fn signed_shr(self, n: u32) -> Self {
-        // Unsigned carrier: the sign bit is always 0, so logical == arithmetic.
-        self >> (n as usize)
+        // Unsigned carrier: heapless mirrors FixedUInt, which shifts logically
+        // (treats the value as unsigned), keeping the two carriers bit-for-bit.
+        <Self as PrimBits>::unsigned_shr(self, n)
     }
 
     // Little-endian host: in-memory order already matches, so to/from_le are
@@ -254,6 +292,29 @@ mod tests {
             HeaplessBigInt::<u32, 8, Nct>::from_le_bytes(&b),
             FixedUInt::<u32, 2, Nct>::from_le_bytes(&b),
         );
+    }
+
+    #[test]
+    fn shr_preserves_value_width() {
+        // PrimBits shifts are fixed-width, unlike the `>>` operator which
+        // narrows `len` on whole-word shifts. Without width preservation,
+        // count_zeros/leading_zeros after the shift report the wrong width.
+        let h = HeaplessBigInt::<u32, 8, Nct>::from_le_bytes(&[0, 0, 0, 0, 0, 0, 0, 0x80]); // len 2
+        let f = FixedUInt::<u32, 2, Nct>::from_le_bytes(&[0, 0, 0, 0, 0, 0, 0, 0x80]);
+        let hs = PrimBits::unsigned_shr(h, 32);
+        assert_eq!(hs.len, 2, "shr must preserve the operand width");
+        assert_eq!(
+            PrimBits::count_zeros(hs),
+            PrimBits::count_zeros(f >> 32usize)
+        );
+        assert_eq!(
+            PrimBits::leading_zeros(hs),
+            PrimBits::leading_zeros(f >> 32usize)
+        );
+        // Over-shift clears to a fixed-width zero, not a narrowed one.
+        let hz = PrimBits::unsigned_shr(h, 999);
+        assert_eq!(hz.len, 2);
+        assert_eq!(PrimBits::count_zeros(hz), 64);
     }
 
     #[test]

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -13,11 +13,11 @@
 
 use const_num_traits::{
     CarryingMul, CheckedAdd, CheckedMul, CheckedSub, Nct, OverflowingAdd, OverflowingMul,
-    OverflowingSub, Parity, WithPrecision, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    OverflowingSub, Parity, PrimBits, WithPrecision, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
-    Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
+    Mul, MulAssign, Not, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign, Sub, SubAssign,
 };
 use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
 
@@ -61,6 +61,8 @@ trait Carrier:
     + CheckedSub<Output = Self>
     + CheckedMul<Output = Self>
     + CarryingMul<Unsigned = Self, Output = Self>
+    + Not<Output = Self>
+    + PrimBits
 {
     /// Build `v` pinned to the carrier's full 32-bit width. `From<u32>`
     /// alone is minimal-width on HeaplessBigInt (100 → one limb), so
@@ -310,6 +312,63 @@ fn div_rem() {
         let mut r = a;
         r %= b;
         assert_eq!(r, C::from_u32(2));
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn prim_bits_bit_vocabulary() {
+    // Both carriers, pinned to 32-bit width, must return identical results
+    // for the whole PrimBits surface plus `Not`. Absolute expectations, so
+    // FixedUInt and HeaplessBigInt are checked against the same truth.
+    fn body<C: Carrier>() {
+        // population counts
+        assert_eq!(PrimBits::count_ones(C::from_u32(0b1011)), 3);
+        assert_eq!(PrimBits::count_zeros(C::from_u32(0b1011)), 29);
+        // leading / trailing scans over the 32-bit width
+        assert_eq!(PrimBits::leading_zeros(C::from_u32(0)), 32);
+        assert_eq!(PrimBits::leading_zeros(C::from_u32(1)), 31);
+        assert_eq!(PrimBits::trailing_zeros(C::from_u32(0b1000)), 3);
+        assert_eq!(PrimBits::trailing_zeros(C::from_u32(0)), 32);
+        assert_eq!(PrimBits::leading_ones(C::from_u32(MAX32)), 32);
+        assert_eq!(PrimBits::trailing_ones(C::from_u32(0b0111)), 3);
+        // rotates wrap within the 32-bit width
+        assert_eq!(PrimBits::rotate_left(C::from_u32(1), 4), C::from_u32(16));
+        assert_eq!(PrimBits::rotate_right(C::from_u32(16), 4), C::from_u32(1));
+        assert_eq!(
+            PrimBits::rotate_left(C::from_u32(0x8000_0000), 1),
+            C::from_u32(1)
+        );
+        assert_eq!(
+            PrimBits::rotate_right(C::from_u32(1), 1),
+            C::from_u32(0x8000_0000)
+        );
+        // shifts (unsigned == signed on an unsigned carrier)
+        assert_eq!(PrimBits::unsigned_shl(C::from_u32(1), 4), C::from_u32(16));
+        assert_eq!(PrimBits::unsigned_shr(C::from_u32(0x10), 4), C::from_u32(1));
+        assert_eq!(PrimBits::signed_shl(C::from_u32(1), 4), C::from_u32(16));
+        assert_eq!(PrimBits::signed_shr(C::from_u32(0x10), 4), C::from_u32(1));
+        // byte / bit order
+        assert_eq!(
+            PrimBits::swap_bytes(C::from_u32(0x1234_5678)),
+            C::from_u32(0x7856_3412)
+        );
+        assert_eq!(
+            PrimBits::reverse_bits(C::from_u32(1)),
+            C::from_u32(0x8000_0000)
+        );
+        assert_eq!(
+            PrimBits::to_be(C::from_u32(0x0000_00FF)),
+            C::from_u32(0xFF00_0000)
+        );
+        assert_eq!(
+            PrimBits::from_be(C::from_u32(0xFF00_0000)),
+            C::from_u32(0x0000_00FF)
+        );
+        assert_eq!(PrimBits::to_le(C::from_u32(0x1234)), C::from_u32(0x1234));
+        // complement over the width
+        assert_eq!(!C::from_u32(0), C::from_u32(MAX32));
+        assert_eq!(!C::from_u32(0x0F0F_0F0F), C::from_u32(0xF0F0_F0F0));
     }
     for_both_carriers!(body);
 }


### PR DESCRIPTION
Second PR of the HeaplessBigInt parity series (roadmap: notes/HEAPLESS_COMPLETION.md). Lands the bit-operation vocabulary.

**Value-width, per the settled design decision:** every width-sensitive member operates over `len·word_bits`, never `CAP` — a value at `len = k` returns exactly what `FixedUInt<T, k>` returns. A differential test drives both carriers through every PrimBits member at full width *and* at a sub-capacity width (len 2 in a CAP-8 carrier), asserting bit-for-bit agreement with FixedUInt.

**What:**
- `Not` — complement over the `len` limbs, result stays at `len`. Data-independent, so uniform across personalities and inherently constant-time. (Unblocks PrimBits, which supertrait-requires `Not`.)
- `const_num_traits::PrimBits` (personality-generic): `count_ones`/`count_zeros`, `leading`/`trailing_zeros`/`_ones`, `swap_bytes`, `reverse_bits`, `rotate_left`/`right`, `un`/`signed_shl`/`shr`, `to`/`from_be`/`le`. `count_*` are uniform; `leading`/`trailing_zeros` branch on `P::TAG` and reuse FixedUInt's `black_box`-guarded Ct scans.
- `const_trailing_zeros_ct` re-typed `&[T; N]` → `&[T]` (like `const_cmp_ct`/`const_leading_zeros_ct` already are) so both carriers share the one CT scan. New heapless/fixed `trailing_zeros_ct` audit fixtures confirm the runtime-slice path stays panic-free on thumbv7em (0 panic/unwind symbols).

**Deferred (deps not landed):** `num_traits::PrimInt` supertrait-requires `CheckedDiv`/`Saturating`/`Num`; `pow` is its own item. Both come in later PRs.

**One resolution note worth a look:** with `PrimBits` in scope, `owned.leading_zeros()` now resolves to the `u32` PrimBits method rather than heapless's inherent `usize` one (this matches FixedUInt and std). The inherent `usize` form stays reachable via a reference and is still what internal callers/bit_length use; only `PrimBits`-in-scope call sites see the change, and it's a compile-time type change, not a silent one. Flagging in case you'd prefer to later align the inherent `leading_zeros` to `u32` outright.

Verified across default / --no-default-features / nightly; clippy clean; audit cross-build panic-free.

## Summary by Sourcery

Implement the `const_num_traits::PrimBits` bit-operation trait for `HeaplessBigInt` and align its behavior and audits with `FixedUInt` at value width.

New Features:
- Add `Not` support for `HeaplessBigInt`, complementing bits over the value width while preserving the current length.
- Implement personality-generic `const_num_traits::PrimBits` for `HeaplessBigInt`, including counting, scanning, rotation, reversal, byte-swap, shifting, and endianness conversions.

Enhancements:
- Retype `const_trailing_zeros_ct` to operate on slices instead of fixed-size arrays so both carriers share the same constant-time trailing-zero scan.
- Extend the heapless module with a dedicated `prim_bits` implementation file and parity tests to guarantee value-width equivalence with `FixedUInt`.
- Update panic-free audit helpers to cover `leading_zeros_ct` and `trailing_zeros_ct` for both fixed and heapless carriers via `PrimBits`.

Tests:
- Add differential tests ensuring `HeaplessBigInt` and `FixedUInt` return identical results for all `PrimBits` members at both full and sub-capacity widths.
- Add tests confirming constant-time personality scans match non-CT results and that the `Not` implementation respects value width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bit-counting and bit-manipulation support for heapless big integers, including complements, rotations, shifts, byte swapping, and bit reversal.
  - Added leading-zero and trailing-zero calculations that respect the value’s active width.
  - Added constant-time trailing-zero scan support.

- **Bug Fixes**
  - Corrected leading-zero result types for consistent API behavior.
  - Improved bitwise complement behavior so unused capacity remains unaffected.

- **Tests**
  - Added coverage validating parity with fixed-width integer operations and value-width invariants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->