### PR TITLE
Tier-3 batch 1: Euclid, AbsDiff, Midpoint, From<u64>

### DIFF
--- a/src/heapless/abs_diff.rs
+++ b/src/heapless/abs_diff.rs
@@ -1,0 +1,23 @@
+//! `const_num_traits::AbsDiff` for `HeaplessBigInt<_, Nct>`.
+//!
+//! `|a - b|` = the larger minus the smaller. Nct-only: the branch on the
+//! comparison isn't constant-time (FixedUInt's Ct arm uses a branchless
+//! select; heapless keeps its Ct trait surface minimal).
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{AbsDiff, Nct};
+
+impl<T, const CAP: usize> AbsDiff for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = Self;
+    fn abs_diff(self, other: Self) -> Self {
+        if self >= other {
+            self - other
+        } else {
+            other - self
+        }
+    }
+}

--- a/src/heapless/euclid.rs
+++ b/src/heapless/euclid.rs
@@ -27,22 +27,16 @@ impl<T, const CAP: usize> CheckedEuclid for HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
 {
+    // Unsigned Euclidean == ordinary; delegate to the inherent checked div/rem
+    // so the zero-divisor guard lives in one tested place.
     fn checked_div_euclid(self, v: Self) -> Option<Self> {
-        if <Self as Zero>::is_zero(&v) {
-            None
-        } else {
-            Some(self / v)
-        }
+        self.checked_div(&v)
     }
     fn checked_rem_euclid(self, v: Self) -> Option<Self> {
-        if <Self as Zero>::is_zero(&v) {
-            None
-        } else {
-            Some(self % v)
-        }
+        self.checked_rem(&v)
     }
     fn checked_div_rem_euclid(self, v: Self) -> Option<(Self, Self)> {
-        if <Self as Zero>::is_zero(&v) {
+        if v.is_zero() {
             None
         } else {
             Some(self.div_rem(&v))

--- a/src/heapless/euclid.rs
+++ b/src/heapless/euclid.rs
@@ -1,0 +1,51 @@
+//! `const_num_traits::Euclid` / `CheckedEuclid` for `HeaplessBigInt<_, Nct>`.
+//!
+//! Unsigned: Euclidean div/rem are ordinary div/rem. Nct-only, like the
+//! division they build on; `checked_*` return `None` on a zero divisor.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{CarryingMul, CheckedEuclid, Euclid, Nct, Zero};
+
+impl<T, const CAP: usize> Euclid for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn div_euclid(self, v: Self) -> Self {
+        self / v
+    }
+    fn rem_euclid(self, v: Self) -> Self {
+        self % v
+    }
+    fn div_rem_euclid(self, v: Self) -> (Self, Self) {
+        self.div_rem(&v)
+    }
+}
+
+impl<T, const CAP: usize> CheckedEuclid for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn checked_div_euclid(self, v: Self) -> Option<Self> {
+        if <Self as Zero>::is_zero(&v) {
+            None
+        } else {
+            Some(self / v)
+        }
+    }
+    fn checked_rem_euclid(self, v: Self) -> Option<Self> {
+        if <Self as Zero>::is_zero(&v) {
+            None
+        } else {
+            Some(self % v)
+        }
+    }
+    fn checked_div_rem_euclid(self, v: Self) -> Option<(Self, Self)> {
+        if <Self as Zero>::is_zero(&v) {
+            None
+        } else {
+            Some(self.div_rem(&v))
+        }
+    }
+}

--- a/src/heapless/from_prim.rs
+++ b/src/heapless/from_prim.rs
@@ -26,4 +26,18 @@ macro_rules! from_primitive {
     )+ };
 }
 
-from_primitive!(u8, u16, u32);
+from_primitive!(u8, u16, u32, u64);
+
+#[cfg(test)]
+mod tests {
+    use super::HeaplessBigInt;
+
+    #[test]
+    fn from_u64_source_width() {
+        // From<u64> constructs at the source-int width (8 bytes → 2 u32 limbs).
+        let v: HeaplessBigInt<u32, 8> = 0x1234_5678_9ABCu64.into();
+        assert_eq!(v.len(), 2);
+        assert_eq!(v.limbs()[0], 0x5678_9ABC);
+        assert_eq!(v.limbs()[1], 0x0000_1234);
+    }
+}

--- a/src/heapless/midpoint.rs
+++ b/src/heapless/midpoint.rs
@@ -1,0 +1,20 @@
+//! `const_num_traits::Midpoint` for `HeaplessBigInt`.
+//!
+//! `(a & b) + ((a ^ b) >> 1)` averages without overflow, and is branchless, so
+//! it is personality-generic and constant-time. The `>> 1` is a single-bit
+//! shift (width-preserving), and `&`/`^`/`+` all resolve at `max(len)`, so the
+//! result is at the operand width.
+
+use super::HeaplessBigInt;
+use crate::MachineWord;
+use const_num_traits::{Midpoint, Personality};
+
+impl<T, const CAP: usize, P: Personality> Midpoint for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    type Output = Self;
+    fn midpoint(self, rhs: Self) -> Self {
+        (self & rhs) + ((self ^ rhs) >> 1usize)
+    }
+}

--- a/src/heapless/mod.rs
+++ b/src/heapless/mod.rs
@@ -44,7 +44,7 @@
 //!
 //! | path | width |
 //! |---|---|
-//! | `From<u8/u16/u32>` | `ceil(size_of::<uN>() / word)` — the source int's width |
+//! | `From<u8/u16/u32/u64>` | `ceil(size_of::<uN>() / word)` — the source int's width |
 //! | inherent [`from_le_bytes`](HeaplessBigInt::from_le_bytes) / `from_be_bytes(&[u8])` | `ceil(slice.len() / word)` — the slice width |
 //! | [`new_zero_with_len`](HeaplessBigInt::new_zero_with_len) / [`from_limbs`](HeaplessBigInt::from_limbs) | exactly the given `len` |
 //! | `FromBytes` **trait** (`BytesHolder<T, CAP>`) | **`CAP`** — an owned holder can't be runtime-sized |
@@ -60,6 +60,7 @@ use crate::MachineWord;
 use const_num_traits::{Ct, Nct, Personality};
 use core::marker::PhantomData;
 
+mod abs_diff;
 mod arith;
 mod bits;
 mod bitwise;
@@ -68,9 +69,11 @@ mod bytes;
 mod cios;
 mod cmp;
 mod div_rem;
+mod euclid;
 mod from_prim;
 mod has_personality;
 mod identities;
+mod midpoint;
 #[cfg(feature = "num-traits")]
 mod num_integer_impl;
 #[cfg(feature = "num-traits")]

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -488,6 +488,19 @@ fn euclid_absdiff_midpoint() {
             CheckedEuclid::checked_div_euclid(C::from_u32(17), C::from_u32(0)),
             None
         );
+        assert_eq!(
+            CheckedEuclid::checked_rem_euclid(C::from_u32(17), C::from_u32(0)),
+            None
+        );
+        // checked_div_rem_euclid carries its own zero guard — pin both paths.
+        assert_eq!(
+            CheckedEuclid::checked_div_rem_euclid(C::from_u32(17), C::from_u32(5)),
+            Some((C::from_u32(3), C::from_u32(2)))
+        );
+        assert_eq!(
+            CheckedEuclid::checked_div_rem_euclid(C::from_u32(17), C::from_u32(0)),
+            None
+        );
 
         // abs_diff, both orders.
         assert_eq!(

--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -12,9 +12,10 @@
 //! file is only the surface both share.
 
 use const_num_traits::{
-    CarryingMul, CheckedAdd, CheckedDiv, CheckedMul, CheckedPow, CheckedRem, CheckedSub, Nct,
-    OverflowingAdd, OverflowingMul, OverflowingSub, Parity, PrimBits, SaturatingAdd, SaturatingMul,
-    SaturatingSub, StrictPow, WithPrecision, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    AbsDiff, CarryingMul, CheckedAdd, CheckedDiv, CheckedEuclid, CheckedMul, CheckedPow,
+    CheckedRem, CheckedSub, Euclid, Midpoint, Nct, OverflowingAdd, OverflowingMul, OverflowingSub,
+    Parity, PrimBits, SaturatingAdd, SaturatingMul, SaturatingSub, StrictPow, WithPrecision,
+    WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use core::ops::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Div, DivAssign,
@@ -71,6 +72,10 @@ trait Carrier:
     + PrimBits
     + CheckedPow<Output = Self>
     + StrictPow<Output = Self>
+    + Euclid<Output = Self>
+    + CheckedEuclid
+    + AbsDiff<Output = Self>
+    + Midpoint<Output = Self>
 {
     /// Build `v` pinned to the carrier's full 32-bit width. `From<u32>`
     /// alone is minimal-width on HeaplessBigInt (100 → one limb), so
@@ -455,6 +460,52 @@ fn pow() {
         assert_eq!(CheckedPow::checked_pow(C::from_u32(2), 32), None);
         // strict_pow returns the value when it fits.
         assert_eq!(StrictPow::strict_pow(C::from_u32(2), 10), C::from_u32(1024));
+    }
+    for_both_carriers!(body);
+}
+
+#[test]
+fn euclid_absdiff_midpoint() {
+    fn body<C: Carrier>() {
+        // Euclid: unsigned, so == ordinary div/rem.
+        assert_eq!(
+            Euclid::div_euclid(C::from_u32(17), C::from_u32(5)),
+            C::from_u32(3)
+        );
+        assert_eq!(
+            Euclid::rem_euclid(C::from_u32(17), C::from_u32(5)),
+            C::from_u32(2)
+        );
+        assert_eq!(
+            Euclid::div_rem_euclid(C::from_u32(17), C::from_u32(5)),
+            (C::from_u32(3), C::from_u32(2))
+        );
+        assert_eq!(
+            CheckedEuclid::checked_rem_euclid(C::from_u32(17), C::from_u32(5)),
+            Some(C::from_u32(2))
+        );
+        assert_eq!(
+            CheckedEuclid::checked_div_euclid(C::from_u32(17), C::from_u32(0)),
+            None
+        );
+
+        // abs_diff, both orders.
+        assert_eq!(
+            AbsDiff::abs_diff(C::from_u32(10), C::from_u32(3)),
+            C::from_u32(7)
+        );
+        assert_eq!(
+            AbsDiff::abs_diff(C::from_u32(3), C::from_u32(10)),
+            C::from_u32(7)
+        );
+
+        // midpoint averages without overflow.
+        assert_eq!(
+            Midpoint::midpoint(C::from_u32(10), C::from_u32(20)),
+            C::from_u32(15)
+        );
+        let max = C::from_u32(MAX32);
+        assert_eq!(Midpoint::midpoint(max, max), max); // (max + max) / 2 = max
     }
     for_both_carriers!(body);
 }


### PR DESCRIPTION
First batch of the Tier-3 convenience polish, mirroring FixedUInt.

- **Euclid / CheckedEuclid** (Nct) — unsigned Euclidean div/rem is ordinary div/rem; `checked_*` return `None` on a zero divisor.
- **AbsDiff** (Nct) — `|a - b|` = larger − smaller. Nct-only: the compare-branch isn't constant-time (FixedUInt's Ct arm uses a branchless select; heapless keeps its Ct trait surface minimal, same as saturating).
- **Midpoint** (personality-generic) — `(a & b) + ((a ^ b) >> 1)`, branchless (so CT-safe) and width-preserving (single-bit shift keeps `len`; `&`/`^`/`+` resolve at `max(len)`).
- **From<u64>** — extend the `from_primitive` macro; source-int width like the others.

Tests: generic `for_both_carriers` body (Euclid/abs_diff/midpoint, incl. the midpoint no-overflow `max` case) plus a `From<u64>` source-width check. Verified default / nightly / --no-default-features; clippy clean.

First of a few Tier-3 batches — power-of-two/multiples, roots/logs, and iterators/bytes/CtParity follow.

## Summary by Sourcery

Add Euclid, AbsDiff, and Midpoint trait support for heapless big integers and extend primitive conversions to include u64, with corresponding tests and documentation updates.

New Features:
- Implement Euclid and CheckedEuclid for HeaplessBigInt in the non-constant-time personality.
- Implement AbsDiff for HeaplessBigInt in the non-constant-time personality.
- Implement personality-generic Midpoint for HeaplessBigInt.
- Extend HeaplessBigInt From<uN> support to include u64, preserving source integer width.

Documentation:
- Update heapless module documentation to describe From<u8/u16/u32/u64> behavior and source-int width semantics.

Tests:
- Add generic carrier tests covering Euclid, CheckedEuclid, AbsDiff, and Midpoint behavior, including midpoint no-overflow max case.
- Add a HeaplessBigInt From<u64> test verifying limb count and layout for source-width construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Euclidean division, remainder, checked arithmetic, absolute difference, and midpoint operations for heapless big integers.
  * Added support for constructing heapless big integers from `u64` values.

* **Bug Fixes**
  * Checked Euclidean operations now safely return no result when dividing by zero.

* **Tests**
  * Added coverage for the new arithmetic operations and `u64` conversions across supported integer types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->