### PR TITLE
Implement num_integer::Integer for HeaplessBigInt

### DIFF
--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -72,6 +72,8 @@ mod from_prim;
 mod has_personality;
 mod identities;
 #[cfg(feature = "num-traits")]
+mod num_integer_impl;
+#[cfg(feature = "num-traits")]
 mod num_traits_bridge;
 mod parity;
 mod pow;

--- a/src/heapless/num_integer_impl.rs
+++ b/src/heapless/num_integer_impl.rs
@@ -1,0 +1,117 @@
+//! `num_integer::Integer` for `HeaplessBigInt<T, CAP, Nct>`.
+//!
+//! Nct-only, mirroring `FixedUInt`. `div_floor`/`mod_floor`/`div_rem` are the
+//! unsigned div/rem (floor == truncating); `gcd` is Stein's binary algorithm;
+//! `lcm` = `a / gcd(a, b) * b`. `is_even`/`is_odd` delegate to the O(1)
+//! `Parity` LSB check. Everything resolves at the operand width `max(len)`.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{CarryingMul, Nct, One, PrimBits, Zero};
+
+impl<T, const CAP: usize> num_integer::Integer for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn div_floor(&self, other: &Self) -> Self {
+        *self / *other
+    }
+
+    fn mod_floor(&self, other: &Self) -> Self {
+        *self % *other
+    }
+
+    fn gcd(&self, other: &Self) -> Self {
+        // Stein's (binary) GCD. Heapless `>>` narrows `len`, so the running
+        // values shrink as they're stripped of factors of two — that's
+        // value-correct (comparisons are value-based). The result is pinned to
+        // the operand width `max(len)`: widen before the final `<< shift` so no
+        // bit is lost and the width matches FixedUInt<k>.
+        let width = core::cmp::max(self.len(), other.len());
+        let mut m = *self;
+        let mut n = *other;
+        let zero = <Self as Zero>::zero();
+        if m == zero || n == zero {
+            return m | n; // already at max(len) via BitOr
+        }
+
+        // Common factors of two, then strip each value to odd.
+        let shift = PrimBits::trailing_zeros(m | n);
+        m = m >> (PrimBits::trailing_zeros(m) as usize);
+        n = n >> (PrimBits::trailing_zeros(n) as usize);
+
+        while m != n {
+            if m > n {
+                m -= n;
+                m = m >> (PrimBits::trailing_zeros(m) as usize);
+            } else {
+                n -= m;
+                n = n >> (PrimBits::trailing_zeros(n) as usize);
+            }
+        }
+        m.widened(width) << (shift as usize)
+    }
+
+    fn lcm(&self, other: &Self) -> Self {
+        if <Self as Zero>::is_zero(self) && <Self as Zero>::is_zero(other) {
+            return <Self as Zero>::zero();
+        }
+        let gcd = self.gcd(other);
+        *self * (*other / gcd)
+    }
+
+    fn divides(&self, other: &Self) -> bool {
+        self.is_multiple_of(other)
+    }
+
+    fn is_multiple_of(&self, other: &Self) -> bool {
+        *self % *other == <Self as Zero>::zero()
+    }
+
+    fn is_even(&self) -> bool {
+        // O(1) LSB check, like FixedUInt. `len == 0` (zero) is even; otherwise
+        // `len > 0` guarantees `limbs[0]` exists.
+        self.len == 0 || self.limbs[0] & <T as One>::one() == <T as Zero>::zero()
+    }
+
+    fn is_odd(&self) -> bool {
+        !self.is_even()
+    }
+
+    fn div_rem(&self, other: &Self) -> (Self, Self) {
+        // Inherent div_rem (single pass); resolves over `&self`, so it's the
+        // inherent method, not this trait one.
+        self.div_rem(other)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_integer::Integer;
+
+    type H = HeaplessBigInt<u32, 8, Nct>; // 256-bit CAP
+
+    #[test]
+    fn gcd_preserves_operand_width() {
+        // Two len-2 (64-bit) values in a CAP-8 carrier. Stein's `>>` narrows
+        // the running values, but the result is pinned to the operand width
+        // (len 2), not the narrow gcd magnitude — matching FixedUInt<u32, 2>.
+        let a = H::from_le_bytes(&12u64.to_le_bytes()); // len 2
+        let b = H::from_le_bytes(&18u64.to_le_bytes()); // len 2
+        let g = a.gcd(&b);
+        assert_eq!(g.len(), 2, "gcd resolves at the operand width");
+        assert_eq!(g.limbs[0], 6);
+        assert_eq!(g.limbs[1], 0);
+    }
+
+    #[test]
+    fn gcd_lcm_multi_limb() {
+        // 64-bit powers of two spanning 2 u32 limbs.
+        let a = H::from_le_bytes(&0x1_0000_0000u64.to_le_bytes()); // 2^32
+        let b = H::from_le_bytes(&0x1_8000_0000u64.to_le_bytes()); // 3·2^31
+        assert_eq!(a.gcd(&b), H::from_le_bytes(&0x8000_0000u64.to_le_bytes())); // 2^31
+        // lcm(2^32, 3·2^31) = 3·2^32
+        assert_eq!(a.lcm(&b), H::from_le_bytes(&0x3_0000_0000u64.to_le_bytes()));
+    }
+}

--- a/src/heapless/num_integer_impl.rs
+++ b/src/heapless/num_integer_impl.rs
@@ -54,17 +54,19 @@ where
 
     fn lcm(&self, other: &Self) -> Self {
         if <Self as Zero>::is_zero(self) && <Self as Zero>::is_zero(other) {
-            return <Self as Zero>::zero();
+            // Zero at the operand width, not the minimal-width `zero()`.
+            return <Self as Zero>::zero().widened(core::cmp::max(self.len(), other.len()));
         }
         let gcd = self.gcd(other);
         *self * (*other / gcd)
     }
 
-    fn divides(&self, other: &Self) -> bool {
-        self.is_multiple_of(other)
-    }
-
     fn is_multiple_of(&self, other: &Self) -> bool {
+        // Guard the zero divisor (as num_integer's primitive impls do): 0 is a
+        // multiple of 0, nothing else is — no `% 0` panic.
+        if <Self as Zero>::is_zero(other) {
+            return <Self as Zero>::is_zero(self);
+        }
         *self % *other == <Self as Zero>::zero()
     }
 
@@ -113,5 +115,22 @@ mod tests {
         assert_eq!(a.gcd(&b), H::from_le_bytes(&0x8000_0000u64.to_le_bytes())); // 2^31
         // lcm(2^32, 3·2^31) = 3·2^32
         assert_eq!(a.lcm(&b), H::from_le_bytes(&0x3_0000_0000u64.to_le_bytes()));
+    }
+
+    #[test]
+    fn is_multiple_of_zero_divisor_no_panic() {
+        // num_integer contract: is_multiple_of(&0) is a predicate, not a panic.
+        let zero = H::from_le_bytes(&0u32.to_le_bytes());
+        let five = H::from_le_bytes(&5u32.to_le_bytes());
+        assert!(zero.is_multiple_of(&zero)); // 0 is a multiple of 0
+        assert!(!five.is_multiple_of(&zero)); // 5 is not
+    }
+
+    #[test]
+    fn lcm_of_zeros_keeps_operand_width() {
+        // lcm(0, 0) = 0 at the operand width, not the minimal len-0 zero.
+        let z = H::from_le_bytes(&0u64.to_le_bytes()); // len 2 (8 zero bytes)
+        assert_eq!(z.len(), 2);
+        assert_eq!(z.lcm(&z).len(), 2);
     }
 }

--- a/tests/carrier_num_traits.rs
+++ b/tests/carrier_num_traits.rs
@@ -34,6 +34,7 @@ trait NumCarrier:
     + core::str::FromStr<Err = core::num::ParseIntError>
     + core::fmt::Display
     + PrimInt
+    + num_integer::Integer
     + From<u32>
     + WithPrecision
 {
@@ -193,6 +194,30 @@ fn prim_int() {
         let v = C::at32(0x1234_5678);
         assert_eq!(PrimInt::from_be(PrimInt::to_be(v)), v);
         assert_eq!(PrimInt::from_le(PrimInt::to_le(v)), v);
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn integer_gcd_lcm() {
+    fn body<C: NumCarrier>() {
+        // Integer methods come in via the NumCarrier: Integer bound.
+        // gcd / lcm
+        assert_eq!(C::at32(12).gcd(&C::at32(18)), C::at32(6));
+        assert_eq!(C::at32(12).lcm(&C::at32(18)), C::at32(36));
+        assert_eq!(C::at32(17).gcd(&C::at32(5)), C::at32(1)); // coprime
+        assert_eq!(C::at32(0).gcd(&C::at32(9)), C::at32(9)); // gcd(0, x) = x
+        assert_eq!(C::at32(0).lcm(&C::at32(0)), C::at32(0));
+        // div_floor / mod_floor / div_rem (unsigned: floor == truncating)
+        assert_eq!(C::at32(17).div_floor(&C::at32(5)), C::at32(3));
+        assert_eq!(C::at32(17).mod_floor(&C::at32(5)), C::at32(2));
+        assert_eq!(C::at32(17).div_rem(&C::at32(5)), (C::at32(3), C::at32(2)));
+        // divisibility / parity
+        assert!(C::at32(12).is_multiple_of(&C::at32(4)));
+        assert!(!C::at32(13).is_multiple_of(&C::at32(4)));
+        assert!(C::at32(12).is_even());
+        assert!(C::at32(13).is_odd());
+        assert!(C::at32(0).is_even());
     }
     for_both_carriers!(body);
 }


### PR DESCRIPTION
The **last Tier-1 parity item** — with this, a `HeaplessBigInt<_, Nct>` is a drop-in `num_traits::PrimInt` **and** `num_integer::Integer`.

Nct-only, mirroring FixedUInt: `gcd`/`lcm`/`div_floor`/`mod_floor`/`divides`/`is_multiple_of`/`is_even`/`is_odd`/`div_rem`.

- **div_floor / mod_floor / div_rem** — the unsigned div/rem (floor == truncating), over the inherent `div_rem`.
- **gcd** — Stein's binary algorithm. Heapless `>>` narrows `len`, so the running values shrink as factors of two are stripped — that's value-correct (comparisons are value-based). **The result is pinned to the operand width `max(len)`: the value is widened before the final `<< shift` so no bit is lost and the width matches `FixedUInt<k>`.** (Straight port of FixedUInt's fixed-width `m << shift` would have narrowed here — a dedicated heapless-internal test covers the sub-capacity case.)
- **lcm** = `a / gcd(a, b) * b`; **is_even/is_odd** — O(1) LSB check like FixedUInt.

**Tests:** generic `for_both_carriers` body (gcd/lcm/div_floor/mod_floor/div_rem/is_multiple_of/parity, incl. coprime and `gcd(0,x)`) plus heapless-internal gcd width-preservation (len 2 in a CAP-8 carrier) and multi-limb gcd/lcm. Verified default / nightly / --no-default-features; clippy clean.

Tier-1 parity is complete. What's left is the optional Tier-3 conveniences (isqrt/ilog/Euclid/abs_diff/Sum-Product/etc.) and the deferred crate-wide signed_shr fix.

## Summary by Sourcery

Implement num_integer::Integer for heapless big integers and verify Tier-1 parity via shared carrier tests.

New Features:
- Support num_integer::Integer for HeaplessBigInt Nct carriers, including gcd, lcm, floor division, modulus, divisibility, parity, and div_rem methods.

Tests:
- Extend NumCarrier tests to cover Integer methods across both carriers, including gcd/lcm edge cases, div_floor/mod_floor/div_rem, divisibility, and parity.
- Add heapless-specific tests to ensure gcd preserves operand width and handles multi-limb values correctly.