### PR TITLE
CheckedDiv/CheckedRem + saturating family for HeaplessBigInt

### DIFF
--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -226,25 +226,6 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         let (res, borrow) = self.overflowing_sub(other);
         if borrow { None } else { Some(res) }
     }
-
-    /// Saturating addition: on overflow, the all-ones value at the operands'
-    /// width `max(a.len, b.len)` (not the CAP-wide max), matching
-    /// `FixedUInt<T, width>::saturating_add`.
-    pub fn saturating_add(&self, other: &Self) -> Self {
-        let (res, overflow) = self.overflowing_add(other);
-        if overflow { max_at_len(res.len) } else { res }
-    }
-
-    /// Saturating subtraction: clamps to zero at the operands' width on
-    /// underflow.
-    pub fn saturating_sub(&self, other: &Self) -> Self {
-        let (res, borrow) = self.overflowing_sub(other);
-        if borrow {
-            Self::new_zero_with_len(res.len)
-        } else {
-            res
-        }
-    }
 }
 
 // Mul lives in its own impl block because `CarryingMul` is not part of
@@ -290,13 +271,6 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
     pub fn checked_mul(&self, other: &Self) -> Option<Self> {
         let (res, overflow) = self.overflowing_mul(other);
         if overflow { None } else { Some(res) }
-    }
-
-    /// Saturating multiplication: on overflow, the all-ones value at the
-    /// operands' width `max(a.len, b.len)`.
-    pub fn saturating_mul(&self, other: &Self) -> Self {
-        let (res, overflow) = self.overflowing_mul(other);
-        if overflow { max_at_len(res.len) } else { res }
     }
 }
 
@@ -422,6 +396,40 @@ impl<T: MachineWord, const CAP: usize> HeaplessBigInt<T, CAP, Nct> {
     #[inline]
     pub fn trim(self) -> Self {
         trim_content(self)
+    }
+
+    /// Saturating addition: on overflow, the all-ones value at the operands'
+    /// width `max(a.len, b.len)` (not the CAP-wide max), matching
+    /// `FixedUInt<T, width>::saturating_add`. Nct-only: the branch on the
+    /// overflow flag is not constant-time, so `Ct` does not expose it (a
+    /// branchless Ct saturating, like FixedUInt's `const_ct_select`, is not
+    /// yet provided).
+    pub fn saturating_add(&self, other: &Self) -> Self {
+        let (res, overflow) = self.overflowing_add(other);
+        if overflow { max_at_len(res.len) } else { res }
+    }
+
+    /// Saturating subtraction: clamps to zero at the operands' width on
+    /// underflow. Nct-only, same reason as `saturating_add`.
+    pub fn saturating_sub(&self, other: &Self) -> Self {
+        let (res, borrow) = self.overflowing_sub(other);
+        if borrow {
+            Self::new_zero_with_len(res.len)
+        } else {
+            res
+        }
+    }
+}
+
+impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize>
+    HeaplessBigInt<T, CAP, Nct>
+{
+    /// Saturating multiplication: on overflow, the all-ones value at the
+    /// operands' width `max(a.len, b.len)`. Nct-only, same reason as
+    /// `saturating_add`.
+    pub fn saturating_mul(&self, other: &Self) -> Self {
+        let (res, overflow) = self.overflowing_mul(other);
+        if overflow { max_at_len(res.len) } else { res }
     }
 }
 

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -15,9 +15,9 @@
 use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
-    BorrowingSub, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, CheckedSub, Nct,
-    OverflowingAdd, OverflowingMul, OverflowingSub, Personality, PersonalityTag, WrappingAdd,
-    WrappingMul, WrappingSub,
+    BorrowingSub, Bounded, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, CheckedSub, Nct,
+    OverflowingAdd, OverflowingMul, OverflowingSub, Personality, PersonalityTag, SaturatingAdd,
+    SaturatingMul, SaturatingSub, WrappingAdd, WrappingMul, WrappingSub,
 };
 use core::marker::PhantomData;
 
@@ -26,6 +26,25 @@ use core::marker::PhantomData;
 // runs for `Nct` only; the `Ct` arm wraps silently (like `wrapping_*`),
 // keeping control flow value-independent. Mirrors `FixedUInt`'s
 // `maybe_panic_if::<P>`.
+// All-ones value at a given width (`len` limbs saturated). This is the
+// saturation target for add/mul overflow: the max at the *operand* width
+// `max(a.len, b.len)`, matching `FixedUInt<T, width>::max_value()`. It is NOT
+// `Bounded::max_value()`, which on this carrier is the CAP-wide max.
+#[inline]
+fn max_at_len<T: MachineWord, const CAP: usize, P: Personality>(
+    len: u16,
+) -> HeaplessBigInt<T, CAP, P> {
+    let mut limbs = [zero::<T>(); CAP];
+    for l in &mut limbs[..len as usize] {
+        *l = <T as Bounded>::max_value();
+    }
+    HeaplessBigInt {
+        limbs,
+        len,
+        _p: PhantomData,
+    }
+}
+
 #[inline]
 fn panic_on_overflow_if_nct<P: Personality>(overflow: bool, msg: &'static str) {
     match P::TAG {
@@ -207,6 +226,25 @@ impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
         let (res, borrow) = self.overflowing_sub(other);
         if borrow { None } else { Some(res) }
     }
+
+    /// Saturating addition: on overflow, the all-ones value at the operands'
+    /// width `max(a.len, b.len)` (not the CAP-wide max), matching
+    /// `FixedUInt<T, width>::saturating_add`.
+    pub fn saturating_add(&self, other: &Self) -> Self {
+        let (res, overflow) = self.overflowing_add(other);
+        if overflow { max_at_len(res.len) } else { res }
+    }
+
+    /// Saturating subtraction: clamps to zero at the operands' width on
+    /// underflow.
+    pub fn saturating_sub(&self, other: &Self) -> Self {
+        let (res, borrow) = self.overflowing_sub(other);
+        if borrow {
+            Self::new_zero_with_len(res.len)
+        } else {
+            res
+        }
+    }
 }
 
 // Mul lives in its own impl block because `CarryingMul` is not part of
@@ -253,6 +291,13 @@ impl<T: MachineWord + CarryingMul<Unsigned = T, Output = T>, const CAP: usize, P
         let (res, overflow) = self.overflowing_mul(other);
         if overflow { None } else { Some(res) }
     }
+
+    /// Saturating multiplication: on overflow, the all-ones value at the
+    /// operands' width `max(a.len, b.len)`.
+    pub fn saturating_mul(&self, other: &Self) -> Self {
+        let (res, overflow) = self.overflowing_mul(other);
+        if overflow { max_at_len(res.len) } else { res }
+    }
 }
 
 // ── const_num_traits CheckedAdd / CheckedMul (Nct only) ──
@@ -291,6 +336,58 @@ where
     type Output = Self;
     fn checked_sub(self, v: Self) -> Option<Self> {
         Self::checked_sub(&self, &v)
+    }
+}
+
+// ── const_num_traits Saturating{Add,Sub,Mul} (Nct only) ──
+//
+// Same gating as the Checked* trait forms above: the value-form trait
+// delegates to the by-reference inherent method (free, `HeaplessBigInt: Copy`).
+// The saturation target is the operand-width max/zero, not the CAP-wide
+// `Bounded` — see `max_at_len`.
+
+impl<T, const CAP: usize> SaturatingAdd for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = Self;
+    fn saturating_add(self, v: Self) -> Self {
+        Self::saturating_add(&self, &v)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingSub for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = Self;
+    fn saturating_sub(self, v: Self) -> Self {
+        Self::saturating_sub(&self, &v)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingMul for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn saturating_mul(self, v: Self) -> Self {
+        Self::saturating_mul(&self, &v)
+    }
+}
+
+// `num_traits::Saturating` (add/sub only) — deprecated upstream but still
+// required by `num_traits::PrimInt`. Nct-only, matching the trait forms above.
+#[cfg(feature = "num-traits")]
+impl<T, const CAP: usize> num_traits::Saturating for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    fn saturating_add(self, v: Self) -> Self {
+        <Self as SaturatingAdd>::saturating_add(self, v)
+    }
+    fn saturating_sub(self, v: Self) -> Self {
+        <Self as SaturatingSub>::saturating_sub(self, v)
     }
 }
 
@@ -744,4 +841,51 @@ pub(crate) fn zero_tail_ok<T: MachineWord>(limbs: &[T], used: usize) -> bool {
         i += 1;
     }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use const_num_traits::Zero;
+
+    type H = HeaplessBigInt<u32, 8, Nct>; // 256-bit CAP
+
+    #[test]
+    fn saturation_is_operand_width_not_cap() {
+        // Two len-1 (32-bit) values in a CAP-8 carrier: overflow saturates to
+        // the 32-bit operand-width max, NOT the 256-bit CAP max — matching
+        // FixedUInt<u32, 1>. This is what the fixed-width carrier harness can't
+        // reach (its backings have width == CAP).
+        let a = H::from_le_bytes(&0xFFFF_FFFFu32.to_le_bytes()); // len 1
+        let one = H::from_le_bytes(&1u32.to_le_bytes());
+        let s = SaturatingAdd::saturating_add(a, one);
+        assert_eq!(s.len, 1);
+        assert_eq!(s.limbs[0], 0xFFFF_FFFF);
+
+        // 2^16 * 2^16 = 2^32 overflows the 32-bit width; saturates the same way.
+        let big = H::from_le_bytes(&0x1_0000u32.to_le_bytes());
+        let m = SaturatingMul::saturating_mul(big, big);
+        assert_eq!(m.len, 1);
+        assert_eq!(m.limbs[0], 0xFFFF_FFFF);
+    }
+
+    #[test]
+    fn saturating_sub_clamps_to_zero_at_width() {
+        let one = H::from_le_bytes(&1u32.to_le_bytes()); // len 1
+        let two = H::from_le_bytes(&2u32.to_le_bytes());
+        let s = SaturatingSub::saturating_sub(one, two);
+        assert_eq!(s.len, 1);
+        assert!(<H as Zero>::is_zero(&s));
+    }
+
+    #[test]
+    fn checked_div_rem_by_zero_is_none() {
+        let a = H::from_le_bytes(&100u32.to_le_bytes());
+        let z = <H as Zero>::zero();
+        assert_eq!(a.checked_div(&z), None);
+        assert_eq!(a.checked_rem(&z), None);
+        let seven = H::from_le_bytes(&7u32.to_le_bytes());
+        assert_eq!(a.checked_div(&seven).unwrap().limbs[0], 14);
+        assert_eq!(a.checked_rem(&seven).unwrap().limbs[0], 2);
+    }
 }

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -14,7 +14,7 @@
 
 use super::HeaplessBigInt;
 use crate::MachineWord;
-use const_num_traits::{CarryingMul, Nct, One, Zero};
+use const_num_traits::{CarryingMul, CheckedDiv, CheckedRem, Nct, One, Zero};
 
 fn div_rem_impl<T, const CAP: usize>(
     dividend: &HeaplessBigInt<T, CAP, Nct>,
@@ -131,6 +131,78 @@ div_impls!(
     &HeaplessBigInt<T, CAP, Nct>,
     HeaplessBigInt<T, CAP, Nct>
 );
+
+// ── Checked division / remainder ──
+//
+// Nct-only, like `Div`/`Rem`. Return `None` on divide-by-zero instead of the
+// `div_rem_impl` assert; the quotient/remainder is the value-width result the
+// same-width `FixedUInt` gives.
+
+impl<T, const CAP: usize> HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    /// Checked division. `None` on divide-by-zero.
+    pub fn checked_div(&self, other: &Self) -> Option<Self> {
+        if <Self as Zero>::is_zero(other) {
+            None
+        } else {
+            Some(div_rem_impl(self, other).0)
+        }
+    }
+
+    /// Checked remainder. `None` on divide-by-zero.
+    pub fn checked_rem(&self, other: &Self) -> Option<Self> {
+        if <Self as Zero>::is_zero(other) {
+            None
+        } else {
+            Some(div_rem_impl(self, other).1)
+        }
+    }
+}
+
+// Value-form trait bridges to the by-reference inherent methods (free,
+// `HeaplessBigInt: Copy`). Nct-only, matching Div/Rem.
+
+impl<T, const CAP: usize> CheckedDiv for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn checked_div(self, v: Self) -> Option<Self> {
+        Self::checked_div(&self, &v)
+    }
+}
+
+impl<T, const CAP: usize> CheckedRem for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn checked_rem(self, v: Self) -> Option<Self> {
+        Self::checked_rem(&self, &v)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl<T, const CAP: usize> num_traits::CheckedDiv for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn checked_div(&self, v: &Self) -> Option<Self> {
+        Self::checked_div(self, v)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl<T, const CAP: usize> num_traits::CheckedRem for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn checked_rem(&self, v: &Self) -> Option<Self> {
+        Self::checked_rem(self, v)
+    }
+}
 
 // ── DivAssign / RemAssign ──
 //

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -12,8 +12,9 @@
 //! file is only the surface both share.
 
 use const_num_traits::{
-    CarryingMul, CheckedAdd, CheckedMul, CheckedSub, Nct, OverflowingAdd, OverflowingMul,
-    OverflowingSub, Parity, PrimBits, WithPrecision, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    CarryingMul, CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, CheckedSub, Nct, OverflowingAdd,
+    OverflowingMul, OverflowingSub, Parity, PrimBits, SaturatingAdd, SaturatingMul, SaturatingSub,
+    WithPrecision, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
@@ -60,6 +61,11 @@ trait Carrier:
     + CheckedAdd<Output = Self>
     + CheckedSub<Output = Self>
     + CheckedMul<Output = Self>
+    + CheckedDiv<Output = Self>
+    + CheckedRem<Output = Self>
+    + SaturatingAdd<Output = Self>
+    + SaturatingSub<Output = Self>
+    + SaturatingMul<Output = Self>
     + CarryingMul<Unsigned = Self, Output = Self>
     + Not<Output = Self>
     + PrimBits
@@ -369,6 +375,52 @@ fn prim_bits_bit_vocabulary() {
         // complement over the width
         assert_eq!(!C::from_u32(0), C::from_u32(MAX32));
         assert_eq!(!C::from_u32(0x0F0F_0F0F), C::from_u32(0xF0F0_F0F0));
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn saturating() {
+    fn body<C: Carrier>() {
+        let max = C::from_u32(MAX32);
+        let one = C::from_u32(1);
+        // add saturates up to the width max
+        assert_eq!(SaturatingAdd::saturating_add(max, one), max);
+        assert_eq!(
+            SaturatingAdd::saturating_add(C::from_u32(100), C::from_u32(50)),
+            C::from_u32(150)
+        );
+        // sub clamps to zero
+        assert_eq!(
+            SaturatingSub::saturating_sub(one, C::from_u32(2)),
+            C::from_u32(0)
+        );
+        assert_eq!(
+            SaturatingSub::saturating_sub(C::from_u32(500), C::from_u32(200)),
+            C::from_u32(300)
+        );
+        // 2^16 * 2^16 = 2^32 overflows the width → saturates up
+        let x = C::from_u32(0x1_0000);
+        assert_eq!(SaturatingMul::saturating_mul(x, x), max);
+        assert_eq!(
+            SaturatingMul::saturating_mul(C::from_u32(13), C::from_u32(17)),
+            C::from_u32(221)
+        );
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn checked_div_rem() {
+    fn body<C: Carrier>() {
+        let a = C::from_u32(100);
+        let b = C::from_u32(7);
+        assert_eq!(CheckedDiv::checked_div(a, b), Some(C::from_u32(14)));
+        assert_eq!(CheckedRem::checked_rem(a, b), Some(C::from_u32(2)));
+        // divide by zero → None (not a panic)
+        let zero = C::from_u32(0);
+        assert_eq!(CheckedDiv::checked_div(a, zero), None);
+        assert_eq!(CheckedRem::checked_rem(a, zero), None);
     }
     for_both_carriers!(body);
 }

--- a/tests/carrier_num_traits.rs
+++ b/tests/carrier_num_traits.rs
@@ -11,7 +11,9 @@
 
 use const_num_traits::{CarryingMul, Nct, WithPrecision};
 use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
-use num_traits::{Bounded, FromPrimitive, NumCast, One, ToPrimitive, Zero};
+use num_traits::{
+    Bounded, CheckedDiv, CheckedRem, FromPrimitive, NumCast, One, Saturating, ToPrimitive, Zero,
+};
 
 /// The num_traits foundation both carriers implement, pinned to 32 bits.
 trait NumCarrier:
@@ -24,6 +26,9 @@ trait NumCarrier:
     + ToPrimitive
     + FromPrimitive
     + NumCast
+    + Saturating
+    + CheckedDiv
+    + CheckedRem
     + From<u32>
     + WithPrecision
 {
@@ -96,6 +101,27 @@ fn numcast() {
         let a: C = NumCast::from(255u32).unwrap();
         assert_eq!(a.to_u64(), Some(255));
         assert!(<C as NumCast>::from(0x1_0000_0000u64).is_none());
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+#[allow(deprecated)] // num_traits::Saturating is deprecated but PrimInt needs it
+fn saturating_and_checked_div() {
+    fn body<C: NumCarrier>() {
+        let max = C::at32(0xFFFF_FFFF);
+        // num_traits::Saturating (add/sub only)
+        assert_eq!(Saturating::saturating_add(max, C::at32(1)), max);
+        assert_eq!(
+            Saturating::saturating_sub(C::at32(1), C::at32(2)),
+            C::at32(0)
+        );
+        // num_traits::CheckedDiv / CheckedRem, incl. the divide-by-zero None
+        let a = C::at32(100);
+        assert_eq!(CheckedDiv::checked_div(&a, &C::at32(7)), Some(C::at32(14)));
+        assert_eq!(CheckedRem::checked_rem(&a, &C::at32(7)), Some(C::at32(2)));
+        assert_eq!(CheckedDiv::checked_div(&a, &C::at32(0)), None);
+        assert_eq!(CheckedRem::checked_rem(&a, &C::at32(0)), None);
     }
     for_both_carriers!(body);
 }


### PR DESCRIPTION
Next in the parity series. Knocks out **two of the three** remaining `num_traits::PrimInt` blockers (the third is `Num`/`from_str_radix`, coming with the string surface).

**CheckedDiv / CheckedRem** (`div_rem.rs`, Nct — division is Nct-only): return `None` on divide-by-zero instead of the `div_rem_impl` assert, so div-by-zero is finally reachable *without* going through the panicking operator. Inherent `checked_div`/`checked_rem` + const_num_traits + num_traits trait forms.

**Saturating** (`arith.rs`): inherent `saturating_add`/`sub` (P-generic) + `saturating_mul`, const_num_traits `Saturating{Add,Sub,Mul}` (Nct, matching the existing `Checked*` gating), and `num_traits::Saturating` (Nct, needed by PrimInt).

**Correctness note worth a look:** the saturation target is the all-ones value at the **operand** width `max(a.len, b.len)` (via `max_at_len`), *not* `Bounded::max_value()`. FixedUInt uses `Bounded::max_value()` because its width *is* `N`; on heapless `Bounded::max_value()` is the **CAP-wide** max, which would over-saturate a sub-capacity value (e.g. two 32-bit values in a 256-bit carrier must saturate to the 32-bit max, not the 256-bit max). There's a dedicated heapless-internal test for exactly this — the kind of case the fixed-width carrier harness can't reach (its backings have width == CAP).

**Tests:** generic `for_both_carriers` bodies in `carrier_generic.rs` (const traits) and `carrier_num_traits.rs` (num_traits bridges), plus the sub-capacity saturation-width and div-by-zero heapless-internal tests. Verified default / nightly / --no-default-features; clippy clean.

## Summary by Sourcery

Add checked division/remainder and saturating arithmetic support to HeaplessBigInt, aligning its behavior and trait coverage with the fixed-width carrier and num_traits requirements.

New Features:
- Provide inherent checked_div and checked_rem methods on HeaplessBigInt that return None on divide-by-zero.
- Add inherent saturating_add, saturating_sub, and saturating_mul operations on HeaplessBigInt that saturate at the operand width rather than the carrier capacity.
- Expose const_num_traits SaturatingAdd, SaturatingSub, and SaturatingMul implementations for HeaplessBigInt, plus num_traits::Saturating for Nct.
- Implement const_num_traits CheckedDiv and CheckedRem, and num_traits::CheckedDiv/CheckedRem, for HeaplessBigInt in the Nct personality.

Enhancements:
- Introduce an internal max_at_len helper to compute the all-ones value at a given limb width for correct saturation semantics on heapless carriers.

Tests:
- Extend generic carrier tests to cover saturating arithmetic and checked division/remainder across both carriers.
- Add heapless-internal tests to verify operand-width saturation behavior and that checked_div/checked_rem return None on divide-by-zero.
- Add num_traits bridge tests validating Saturating and CheckedDiv/CheckedRem behavior for both carriers.