### PR TITLE
Align BitAnd to max(len) — width-preservation audit fix

### DIFF
--- a/src/heapless/bitwise.rs
+++ b/src/heapless/bitwise.rs
@@ -168,21 +168,24 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitAndAssign<&HeaplessBig
     for HeaplessBigInt<T, CAP, P>
 {
     fn bitand_assign(&mut self, other: &Self) {
-        // Result width is `max(len)` (operand width). AND the overlap; every
-        // limb above `min` ANDs with a zero-tail (whichever operand is shorter),
-        // so it becomes zero.
+        // Result width is `max(len)` (operand width). AND the overlap, then
+        // clear `self`'s own limbs above it — they AND with `other`'s zero-tail,
+        // so they go to zero. When `other` is the wider operand `[min..self.len]`
+        // is empty: `self`'s high limbs are already zero, and the wider result
+        // width is reached just by bumping `len`.
         let min_len = core::cmp::min(self.len, other.len) as usize;
-        let max_len = core::cmp::max(self.len, other.len) as usize;
+        let self_len = self.len as usize;
+        let max_len = core::cmp::max(self.len, other.len);
         for (si, &oi) in self.limbs[..min_len]
             .iter_mut()
             .zip(&other.limbs[..min_len])
         {
             *si &= oi;
         }
-        for si in &mut self.limbs[min_len..max_len] {
+        for si in &mut self.limbs[min_len..self_len] {
             *si = zero::<T>();
         }
-        self.len = max_len as u16;
+        self.len = max_len;
     }
 }
 

--- a/src/heapless/bitwise.rs
+++ b/src/heapless/bitwise.rs
@@ -1,17 +1,17 @@
 //! `BitAnd` / `BitOr` / `BitXor` for `HeaplessBigInt` (all four receiver
 //! forms each), plus the compound-assign forms.
 //!
-//! Limb-wise, width-based, `CAP` never enters:
-//! - `BitAnd` → `len = min(a.len, b.len)`: at or above that bound one
-//!   operand is in its zero-tail, so the AND is zero — `min` is
-//!   value-tight and satisfies the zero-tail invariant.
-//! - `BitOr` / `BitXor` → `len = max(a.len, b.len)`: they leave a bit set
-//!   wherever exactly one operand has it, so the result spans the wider
-//!   operand; the shorter operand's zero-tail leaves the wider operand's
-//!   limbs unchanged there.
+//! All three resolve at `len = max(a.len, b.len)` — the same operand-width
+//! rule as the arithmetic ops, so every binary op hands back one consistent
+//! width. `CAP` never enters. Above `min(len)` the shorter operand is in its
+//! zero-tail, so `AND` yields zero there while `OR` / `XOR` leave the wider
+//! operand's limbs unchanged; the result is value-correct at the wider width.
+//! (`AND` could store the value in `min(len)` — its high limbs are zero — but
+//! a narrower result than the sibling ops would desync widths for a following
+//! width-sensitive op such as `Not` / `count_zeros`.)
 //!
-//! Both lens are public shape parameters, so the body is identical for
-//! Nct and Ct. The compound-assign forms delegate to the binary op.
+//! `len` is a public shape parameter, so the body is identical for Nct and
+//! Ct. The compound-assign forms delegate to (or mirror) the binary op.
 
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
@@ -54,7 +54,10 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitAnd<&HeaplessBigInt<T,
 {
     type Output = HeaplessBigInt<T, CAP, P>;
     fn bitand(self, other: &HeaplessBigInt<T, CAP, P>) -> Self::Output {
-        let out_len = core::cmp::min(self.len, other.len);
+        // Operand width, like every other binary op. Above `min(len)` one
+        // operand's zero-tail forces the AND to zero, so the extra high limbs
+        // stay zero — value-correct at the wider width.
+        let out_len = core::cmp::max(self.len, other.len);
         let n = out_len as usize;
         let mut limbs = [zero::<T>(); CAP];
         for ((&ai, &bi), oi) in self.limbs[..n]
@@ -165,20 +168,21 @@ impl<T: MachineWord, const CAP: usize, P: Personality> BitAndAssign<&HeaplessBig
     for HeaplessBigInt<T, CAP, P>
 {
     fn bitand_assign(&mut self, other: &Self) {
-        // Result width is `min(len)`: AND the overlap, then clear `self`'s
-        // limbs above `min` (they AND with `other`'s zero-tail = 0).
+        // Result width is `max(len)` (operand width). AND the overlap; every
+        // limb above `min` ANDs with a zero-tail (whichever operand is shorter),
+        // so it becomes zero.
         let min_len = core::cmp::min(self.len, other.len) as usize;
-        let self_len = self.len as usize;
+        let max_len = core::cmp::max(self.len, other.len) as usize;
         for (si, &oi) in self.limbs[..min_len]
             .iter_mut()
             .zip(&other.limbs[..min_len])
         {
             *si &= oi;
         }
-        for si in &mut self.limbs[min_len..self_len] {
+        for si in &mut self.limbs[min_len..max_len] {
             *si = zero::<T>();
         }
-        self.len = min_len as u16;
+        self.len = max_len as u16;
     }
 }
 

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -33,8 +33,7 @@
 //! | `Shr` (`>>`) | `self.len` minus the whole-word shift |
 //! | `WideMul` / [`CarryingMul`](const_num_traits::CarryingMul) | `lo` and `hi` each `max(a.len, b.len)`; reconstruct `hi·2^(W·word_bits) + lo` |
 //! | `Div` (`/`), `Rem` (`%`) | `max(dividend.len, divisor.len)` |
-//! | `BitAnd` (`&`) | `min(a.len, b.len)` |
-//! | `BitOr` | `max(a.len, b.len)` |
+//! | `BitAnd` (`&`), `BitOr`, `BitXor` | `max(a.len, b.len)` |
 //! | [`widened`](HeaplessBigInt::widened) / `WithPrecision` | the requested width (grow-only) |
 //!
 //! ## Construction & serialization widths

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1334,13 +1334,27 @@ fn bitand_masks_bits() {
 }
 
 #[test]
-fn bitand_output_len_is_min_of_operand_lens() {
-    // a spans 3 limbs, mask spans 1 → result can only have limb 0 set.
+fn bitand_output_len_is_max_of_operand_lens() {
+    // a spans 3 limbs, mask spans 1. AND masks to limb 0, but the result
+    // resolves at the wider operand width like every other binary op — the
+    // high limbs are zero (masked against the shorter operand's zero-tail).
     let a = H4u32Nct::from_limbs([0xFFFF_FFFF, 0xFFFF_FFFF, 0xFFFF_FFFF, 0], 3);
     let mask: H4u32Nct = 0x0000_00FFu32.into(); // len 1
     let out = &a & &mask;
-    assert_eq!(out.len(), 1);
+    assert_eq!(out.len(), 3);
     assert_eq!(out.limbs()[0], 0x0000_00FF);
+    assert_eq!(out.limbs()[1], 0);
+    assert_eq!(out.limbs()[2], 0);
+
+    // The compound-assign form agrees, in both operand orders.
+    let mut x = a;
+    x &= mask;
+    assert_eq!(x.len(), 3);
+    assert_eq!(x.limbs()[0], 0x0000_00FF);
+    let mut y = mask;
+    y &= a;
+    assert_eq!(y.len(), 3);
+    assert_eq!(y.limbs()[0], 0x0000_00FF);
 }
 
 #[test]
@@ -1364,12 +1378,16 @@ fn bitand_all_receiver_forms_agree() {
 
 #[test]
 fn bitand_with_full_width_mask() {
-    // Masking a short value by a full-CAP all-ones mask returns the value.
+    // Masking a short value by a full-CAP all-ones mask returns the value at
+    // the wider (mask) width — high limbs zero.
     let v: H4u32Nct = 0x1234_5678u32.into(); // len 1
     let mask = H4u32Nct::from_limbs([u32::MAX; 4], 4);
     let out = v & mask;
+    assert_eq!(out.len(), 4);
     assert_eq!(out.limbs()[0], 0x1234_5678);
-    assert_eq!(out.len(), 1);
+    assert_eq!(out.limbs()[1], 0);
+    assert_eq!(out.limbs()[2], 0);
+    assert_eq!(out.limbs()[3], 0);
 }
 
 // ── BitOr ──
@@ -1742,15 +1760,16 @@ fn bitxor_and_bitwise_assign_ops() {
 
 #[test]
 fn bitwise_assign_ops_cross_width() {
-    // The in-place assigns must reshape `len` like the binary ops:
-    // `&=` shrinks to min, `|=`/`^=` grow to max.
+    // The in-place assigns reshape `len` like the binary ops — all resolve at
+    // max(len), including `&=` (its high limbs mask to zero).
     let wide = H4u32Nct::from_limbs([0xFFFF_FFFF, 0xFFFF_FFFF, 0, 0], 2);
     let narrow = H4u32Nct::from_limbs([0x0F0F_0F0F, 0, 0, 0], 1);
 
     let mut a = wide;
     a &= narrow;
-    assert_eq!(a.len(), 1);
+    assert_eq!(a.len(), 2);
     assert_eq!(a.limbs()[0], 0x0F0F_0F0F);
+    assert_eq!(a.limbs()[1], 0);
 
     let mut b = narrow;
     b |= wide;

--- a/tests/heapless_basic.rs
+++ b/tests/heapless_basic.rs
@@ -1346,6 +1346,13 @@ fn bitand_output_len_is_max_of_operand_lens() {
     assert_eq!(out.limbs()[1], 0);
     assert_eq!(out.limbs()[2], 0);
 
+    // Narrow value on the left resolves at the same wider width.
+    let out2 = &mask & &a;
+    assert_eq!(out2.len(), 3);
+    assert_eq!(out2.limbs()[0], 0x0000_00FF);
+    assert_eq!(out2.limbs()[1], 0);
+    assert_eq!(out2.limbs()[2], 0);
+
     // The compound-assign form agrees, in both operand orders.
     let mut x = a;
     x &= mask;


### PR DESCRIPTION
Outcome of a width-preservation audit that swept every value-returning HeaplessBigInt op for the "correct value, wrong `len`" class — bugs that value-based `PartialEq` (which zero-extends the shorter operand) waves straight through, and that only bite when a later width-sensitive op runs on the result.

**The audit found one real inconsistency:** `BitAnd`/`BitAndAssign` resolved at `min(a.len, b.len)` while every other binary op — `add`/`sub`/`mul`, `BitOr`, `BitXor`, `div`/`rem` — uses `max(len)`. It was documented as deliberate ("value-tight"), and for equal-width operands `min == max` so no test caught it. But for mixed widths, AND handed back a narrower result than its siblings, so `!(a & b)` / `count_zeros` / `swap_bytes` on the result would see a different width. Above `min(len)` the shorter operand's zero-tail forces the AND to zero, so widening to `max` is **value-identical** — just at the consistent operand width.

Changed `BitAnd`/`BitAndAssign` to `max(len)`, updated the module width-contract docs, and updated the three tests that pinned the old `min` behavior (now asserting the wider `len` with zeroed high limbs, both operand orders).

**The rest of the audit came back clean:** all prior width-calibration fixes are intact (`unsigned_shr` restores `len`, `pow` widens the `exp==0` identity, saturating uses operand-width not CAP), and `cios_accumulator` already overrides the CIOS trait default specifically to preserve operand width. Full findings summarized in the commit.

Verified default / nightly / --no-default-features; clippy clean.

## Summary by Sourcery

Align HeaplessBigInt bitwise AND behavior and its documentation/tests with the max operand-width convention used by other binary operations.

Bug Fixes:
- Fix BitAnd and BitAndAssign to preserve operand width by returning results at max(a.len, b.len) instead of min(a.len, b.len).

Documentation:
- Update HeaplessBigInt width-contract documentation to state that BitAnd, BitOr, and BitXor all resolve at max(a.len, b.len).

Tests:
- Adjust and extend bitwise AND tests to assert the widened output length, zeroed high limbs, and consistent behavior across binary and compound-assign forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected big-integer bitwise AND operations to preserve the wider operand’s result width.
  * Updated in-place AND operations to retain the maximum operand width while clearing non-overlapping higher bits.
  * Ensured full-width masks produce correctly sized results with zeroed higher limbs.

* **Tests**
  * Expanded coverage for cross-width AND operations and operand-order scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->