### PR TITLE
Consolidate num_traits foundation parity into a generic carrier harness

### DIFF
--- a/src/heapless/num_traits_bridge.rs
+++ b/src/heapless/num_traits_bridge.rs
@@ -139,11 +139,13 @@ mod tests {
 
     #[test]
     fn wide_value_roundtrip() {
-        // Values wider than 32 bits (multi-limb u64 assembly, and the
-        // >u64-max `Bounded` path where to_u64 of the 256-bit max is None)
-        // round-trip in a carrier wide enough to hold them.
+        // Values wider than 32 bits round-trip via multi-limb u64 assembly in
+        // a carrier wide enough to hold them.
         for v in [0x1_0000_0000u64, 0x1234_5678_9ABC, 0xFFFF_FFFF_FFFF_FFFF] {
             assert_eq!(H32x8::from_u64(v).unwrap().to_u64(), Some(v));
         }
+        // The 256-bit max exceeds u64, so to_u64 saturates to None — the
+        // branch from_u64 relies on to accept every u64 above.
+        assert_eq!(<H32x8 as num_traits::Bounded>::max_value().to_u64(), None);
     }
 }

--- a/src/heapless/num_traits_bridge.rs
+++ b/src/heapless/num_traits_bridge.rs
@@ -121,64 +121,13 @@ impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::NumCast
 #[cfg(test)]
 mod tests {
     use super::*;
-    // Alias so the assertions exercise the *num_traits* bridge, not the
-    // `const_num_traits::Bounded` pulled in by `super::*`.
-    use num_traits::{Bounded as NumBounded, FromPrimitive, NumCast, One, ToPrimitive, Zero};
+    use num_traits::{FromPrimitive, ToPrimitive};
 
-    type H8x4 = HeaplessBigInt<u8, 4>; // 32-bit carrier
     type H32x8 = HeaplessBigInt<u32, 8>; // 256-bit carrier
 
-    #[test]
-    fn zero_one_bounded() {
-        assert!(<H8x4 as Zero>::zero().is_zero());
-        assert!(!<H8x4 as One>::one().is_zero());
-        // max is capacity-wide (all CAP limbs saturated).
-        let max = <H8x4 as NumBounded>::max_value();
-        assert_eq!(max.to_u64(), Some(0xFFFF_FFFF));
-        assert!(<H8x4 as NumBounded>::min_value().is_zero());
-    }
-
-    #[test]
-    fn to_u64_roundtrips_and_overflows() {
-        // Fits.
-        assert_eq!(
-            H32x8::from_u64(0x1234_5678_9ABC).unwrap().to_u64(),
-            Some(0x1234_5678_9ABC)
-        );
-        // 32-bit carrier can't hold a value above u32::MAX → to_u64 None path
-        // is only reachable when higher limbs are set; here the value is built
-        // from_u64 so overflow surfaces at construction instead.
-        assert_eq!(H8x4::from_u64(0x1_0000_0000), None); // > u32::MAX
-        assert_eq!(
-            H8x4::from_u64(0xFFFF_FFFF).unwrap().to_u64(),
-            Some(0xFFFF_FFFF)
-        );
-        assert_eq!(H8x4::from_u64(0).unwrap().to_u64(), Some(0));
-    }
-
-    #[test]
-    fn numcast_between_widths() {
-        let a: H32x8 = NumCast::from(255u32).unwrap();
-        assert_eq!(a.to_u64(), Some(255));
-        assert!(<H8x4 as NumCast>::from(0x1_0000_0000u64).is_none());
-    }
-
-    #[test]
-    fn matches_fixeduint_reference() {
-        // The bridge mirrors `FixedUInt`'s; at equal width the primitive
-        // casts must agree value-for-value.
-        type F32x8 = crate::FixedUInt<u32, 8>;
-        for v in [0u64, 1, 0xFF, 0x1_0000, 0x1234_5678_9ABC_DEF0] {
-            assert_eq!(
-                H32x8::from_u64(v).unwrap().to_u64(),
-                F32x8::from_u64(v).unwrap().to_u64(),
-                "to_u64 mismatch for {v:#x}"
-            );
-        }
-        // Overflow verdict agrees on a narrow (32-bit) carrier.
-        assert!(H8x4::from_u64(0x1_0000_0000).is_none());
-        assert!(crate::FixedUInt::<u8, 4>::from_u64(0x1_0000_0000).is_none());
-    }
+    // The 32-bit foundation surface (Zero/One/Bounded/NumCast, round-trip and
+    // overflow) is covered for both carriers in tests/carrier_num_traits.rs.
+    // These two exercise heapless behavior the fixed-width harness can't reach.
 
     #[test]
     fn from_u64_is_natural_width() {
@@ -186,5 +135,15 @@ mod tests {
         use const_num_traits::BitsPrecision;
         let small = H32x8::from_u64(1).unwrap();
         assert_eq!(small.bits_precision(), 32); // one u32 limb, not 8
+    }
+
+    #[test]
+    fn wide_value_roundtrip() {
+        // Values wider than 32 bits (multi-limb u64 assembly, and the
+        // >u64-max `Bounded` path where to_u64 of the 256-bit max is None)
+        // round-trip in a carrier wide enough to hold them.
+        for v in [0x1_0000_0000u64, 0x1234_5678_9ABC, 0xFFFF_FFFF_FFFF_FFFF] {
+            assert_eq!(H32x8::from_u64(v).unwrap().to_u64(), Some(v));
+        }
     }
 }

--- a/tests/carrier_num_traits.rs
+++ b/tests/carrier_num_traits.rs
@@ -1,0 +1,101 @@
+//! `num_traits` foundation shared by both carriers — written once as a generic
+//! body and run for `FixedUInt` and `HeaplessBigInt`.
+//!
+//! The sibling `carrier_generic.rs` stays feature-free (const-only surface);
+//! this file is its `feature = "num-traits"` counterpart, same shape. Values
+//! are pinned to a 32-bit width so the two carriers' `Bounded`/overflow
+//! boundaries line up. Heapless-only behavior (natural-width construction,
+//! sub-capacity widths) lives in `src/heapless/num_traits_bridge.rs`.
+
+#![cfg(feature = "num-traits")]
+
+use const_num_traits::{CarryingMul, Nct, WithPrecision};
+use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
+use num_traits::{Bounded, FromPrimitive, NumCast, One, ToPrimitive, Zero};
+
+/// The num_traits foundation both carriers implement, pinned to 32 bits.
+trait NumCarrier:
+    Copy
+    + core::fmt::Debug
+    + PartialEq
+    + Zero
+    + One
+    + Bounded
+    + ToPrimitive
+    + FromPrimitive
+    + NumCast
+    + From<u32>
+    + WithPrecision
+{
+    /// Build `v` at the carrier's full 32-bit width (see `carrier_generic.rs`).
+    fn at32(v: u32) -> Self {
+        <Self as From<u32>>::from(v).widen_to_precision(32)
+    }
+}
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T> + core::fmt::Debug, const N: usize>
+    NumCarrier for FixedUInt<T, N, Nct>
+{
+}
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T> + core::fmt::Debug, const CAP: usize>
+    NumCarrier for HeaplessBigInt<T, CAP, Nct>
+{
+}
+
+/// Run a generic body for both carriers across three 32-bit backings.
+macro_rules! for_both_carriers {
+    ($body:ident) => {{
+        $body::<FixedUInt<u8, 4, Nct>>();
+        $body::<HeaplessBigInt<u8, 4, Nct>>();
+        $body::<FixedUInt<u16, 2, Nct>>();
+        $body::<HeaplessBigInt<u16, 2, Nct>>();
+        $body::<FixedUInt<u32, 1, Nct>>();
+        $body::<HeaplessBigInt<u32, 1, Nct>>();
+    }};
+}
+
+#[test]
+fn zero_one() {
+    fn body<C: NumCarrier>() {
+        assert!(<C as Zero>::zero().is_zero());
+        assert_eq!(<C as Zero>::zero().to_u64(), Some(0));
+        assert!(!<C as One>::one().is_zero());
+        assert_eq!(<C as One>::one().to_u64(), Some(1));
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn bounded() {
+    fn body<C: NumCarrier>() {
+        // All three backings are 32-bit wide, so max = u32::MAX.
+        assert_eq!(<C as Bounded>::max_value().to_u64(), Some(0xFFFF_FFFF));
+        assert!(<C as Bounded>::min_value().is_zero());
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn to_from_primitive_roundtrip() {
+    fn body<C: NumCarrier>() {
+        for v in [0u64, 1, 0xFF, 0x1234, 0xFFFF_FFFF] {
+            assert_eq!(C::from_u64(v).unwrap().to_u64(), Some(v));
+        }
+        // Above the 32-bit width → rejected, not truncated.
+        assert!(C::from_u64(0x1_0000_0000).is_none());
+        // The unsigned carriers never claim i64.
+        assert_eq!(C::at32(5).to_i64(), None);
+        assert_eq!(C::from_i64(5), None);
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn numcast() {
+    fn body<C: NumCarrier>() {
+        let a: C = NumCast::from(255u32).unwrap();
+        assert_eq!(a.to_u64(), Some(255));
+        assert!(<C as NumCast>::from(0x1_0000_0000u64).is_none());
+    }
+    for_both_carriers!(body);
+}


### PR DESCRIPTION
Test-only. Closes the consolidation debt noted after PR #148: its num_traits foundation parity (Zero/One/Bounded/ToPrimitive/FromPrimitive/NumCast) was written as bespoke inline tests against one carrier, not the `for_both_carriers` template we use elsewhere.

**What:**
- New `tests/carrier_num_traits.rs` — the `feature = "num-traits"` counterpart to `carrier_generic.rs` (which stays feature-free for the const-only surface, hence a separate file rather than adding num_traits bounds to the ungated one). A `NumCarrier` trait bundles the foundation, one generic body per concern, run for both carriers across three 32-bit backings.
- `num_traits_bridge.rs` inline tests trimmed to only what the fixed-width harness structurally can't reach: `from_u64`'s natural-width construction (heapless-specific) and a wide (>32-bit) multi-limb round-trip that also exercises the >u64-max `Bounded` path.

No production code changes. Harness gates out cleanly with `--no-default-features`; clippy clean.

## Summary by Sourcery

Introduce a shared num_traits test harness for both fixed-width and heapless carriers while trimming heapless-specific inline tests to only cover behavior not exercised by the generic harness.

New Features:
- Add a feature-gated carrier_num_traits test module that validates num_traits foundation (Zero/One/Bounded/ToPrimitive/FromPrimitive/NumCast) across both carriers and multiple 32-bit backings.

Enhancements:
- Refocus heapless num_traits bridge tests on natural-width construction and wide multi-limb round-trip cases that fall outside the fixed-width carrier harness.

Tests:
- Add generic NumCarrier trait and for_both_carriers harness to deduplicate and standardize num_traits coverage for FixedUInt and HeaplessBigInt.
- Remove now-redundant num_traits foundation tests from num_traits_bridge.rs, keeping only heapless-specific behavior checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded numeric trait coverage across supported fixed-width and heapless integer types.
  * Added shared generic assertions covering zero/one and bounded min/max behavior across multiple 32-bit backings.
  * Verified primitive conversion and casting for in-range `u64` values, with rejection for values outside the carrier’s width.
  * Improved wide-value round-trip coverage, including correct handling when the max value cannot fit in `u64`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->