### PR TITLE
Complete num_traits::PrimInt for HeaplessBigInt (+ pow family)

### DIFF
--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -313,6 +313,42 @@ where
     }
 }
 
+// ── num_traits Checked{Add,Sub,Mul} (Nct only) ──
+//
+// The `num_traits::PrimInt` supertraits, bridging its by-reference receiver to
+// the inherent by-reference method (same values as the const_num_traits forms
+// above; different crate and receiver shape).
+
+#[cfg(feature = "num-traits")]
+impl<T, const CAP: usize> num_traits::CheckedAdd for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    fn checked_add(&self, v: &Self) -> Option<Self> {
+        Self::checked_add(self, v)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl<T, const CAP: usize> num_traits::CheckedSub for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    fn checked_sub(&self, v: &Self) -> Option<Self> {
+        Self::checked_sub(self, v)
+    }
+}
+
+#[cfg(feature = "num-traits")]
+impl<T, const CAP: usize> num_traits::CheckedMul for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn checked_mul(&self, v: &Self) -> Option<Self> {
+        Self::checked_mul(self, v)
+    }
+}
+
 // ── const_num_traits Saturating{Add,Sub,Mul} (Nct only) ──
 //
 // Same gating as the Checked* trait forms above: the value-form trait

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -74,7 +74,10 @@ mod identities;
 #[cfg(feature = "num-traits")]
 mod num_traits_bridge;
 mod parity;
+mod pow;
 mod prim_bits;
+#[cfg(feature = "num-traits")]
+mod prim_int;
 mod shift;
 mod string_conversion;
 #[cfg(any(feature = "nightly", feature = "use-unsafe"))]

--- a/src/heapless/pow.rs
+++ b/src/heapless/pow.rs
@@ -1,0 +1,113 @@
+//! `pow` for `HeaplessBigInt<T, CAP, Nct>`: the inherent method plus the
+//! `const_num_traits::CheckedPow` / `StrictPow` parallels.
+//!
+//! All Nct-only, mirroring `FixedUInt`. Exponentiation is by squaring at the
+//! value width (`max(a.len, b.len)` per multiply), so a value at `len = k`
+//! raises exactly like `FixedUInt<T, k>`. `pow_impl` is the shared kernel; the
+//! num_traits::PrimInt bridge reuses it too.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{CarryingMul, CheckedMul, CheckedPow, Nct, One, StrictPow};
+
+/// Square-and-multiply with the panicking Nct `Mul`, so it panics on overflow
+/// at the value width — like `FixedUInt`'s `pow_impl` and std's `pow`.
+pub(crate) fn pow_impl<T, const CAP: usize>(
+    base: HeaplessBigInt<T, CAP, Nct>,
+    exp: u32,
+) -> HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    let mut result = <HeaplessBigInt<T, CAP, Nct> as One>::one();
+    let mut b = base;
+    let mut e = exp;
+    while e > 0 {
+        if e & 1 == 1 {
+            result *= b;
+        }
+        e >>= 1;
+        if e > 0 {
+            b *= b;
+        }
+    }
+    result
+}
+
+impl<T, const CAP: usize> HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    /// Raises `self` to `exp` by squaring. Panics on overflow at the value
+    /// width (Nct), like std's `pow`; use `checked_pow` to get `None` instead.
+    pub fn pow(self, exp: u32) -> Self {
+        pow_impl(self, exp)
+    }
+}
+
+impl<T, const CAP: usize> CheckedPow for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn checked_pow(self, exp: u32) -> Option<Self> {
+        let mut result = <Self as One>::one();
+        let mut base = self;
+        let mut e = exp;
+        while e > 0 {
+            if e & 1 == 1 {
+                result = CheckedMul::checked_mul(result, base)?;
+            }
+            e >>= 1;
+            if e > 0 {
+                base = CheckedMul::checked_mul(base, base)?;
+            }
+        }
+        Some(result)
+    }
+}
+
+impl<T, const CAP: usize> StrictPow for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn strict_pow(self, exp: u32) -> Self {
+        match <Self as CheckedPow>::checked_pow(self, exp) {
+            Some(v) => v,
+            None => panic!("HeaplessBigInt: strict_pow overflowed"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FixedUInt;
+
+    type H = HeaplessBigInt<u32, 8, Nct>; // 256-bit CAP
+
+    #[test]
+    fn pow_value_width_and_overflow() {
+        let base = H::from_le_bytes(&2u32.to_le_bytes()); // len 1 (32-bit)
+        // 2^10 = 1024, still at the operand width (len 1), not CAP.
+        let r = base.pow(10);
+        assert_eq!(r.len, 1);
+        assert_eq!(r.limbs[0], 1024);
+        assert_eq!(base.pow(0).limbs[0], 1); // x^0 = 1
+        // 2^32 overflows the 32-bit width → None, matching FixedUInt<u32, 1>.
+        assert_eq!(CheckedPow::checked_pow(base, 32), None);
+        assert_eq!(
+            CheckedPow::checked_pow(FixedUInt::<u32, 1, Nct>::from(2u8), 32),
+            None
+        );
+        assert_eq!(StrictPow::strict_pow(base, 10).limbs[0], 1024);
+    }
+
+    #[test]
+    #[should_panic(expected = "strict_pow overflowed")]
+    fn strict_pow_panics_on_overflow() {
+        let base = H::from_le_bytes(&2u32.to_le_bytes());
+        let _ = StrictPow::strict_pow(base, 32);
+    }
+}

--- a/src/heapless/pow.rs
+++ b/src/heapless/pow.rs
@@ -19,7 +19,11 @@ pub(crate) fn pow_impl<T, const CAP: usize>(
 where
     T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
 {
-    let mut result = <HeaplessBigInt<T, CAP, Nct> as One>::one();
+    // x^0 is 1 at the operand's width (`base.len`), matching FixedUInt<k>;
+    // widen the identity so the `exp == 0` early path doesn't return a narrow
+    // (len-1) value. For `exp > 0` the first multiply would widen it anyway.
+    let mut result =
+        <HeaplessBigInt<T, CAP, Nct> as One>::one().widened(core::cmp::max(1, base.len));
     let mut b = base;
     let mut e = exp;
     while e > 0 {
@@ -51,7 +55,7 @@ where
 {
     type Output = Self;
     fn checked_pow(self, exp: u32) -> Option<Self> {
-        let mut result = <Self as One>::one();
+        let mut result = <Self as One>::one().widened(core::cmp::max(1, self.len));
         let mut base = self;
         let mut e = exp;
         while e > 0 {
@@ -94,7 +98,11 @@ mod tests {
         let r = base.pow(10);
         assert_eq!(r.len, 1);
         assert_eq!(r.limbs[0], 1024);
-        assert_eq!(base.pow(0).limbs[0], 1); // x^0 = 1
+        // x^0 = 1 at the operand width, not a narrowed len-1 value.
+        assert_eq!(base.pow(0).len, 1);
+        let base2 = base.widened(2);
+        assert_eq!(base2.pow(0).len, 2);
+        assert_eq!(base2.pow(0).limbs[0], 1);
         // 2^32 overflows the 32-bit width → None, matching FixedUInt<u32, 1>.
         assert_eq!(CheckedPow::checked_pow(base, 32), None);
         assert_eq!(

--- a/src/heapless/prim_int.rs
+++ b/src/heapless/prim_int.rs
@@ -1,0 +1,72 @@
+//! `num_traits::PrimInt` for `HeaplessBigInt<T, CAP, Nct>`.
+//!
+//! A thin bridge: the bit-operation methods delegate to the already-implemented
+//! `const_num_traits::PrimBits`, and `pow` to the shared `pow_impl`. Nct-only
+//! (PrimInt supertrait-bundles `Num`, which is Nct on this carrier);
+//! `reverse_bits`/`leading_ones`/`trailing_ones` use the trait defaults, same
+//! as `FixedUInt`.
+
+use super::HeaplessBigInt;
+use super::pow::pow_impl;
+use crate::MachineWord;
+use const_num_traits::{CarryingMul, Nct, PrimBits};
+
+impl<T, const CAP: usize> num_traits::PrimInt for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn count_ones(self) -> u32 {
+        PrimBits::count_ones(self)
+    }
+    fn count_zeros(self) -> u32 {
+        PrimBits::count_zeros(self)
+    }
+    fn leading_zeros(self) -> u32 {
+        PrimBits::leading_zeros(self)
+    }
+    fn trailing_zeros(self) -> u32 {
+        PrimBits::trailing_zeros(self)
+    }
+    fn rotate_left(self, n: u32) -> Self {
+        PrimBits::rotate_left(self, n)
+    }
+    fn rotate_right(self, n: u32) -> Self {
+        PrimBits::rotate_right(self, n)
+    }
+    fn signed_shl(self, n: u32) -> Self {
+        PrimBits::signed_shl(self, n)
+    }
+    fn signed_shr(self, n: u32) -> Self {
+        PrimBits::signed_shr(self, n)
+    }
+    fn unsigned_shl(self, n: u32) -> Self {
+        PrimBits::unsigned_shl(self, n)
+    }
+    fn unsigned_shr(self, n: u32) -> Self {
+        PrimBits::unsigned_shr(self, n)
+    }
+    fn swap_bytes(self) -> Self {
+        PrimBits::swap_bytes(self)
+    }
+    // Override the num_traits default: it reverses via shifts, and heapless's
+    // `Shr` narrows `len`, so the default collapses to zero. PrimBits does it
+    // limb-wise at the value width.
+    fn reverse_bits(self) -> Self {
+        PrimBits::reverse_bits(self)
+    }
+    fn from_be(x: Self) -> Self {
+        PrimBits::from_be(x)
+    }
+    fn from_le(x: Self) -> Self {
+        PrimBits::from_le(x)
+    }
+    fn to_be(self) -> Self {
+        PrimBits::to_be(self)
+    }
+    fn to_le(self) -> Self {
+        PrimBits::to_le(self)
+    }
+    fn pow(self, exp: u32) -> Self {
+        pow_impl(self, exp)
+    }
+}

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -12,9 +12,9 @@
 //! file is only the surface both share.
 
 use const_num_traits::{
-    CarryingMul, CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, CheckedSub, Nct, OverflowingAdd,
-    OverflowingMul, OverflowingSub, Parity, PrimBits, SaturatingAdd, SaturatingMul, SaturatingSub,
-    WithPrecision, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    CarryingMul, CheckedAdd, CheckedDiv, CheckedMul, CheckedPow, CheckedRem, CheckedSub, Nct,
+    OverflowingAdd, OverflowingMul, OverflowingSub, Parity, PrimBits, SaturatingAdd, SaturatingMul,
+    SaturatingSub, StrictPow, WithPrecision, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
@@ -69,6 +69,8 @@ trait Carrier:
     + CarryingMul<Unsigned = Self, Output = Self>
     + Not<Output = Self>
     + PrimBits
+    + CheckedPow<Output = Self>
+    + StrictPow<Output = Self>
 {
     /// Build `v` pinned to the carrier's full 32-bit width. `From<u32>`
     /// alone is minimal-width on HeaplessBigInt (100 → one limb), so
@@ -429,3 +431,30 @@ fn checked_div_rem() {
 // only implements Display when `num-traits` is on, so a Display bound here would
 // break the feature-free build. HeaplessBigInt's own feature-independent Display
 // is covered in tests/heapless_string.rs.
+
+#[test]
+fn pow() {
+    fn body<C: Carrier>() {
+        assert_eq!(
+            CheckedPow::checked_pow(C::from_u32(2), 10),
+            Some(C::from_u32(1024))
+        );
+        assert_eq!(
+            CheckedPow::checked_pow(C::from_u32(3), 0),
+            Some(C::from_u32(1))
+        ); // x^0 = 1
+        assert_eq!(
+            CheckedPow::checked_pow(C::from_u32(5), 1),
+            Some(C::from_u32(5))
+        );
+        assert_eq!(
+            CheckedPow::checked_pow(C::from_u32(7), 3),
+            Some(C::from_u32(343))
+        );
+        // 2^32 overflows the 32-bit width → None.
+        assert_eq!(CheckedPow::checked_pow(C::from_u32(2), 32), None);
+        // strict_pow returns the value when it fits.
+        assert_eq!(StrictPow::strict_pow(C::from_u32(2), 10), C::from_u32(1024));
+    }
+    for_both_carriers!(body);
+}

--- a/tests/carrier_num_traits.rs
+++ b/tests/carrier_num_traits.rs
@@ -12,8 +12,8 @@
 use const_num_traits::{CarryingMul, Nct, WithPrecision};
 use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
 use num_traits::{
-    Bounded, CheckedDiv, CheckedRem, FromPrimitive, Num, NumCast, One, Saturating, ToPrimitive,
-    Zero,
+    Bounded, CheckedDiv, CheckedRem, FromPrimitive, Num, NumCast, One, PrimInt, Saturating,
+    ToPrimitive, Zero,
 };
 
 /// The num_traits foundation both carriers implement, pinned to 32 bits.
@@ -33,6 +33,7 @@ trait NumCarrier:
     + Num<FromStrRadixErr = core::num::ParseIntError>
     + core::str::FromStr<Err = core::num::ParseIntError>
     + core::fmt::Display
+    + PrimInt
     + From<u32>
     + WithPrecision
 {
@@ -160,6 +161,26 @@ fn display_decimal() {
         assert_eq!(std::format!("{}", C::at32(1)), "1");
         assert_eq!(std::format!("{}", C::at32(0xDEAD_BEEF)), "3735928559");
         assert_eq!(std::format!("{}", C::at32(0xFFFF_FFFF)), "4294967295");
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn prim_int() {
+    fn body<C: NumCarrier>() {
+        // Delegates to PrimBits; pow to the shared kernel. reverse_bits uses
+        // the num_traits default (as FixedUInt does) — verify it here too.
+        assert_eq!(PrimInt::count_ones(C::at32(0b1011)), 3);
+        assert_eq!(PrimInt::leading_zeros(C::at32(1)), 31);
+        assert_eq!(PrimInt::trailing_zeros(C::at32(0b1000)), 3);
+        assert_eq!(PrimInt::rotate_left(C::at32(1), 4), C::at32(16));
+        assert_eq!(
+            PrimInt::swap_bytes(C::at32(0x0000_00FF)),
+            C::at32(0xFF00_0000)
+        );
+        assert_eq!(PrimInt::reverse_bits(C::at32(1)), C::at32(0x8000_0000));
+        assert_eq!(PrimInt::pow(C::at32(2), 10), C::at32(1024));
+        assert_eq!(PrimInt::pow(C::at32(7), 3), C::at32(343));
     }
     for_both_carriers!(body);
 }

--- a/tests/carrier_num_traits.rs
+++ b/tests/carrier_num_traits.rs
@@ -181,6 +181,18 @@ fn prim_int() {
         assert_eq!(PrimInt::reverse_bits(C::at32(1)), C::at32(0x8000_0000));
         assert_eq!(PrimInt::pow(C::at32(2), 10), C::at32(1024));
         assert_eq!(PrimInt::pow(C::at32(7), 3), C::at32(343));
+
+        // Shifts (delegated via PrimBits): unsigned == signed for the unsigned
+        // carrier, and both stay fixed-width.
+        assert_eq!(PrimInt::unsigned_shl(C::at32(1), 31), C::at32(0x8000_0000));
+        assert_eq!(PrimInt::unsigned_shr(C::at32(0x8000_0000), 31), C::at32(1));
+        assert_eq!(PrimInt::signed_shl(C::at32(1), 31), C::at32(0x8000_0000));
+        assert_eq!(PrimInt::signed_shr(C::at32(0x8000_0000), 31), C::at32(1));
+
+        // Endianness conversions round-trip.
+        let v = C::at32(0x1234_5678);
+        assert_eq!(PrimInt::from_be(PrimInt::to_be(v)), v);
+        assert_eq!(PrimInt::from_le(PrimInt::to_le(v)), v);
     }
     for_both_carriers!(body);
 }


### PR DESCRIPTION
Finishes the num_traits story: a `HeaplessBigInt<_, Nct>` is now a drop-in `num_traits::PrimInt`. Includes the const-num-traits parallels and shares code with what's already there.

**What:**
- **`pow`** (`pow.rs`): inherent `pow` (square-and-multiply via the panicking Nct `Mul`, so it panics on overflow like std) built on a shared `pow_impl` kernel, plus `const_num_traits::CheckedPow` (None on overflow) and `StrictPow` (panics).
- **`num_traits::PrimInt`** (`prim_int.rs`, Nct): a *thin bridge* — every bit-op delegates to `const_num_traits::PrimBits` and `pow` to `pow_impl`, so no logic is duplicated. (This is the "share code where possible" part: PrimInt reuses PrimBits rather than reimplementing count/scan/rotate/shift as FixedUInt does.)
- **`num_traits` `CheckedAdd`/`CheckedSub`/`CheckedMul`** (`arith.rs`, Nct): PrimInt supertraits that heapless had only in the const-num-traits form — a gap PrimInt exposed.

**Two things worth a look:**
1. **`reverse_bits` override.** The `num_traits::PrimInt` *default* `reverse_bits` reverses via shifts; heapless's `Shr` narrows `len`, so the default collapses to zero. FixedUInt's default happens to work (width-preserving shifts), heapless's doesn't — the generic parity test caught it. Overridden to `PrimBits::reverse_bits`.
2. **Value-width throughout.** `pow` at `len = k` raises exactly like `FixedUInt<k>`; overflow is at the operand width, not CAP. Dedicated heapless-internal test for the sub-capacity case.

**Tests:** generic `for_both_carriers` bodies — pow in `carrier_generic.rs`, PrimInt in `carrier_num_traits.rs` — plus heapless-internal pow value-width / overflow-None / strict-panic. Verified default / nightly / --no-default-features; clippy clean.

Leaves `num_integer::Integer` (gcd/lcm/…) as the remaining Tier-1 item.

## Summary by Sourcery

Implement full num_traits::PrimInt and pow support for HeaplessBigInt with the Nct carrier, aligned with existing const_num_traits behavior and value-width semantics.

New Features:
- Add inherent pow, const_num_traits::CheckedPow, and const_num_traits::StrictPow implementations for HeaplessBigInt using a shared exponentiation kernel.
- Provide a num_traits::PrimInt implementation for HeaplessBigInt (Nct) that bridges to existing PrimBits and shared pow logic.
- Expose num_traits::CheckedAdd, CheckedSub, and CheckedMul for HeaplessBigInt (Nct) to satisfy PrimInt supertraits.

Bug Fixes:
- Override PrimInt::reverse_bits for HeaplessBigInt to avoid incorrect results caused by width-narrowing shifts in the default implementation.

Tests:
- Extend generic carrier tests to cover CheckedPow/StrictPow behavior and value-width overflow semantics for pow.
- Add num_traits-focused tests validating PrimInt behavior for both FixedUInt and HeaplessBigInt carriers, including reverse_bits and pow.