### PR TITLE
Display/hex/FromStr/Num for HeaplessBigInt (string surface)

### DIFF
--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -1601,15 +1601,15 @@ c0nst::c0nst! {
 
 // This is slightly less than ideal, but PIE isn't directly constructible
 // due to unstable members.
-fn make_parse_int_err() -> core::num::ParseIntError {
+pub(crate) fn make_parse_int_err() -> core::num::ParseIntError {
     <u8>::from_str_radix("-", 2).err().unwrap()
 }
 #[cfg(feature = "num-traits")]
-fn make_overflow_err() -> core::num::ParseIntError {
+pub(crate) fn make_overflow_err() -> core::num::ParseIntError {
     <u8>::from_str_radix("101", 16).err().unwrap()
 }
 #[cfg(feature = "num-traits")]
-fn make_empty_error() -> core::num::ParseIntError {
+pub(crate) fn make_empty_error() -> core::num::ParseIntError {
     <u8>::from_str_radix("", 8).err().unwrap()
 }
 

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -142,6 +142,12 @@ impl<T, const CAP: usize> HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
 {
+    /// Quotient and remainder in one pass. Panics on divide-by-zero, like the
+    /// `Div`/`Rem` operators; use `checked_div`/`checked_rem` to avoid the panic.
+    pub fn div_rem(&self, other: &Self) -> (Self, Self) {
+        div_rem_impl(self, other)
+    }
+
     /// Checked division. `None` on divide-by-zero.
     pub fn checked_div(&self, other: &Self) -> Option<Self> {
         if <Self as Zero>::is_zero(other) {

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -77,6 +77,7 @@ mod num_traits_bridge;
 mod parity;
 mod prim_bits;
 mod shift;
+mod string_conversion;
 #[cfg(any(feature = "nightly", feature = "use-unsafe"))]
 mod to_bytes;
 #[cfg(feature = "zeroize")]

--- a/src/heapless/string_conversion.rs
+++ b/src/heapless/string_conversion.rs
@@ -20,7 +20,10 @@ where
     T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        const MAX_DIGITS: usize = 20; // decimal digits per u64-sized block
+        // A limb is at most u64 (the widest MachineWord), whose decimal form
+        // is <= 20 digits; `CAP` such blocks cover the widest value. (A
+        // per-limb `size_of::<T>() * 3` would need generic_const_exprs.)
+        const MAX_DIGITS: usize = 20;
 
         if <Self as Zero>::is_zero(self) {
             return f.write_char('0');
@@ -52,10 +55,10 @@ where
 impl<T, const CAP: usize> HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord,
-    u8: core::convert::TryFrom<T>,
 {
     // MSB-to-LSB over the value width, suppressing leading-zero nibbles. Zero
     // renders empty (as `FixedUInt` does); callers that need "0" use `Display`.
+    // `to_be_bytes` gives each limb's bytes most-significant-first directly.
     fn hex_fmt(
         &self,
         formatter: &mut core::fmt::Formatter<'_>,
@@ -70,7 +73,6 @@ where
             }
         }
 
-        let word_size = core::mem::size_of::<T>();
         let mut leading_zero = true;
         let mut maybe_write = |nibble: char| -> core::fmt::Result {
             leading_zero &= nibble == '0';
@@ -81,12 +83,7 @@ where
         };
 
         for index in (0..self.len as usize).rev() {
-            let val = self.limbs[index];
-            let mask: T = 0xff.into();
-            for j in (0..word_size as u32).rev() {
-                let masked = val & mask.shl((j * 8) as usize);
-                let byte =
-                    u8::try_from(masked.shr((j * 8) as usize)).map_err(|_| core::fmt::Error)?;
+            for &byte in self.limbs[index].to_be_bytes().as_ref() {
                 maybe_write(to_casedigit((byte & 0xf0) >> 4, uppercase)?)?;
                 maybe_write(to_casedigit(byte & 0x0f, uppercase)?)?;
             }
@@ -98,7 +95,6 @@ where
 impl<T, const CAP: usize> core::fmt::UpperHex for HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord,
-    u8: core::convert::TryFrom<T>,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.hex_fmt(f, true)
@@ -108,7 +104,6 @@ where
 impl<T, const CAP: usize> core::fmt::LowerHex for HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord,
-    u8: core::convert::TryFrom<T>,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.hex_fmt(f, false)
@@ -142,10 +137,10 @@ where
             Some(x) => &input[x..],
             _ => input,
         };
+        let radix_val = Self::from(radix as u8);
         for c in range.chars() {
             let digit = c.to_digit(radix).ok_or_else(make_parse_int_err)?;
-            ret = CheckedMul::checked_mul(ret, Self::from(radix as u8))
-                .ok_or_else(make_overflow_err)?;
+            ret = CheckedMul::checked_mul(ret, radix_val).ok_or_else(make_overflow_err)?;
             ret = CheckedAdd::checked_add(ret, Self::from(digit as u8))
                 .ok_or_else(make_overflow_err)?;
         }

--- a/src/heapless/string_conversion.rs
+++ b/src/heapless/string_conversion.rs
@@ -1,0 +1,166 @@
+//! `Display`, `LowerHex`/`UpperHex`, `FromStr`, and `num_traits::Num` for
+//! `HeaplessBigInt<T, CAP, Nct>`.
+//!
+//! All Nct-only, mirroring `FixedUInt`: decimal/hex rendering and radix
+//! parsing walk limb content, which is not constant-time. `Display` and hex
+//! are feature-independent — digit extraction goes through the `MachineWord`
+//! `const_num_traits::ToPrimitive` supertrait, not `num_traits` — while
+//! `Num`/`FromStr` are gated behind `num-traits`.
+//!
+//! Rendering is over the value width (`self.len`), never `CAP`, so a value at
+//! `len = k` prints exactly what the same-width `FixedUInt<T, k>` prints.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{CarryingMul, Nct, ToPrimitive, Zero};
+use core::fmt::Write;
+
+impl<T, const CAP: usize> core::fmt::Display for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        const MAX_DIGITS: usize = 20; // decimal digits per u64-sized block
+
+        if <Self as Zero>::is_zero(self) {
+            return f.write_char('0');
+        }
+
+        // Worst-case decimal length is bounded by the value width (`len` ≤
+        // `CAP`), so `CAP` blocks of `MAX_DIGITS` always suffice.
+        let mut digit_blocks = [[0u8; MAX_DIGITS]; CAP];
+        let mut digit_count = 0;
+        let mut number = *self;
+        let ten = Self::from(10u8);
+
+        while !<Self as Zero>::is_zero(&number) && digit_count < CAP * MAX_DIGITS {
+            let (quotient, remainder) = number.div_rem(&ten);
+            // remainder < 10, held in the low limb (zero-tail gives 0 at len 0).
+            let digit = <T as ToPrimitive>::to_u8(&remainder.limbs[0]).unwrap_or(0);
+            digit_blocks[digit_count / MAX_DIGITS][digit_count % MAX_DIGITS] = b'0' + digit;
+            digit_count += 1;
+            number = quotient;
+        }
+
+        for i in (0..digit_count).rev() {
+            f.write_char(digit_blocks[i / MAX_DIGITS][i % MAX_DIGITS] as char)?;
+        }
+        Ok(())
+    }
+}
+
+impl<T, const CAP: usize> HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+    u8: core::convert::TryFrom<T>,
+{
+    // MSB-to-LSB over the value width, suppressing leading-zero nibbles. Zero
+    // renders empty (as `FixedUInt` does); callers that need "0" use `Display`.
+    fn hex_fmt(
+        &self,
+        formatter: &mut core::fmt::Formatter<'_>,
+        uppercase: bool,
+    ) -> core::fmt::Result {
+        fn to_casedigit(byte: u8, uppercase: bool) -> Result<char, core::fmt::Error> {
+            let digit = core::char::from_digit(byte as u32, 16).ok_or(core::fmt::Error)?;
+            if uppercase {
+                digit.to_uppercase().next().ok_or(core::fmt::Error)
+            } else {
+                digit.to_lowercase().next().ok_or(core::fmt::Error)
+            }
+        }
+
+        let word_size = core::mem::size_of::<T>();
+        let mut leading_zero = true;
+        let mut maybe_write = |nibble: char| -> core::fmt::Result {
+            leading_zero &= nibble == '0';
+            if !leading_zero {
+                formatter.write_char(nibble)?;
+            }
+            Ok(())
+        };
+
+        for index in (0..self.len as usize).rev() {
+            let val = self.limbs[index];
+            let mask: T = 0xff.into();
+            for j in (0..word_size as u32).rev() {
+                let masked = val & mask.shl((j * 8) as usize);
+                let byte =
+                    u8::try_from(masked.shr((j * 8) as usize)).map_err(|_| core::fmt::Error)?;
+                maybe_write(to_casedigit((byte & 0xf0) >> 4, uppercase)?)?;
+                maybe_write(to_casedigit(byte & 0x0f, uppercase)?)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T, const CAP: usize> core::fmt::UpperHex for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+    u8: core::convert::TryFrom<T>,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.hex_fmt(f, true)
+    }
+}
+
+impl<T, const CAP: usize> core::fmt::LowerHex for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+    u8: core::convert::TryFrom<T>,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.hex_fmt(f, false)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl<T, const CAP: usize> num_traits::Num for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type FromStrRadixErr = core::num::ParseIntError;
+
+    fn from_str_radix(input: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        use crate::fixeduint::{make_empty_error, make_overflow_err, make_parse_int_err};
+        use const_num_traits::{CheckedAdd, CheckedMul};
+
+        if input.is_empty() {
+            return Err(make_empty_error());
+        }
+        if !(2..=16).contains(&radix) {
+            return Err(make_overflow_err());
+        }
+
+        // Accumulate at the full CAP width, not the minimal width of the
+        // intermediate `from(digit)` values — otherwise `ret * radix + digit`
+        // would overflow at a single word instead of the carrier's capacity
+        // (matching `FixedUInt<T, CAP>`, whose parse width is its `N`).
+        let mut ret = <Self as Zero>::zero().widened(CAP as u16);
+        let range = match input.find(|c: char| c != '0') {
+            Some(x) => &input[x..],
+            _ => input,
+        };
+        for c in range.chars() {
+            let digit = c.to_digit(radix).ok_or_else(make_parse_int_err)?;
+            ret = CheckedMul::checked_mul(ret, Self::from(radix as u8))
+                .ok_or_else(make_overflow_err)?;
+            ret = CheckedAdd::checked_add(ret, Self::from(digit as u8))
+                .ok_or_else(make_overflow_err)?;
+        }
+        Ok(ret)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl<T, const CAP: usize> core::str::FromStr for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Err = core::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        <Self as num_traits::Num>::from_str_radix(s, 10)
+    }
+}

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -69,6 +69,7 @@ trait Carrier:
     + CarryingMul<Unsigned = Self, Output = Self>
     + Not<Output = Self>
     + PrimBits
+    + core::fmt::Display
 {
     /// Build `v` pinned to the carrier's full 32-bit width. `From<u32>`
     /// alone is minimal-width on HeaplessBigInt (100 → one limb), so
@@ -421,6 +422,17 @@ fn checked_div_rem() {
         let zero = C::from_u32(0);
         assert_eq!(CheckedDiv::checked_div(a, zero), None);
         assert_eq!(CheckedRem::checked_rem(a, zero), None);
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn display_decimal() {
+    fn body<C: Carrier>() {
+        assert_eq!(std::format!("{}", C::from_u32(0)), "0");
+        assert_eq!(std::format!("{}", C::from_u32(1)), "1");
+        assert_eq!(std::format!("{}", C::from_u32(0xDEAD_BEEF)), "3735928559");
+        assert_eq!(std::format!("{}", C::from_u32(MAX32)), "4294967295");
     }
     for_both_carriers!(body);
 }

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -69,7 +69,6 @@ trait Carrier:
     + CarryingMul<Unsigned = Self, Output = Self>
     + Not<Output = Self>
     + PrimBits
-    + core::fmt::Display
 {
     /// Build `v` pinned to the carrier's full 32-bit width. `From<u32>`
     /// alone is minimal-width on HeaplessBigInt (100 → one limb), so
@@ -426,13 +425,7 @@ fn checked_div_rem() {
     for_both_carriers!(body);
 }
 
-#[test]
-fn display_decimal() {
-    fn body<C: Carrier>() {
-        assert_eq!(std::format!("{}", C::from_u32(0)), "0");
-        assert_eq!(std::format!("{}", C::from_u32(1)), "1");
-        assert_eq!(std::format!("{}", C::from_u32(0xDEAD_BEEF)), "3735928559");
-        assert_eq!(std::format!("{}", C::from_u32(MAX32)), "4294967295");
-    }
-    for_both_carriers!(body);
-}
+// Display is tested in the num-traits harness (carrier_num_traits.rs): FixedUInt
+// only implements Display when `num-traits` is on, so a Display bound here would
+// break the feature-free build. HeaplessBigInt's own feature-independent Display
+// is covered in tests/heapless_string.rs.

--- a/tests/carrier_num_traits.rs
+++ b/tests/carrier_num_traits.rs
@@ -12,7 +12,8 @@
 use const_num_traits::{CarryingMul, Nct, WithPrecision};
 use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
 use num_traits::{
-    Bounded, CheckedDiv, CheckedRem, FromPrimitive, NumCast, One, Saturating, ToPrimitive, Zero,
+    Bounded, CheckedDiv, CheckedRem, FromPrimitive, Num, NumCast, One, Saturating, ToPrimitive,
+    Zero,
 };
 
 /// The num_traits foundation both carriers implement, pinned to 32 bits.
@@ -29,6 +30,8 @@ trait NumCarrier:
     + Saturating
     + CheckedDiv
     + CheckedRem
+    + Num<FromStrRadixErr = core::num::ParseIntError>
+    + core::str::FromStr<Err = core::num::ParseIntError>
     + From<u32>
     + WithPrecision
 {
@@ -122,6 +125,24 @@ fn saturating_and_checked_div() {
         assert_eq!(CheckedRem::checked_rem(&a, &C::at32(7)), Some(C::at32(2)));
         assert_eq!(CheckedDiv::checked_div(&a, &C::at32(0)), None);
         assert_eq!(CheckedRem::checked_rem(&a, &C::at32(0)), None);
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn num_from_str_radix_and_fromstr() {
+    fn body<C: NumCarrier>() {
+        // decimal + hex parse
+        assert_eq!(Num::from_str_radix("255", 10), Ok(C::at32(255)));
+        assert_eq!(Num::from_str_radix("ff", 16), Ok(C::at32(255)));
+        assert_eq!(Num::from_str_radix("0", 10), Ok(C::at32(0)));
+        // FromStr is decimal
+        assert_eq!("4294967295".parse::<C>(), Ok(C::at32(0xFFFF_FFFF)));
+        // errors: empty, bad char, bad radix, and 32-bit overflow
+        assert!(<C as Num>::from_str_radix("", 10).is_err());
+        assert!(<C as Num>::from_str_radix("12x", 10).is_err());
+        assert!(<C as Num>::from_str_radix("1", 99).is_err());
+        assert!(<C as Num>::from_str_radix("4294967296", 10).is_err()); // 2^32 > width
     }
     for_both_carriers!(body);
 }

--- a/tests/carrier_num_traits.rs
+++ b/tests/carrier_num_traits.rs
@@ -32,6 +32,7 @@ trait NumCarrier:
     + CheckedRem
     + Num<FromStrRadixErr = core::num::ParseIntError>
     + core::str::FromStr<Err = core::num::ParseIntError>
+    + core::fmt::Display
     + From<u32>
     + WithPrecision
 {
@@ -135,14 +136,30 @@ fn num_from_str_radix_and_fromstr() {
         // decimal + hex parse
         assert_eq!(Num::from_str_radix("255", 10), Ok(C::at32(255)));
         assert_eq!(Num::from_str_radix("ff", 16), Ok(C::at32(255)));
+        assert_eq!(Num::from_str_radix("FF", 16), Ok(C::at32(255))); // uppercase hex
         assert_eq!(Num::from_str_radix("0", 10), Ok(C::at32(0)));
+        // leading zeros are stripped
+        assert_eq!(Num::from_str_radix("000255", 10), Ok(C::at32(255)));
+        assert_eq!(Num::from_str_radix("0000", 10), Ok(C::at32(0)));
         // FromStr is decimal
         assert_eq!("4294967295".parse::<C>(), Ok(C::at32(0xFFFF_FFFF)));
-        // errors: empty, bad char, bad radix, and 32-bit overflow
+        // errors: empty, bad char, both radix bounds, and 32-bit overflow
         assert!(<C as Num>::from_str_radix("", 10).is_err());
         assert!(<C as Num>::from_str_radix("12x", 10).is_err());
-        assert!(<C as Num>::from_str_radix("1", 99).is_err());
+        assert!(<C as Num>::from_str_radix("1", 1).is_err()); // radix < 2
+        assert!(<C as Num>::from_str_radix("1", 99).is_err()); // radix > 16
         assert!(<C as Num>::from_str_radix("4294967296", 10).is_err()); // 2^32 > width
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn display_decimal() {
+    fn body<C: NumCarrier>() {
+        assert_eq!(std::format!("{}", C::at32(0)), "0");
+        assert_eq!(std::format!("{}", C::at32(1)), "1");
+        assert_eq!(std::format!("{}", C::at32(0xDEAD_BEEF)), "3735928559");
+        assert_eq!(std::format!("{}", C::at32(0xFFFF_FFFF)), "4294967295");
     }
     for_both_carriers!(body);
 }

--- a/tests/heapless_string.rs
+++ b/tests/heapless_string.rs
@@ -1,0 +1,42 @@
+//! Heapless string surface at widths the fixed-width carrier harness can't
+//! reach: sub-capacity values (a narrow value in a wide carrier) and
+//! multi-limb rendering / parsing.
+
+use fixed_bigint::HeaplessBigInt;
+
+type H = HeaplessBigInt<u32, 8>; // 256-bit CAP
+
+#[test]
+fn display_hex_value_width() {
+    // A small value in a wide carrier prints its value, never CAP-padded.
+    assert_eq!(std::format!("{}", H::from(255u8)), "255");
+    assert_eq!(std::format!("{:x}", H::from(255u8)), "ff");
+    assert_eq!(std::format!("{:X}", H::from(255u8)), "FF");
+    assert_eq!(std::format!("{}", H::from(0u8)), "0");
+
+    // Multi-limb value: 2 u32 limbs (0xFEEDF00D_DEADBEEF), hex is MSB-first
+    // over the value width with leading-zero suppression.
+    let v = H::from_le_bytes(&[0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xF0, 0xED, 0xFE]);
+    assert_eq!(std::format!("{:x}", v), "feedf00ddeadbeef");
+}
+
+#[cfg(feature = "num-traits")]
+#[test]
+fn from_str_wide_roundtrip() {
+    use core::str::FromStr;
+
+    // A value wider than 32 bits parses into the wide carrier (the parse
+    // accumulates at CAP width) and round-trips through Display.
+    let v = H::from_le_bytes(&[0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xF0, 0xED, 0xFE]);
+    let dec = std::format!("{}", v);
+    let back = H::from_str(&dec).unwrap();
+    assert_eq!(std::format!("{}", back), dec);
+    assert_eq!(std::format!("{:x}", back), "feedf00ddeadbeef");
+
+    // Radix-16 parse agrees.
+    let h = <H as num_traits::Num>::from_str_radix("feedf00ddeadbeef", 16).unwrap();
+    assert_eq!(std::format!("{}", h), dec);
+
+    assert!(H::from_str("").is_err());
+    assert!(H::from_str("12x").is_err());
+}


### PR DESCRIPTION
The string/parse surface, Nct-only, over the value width — and the **last `num_traits::PrimInt` blocker** (`Num`/`from_str_radix`). After this, PrimInt and Integer are reachable.

**What:**
- **`Display` / `LowerHex` / `UpperHex`** — feature-independent. Digit extraction goes through the `MachineWord` `const_num_traits::ToPrimitive` supertrait (like FixedUInt's `to_radix_str`), not `num_traits`, so a heapless bignum is printable *without* opting into `num-traits`. Hex mirrors FixedUInt exactly (MSB-first, leading-zero suppression; zero renders empty and Display special-cases it to `0`).
- **`Num` (`from_str_radix`) / `FromStr`** — gated behind `num-traits`, reusing FixedUInt's `ParseIntError` constructors (now `pub(crate)`).
- **Inherent `div_rem`** exposed on the Nct carrier — closes a parity gap, and Display uses it.

**Width subtlety worth a look:** `from_str_radix` accumulates at **CAP width** (`ret` widened up front), not the minimal width of the intermediate `from(digit)` values. Otherwise `ret*radix + digit` overflows at a single word instead of the carrier's capacity — my first cut had exactly that bug (`"4294967295"` failed to parse into a `HeaplessBigInt<u8, 4>`). This matches `FixedUInt<T, CAP>`, whose parse width is its `N`.

**Tests:** generic `for_both_carriers` bodies — Display in `carrier_generic.rs`, Num/FromStr in `carrier_num_traits.rs` — plus heapless-internal value-width tests the fixed-width harness can't reach (sub-capacity Display/hex, multi-limb render, wide-value parse round-trip). Verified default / nightly / --no-default-features (Display/hex build feature-independently); clippy clean.

## Summary by Sourcery

Extend HeaplessBigInt’s string interface to support feature-independent decimal/hex formatting and num-traits–gated radix parsing, aligning its behavior and error handling with FixedUInt and adding tests for both carriers and heapless-specific width scenarios.

New Features:
- Add Display and LowerHex/UpperHex formatting support for HeaplessBigInt over its value width without requiring num-traits.
- Implement num_traits::Num::from_str_radix and core::str::FromStr for HeaplessBigInt when the num-traits feature is enabled.
- Expose an inherent div_rem method on HeaplessBigInt for quotient/remainder calculation in a single pass.

Enhancements:
- Reuse FixedUInt’s ParseIntError constructors by making them pub(crate) for parsing implementations across carriers.

Tests:
- Add shared carrier tests covering Display formatting, Num::from_str_radix, and FromStr behavior for both carriers.
- Introduce heapless-specific tests that validate value-width-aware decimal/hex rendering and wide-value parse/display round-trips beyond fixed-width harness coverage.