### PR TITLE
Add DivCeil, CtIsPowerOfTwo, and the Unsigned marker to HeaplessBigInt

### DIFF
--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -14,7 +14,7 @@
 
 use super::HeaplessBigInt;
 use crate::MachineWord;
-use const_num_traits::{CarryingMul, CheckedDiv, CheckedRem, Nct, One, Zero};
+use const_num_traits::{CarryingMul, CheckedAdd, CheckedDiv, CheckedRem, DivCeil, Nct, One, Zero};
 
 fn div_rem_impl<T, const CAP: usize>(
     dividend: &HeaplessBigInt<T, CAP, Nct>,
@@ -165,6 +165,20 @@ where
             Some(div_rem_impl(self, other).1)
         }
     }
+
+    /// Ceiling division. `None` on divide-by-zero or when rounding up
+    /// overflows the value width. Result width is `max(self.len, other.len)`.
+    pub fn checked_div_ceil(&self, other: &Self) -> Option<Self> {
+        if <Self as Zero>::is_zero(other) {
+            return None;
+        }
+        let (q, r) = div_rem_impl(self, other);
+        if <Self as Zero>::is_zero(&r) {
+            Some(q)
+        } else {
+            CheckedAdd::checked_add(q, <Self as One>::one())
+        }
+    }
 }
 
 // Value-form trait bridges to the by-reference inherent methods (free,
@@ -187,6 +201,19 @@ where
     type Output = Self;
     fn checked_rem(self, v: Self) -> Option<Self> {
         Self::checked_rem(&self, &v)
+    }
+}
+
+impl<T, const CAP: usize> DivCeil for HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = Self;
+    fn div_ceil(self, rhs: Self) -> Self {
+        match Self::checked_div_ceil(&self, &rhs) {
+            Some(v) => v,
+            None => panic!("HeaplessBigInt::div_ceil: division by zero or overflow"),
+        }
     }
 }
 
@@ -250,5 +277,32 @@ where
 {
     fn rem_assign(&mut self, other: &Self) {
         *self = div_rem_impl::<T, CAP>(self, other).1;
+    }
+}
+
+#[cfg(test)]
+mod div_ceil_tests {
+    use super::HeaplessBigInt;
+    use const_num_traits::DivCeil;
+
+    type H = HeaplessBigInt<u8, 4>;
+
+    #[test]
+    fn div_ceil_rounds_up() {
+        assert_eq!(DivCeil::div_ceil(H::from(10u8), H::from(5u8)), H::from(2u8));
+        assert_eq!(DivCeil::div_ceil(H::from(11u8), H::from(3u8)), H::from(4u8));
+        assert_eq!(DivCeil::div_ceil(H::from(1u8), H::from(5u8)), H::from(1u8));
+        assert_eq!(DivCeil::div_ceil(H::from(0u8), H::from(5u8)), H::from(0u8));
+    }
+
+    #[test]
+    fn checked_div_ceil_edges() {
+        // Divide-by-zero and rounding overflow both yield None.
+        assert_eq!(H::from(10u8).checked_div_ceil(&H::from(0u8)), None);
+        // MAX / 2 rounds to 2^31, still fits the 32-bit width.
+        assert_eq!(
+            H::from(u32::MAX).checked_div_ceil(&H::from(2u8)),
+            Some(H::from(0x8000_0000u32))
+        );
     }
 }

--- a/src/heapless/num_traits_bridge.rs
+++ b/src/heapless/num_traits_bridge.rs
@@ -8,7 +8,7 @@
 
 use super::HeaplessBigInt;
 use crate::MachineWord;
-use const_num_traits::{Bounded, CarryingMul, ConstOne, ConstZero, Personality, Zero};
+use const_num_traits::{Bounded, CarryingMul, ConstOne, ConstZero, Nct, Personality, Zero};
 
 impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::Zero
     for HeaplessBigInt<T, CAP, P>
@@ -116,6 +116,12 @@ impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::NumCast
     fn from<X: num_traits::ToPrimitive>(arg: X) -> Option<Self> {
         <Self as num_traits::FromPrimitive>::from_u64(arg.to_u64()?)
     }
+}
+
+// Marker: an unsigned `Num`. Nct-only, since `Num` (via `from_str_radix`) is.
+impl<T, const CAP: usize> num_traits::Unsigned for HeaplessBigInt<T, CAP, Nct> where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>
+{
 }
 
 #[cfg(test)]

--- a/src/heapless/power_of_two.rs
+++ b/src/heapless/power_of_two.rs
@@ -77,10 +77,28 @@ where
     }
 }
 
+// `CtIsPowerOfTwo` — masked-return `is_power_of_two`, the same subtle-predicate
+// style as `CtIsZero`/`CtParity` (`nonzero & is_zero(x & (x - 1))` composed of
+// `Choice`s). No `const_ct_select` needed, so it's personality-generic.
+impl<T, const CAP: usize, P: Personality> const_num_traits::ops::ct::CtIsPowerOfTwo
+    for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + subtle::ConstantTimeEq,
+{
+    fn ct_is_power_of_two(&self) -> subtle::Choice {
+        use const_num_traits::ops::ct::CtIsZero;
+        let nonzero = !self.ct_is_zero();
+        let one = <Self as const_num_traits::ConstOne>::ONE;
+        let masked = *self & <Self as WrappingSub>::wrapping_sub(*self, one);
+        nonzero & masked.ct_is_zero()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::HeaplessBigInt;
     use const_num_traits::NextPowerOfTwo;
+    use const_num_traits::ops::ct::CtIsPowerOfTwo;
 
     type H = HeaplessBigInt<u8, 8>;
 
@@ -115,5 +133,14 @@ mod tests {
         let w = NextPowerOfTwo::wrapping_next_power_of_two(x);
         assert_eq!(w, HeaplessBigInt::<u8, 8>::from(0u8));
         assert_eq!(w.len(), 1);
+    }
+
+    #[test]
+    fn ct_is_power_of_two_matches_bool() {
+        for v in [0u32, 1, 2, 3, 4, 100, 255, 256, 0x8000_0000] {
+            let h = H::from(v);
+            let ct = bool::from(h.ct_is_power_of_two());
+            assert_eq!(ct, v != 0 && v & (v - 1) == 0, "ct_is_power_of_two({v})");
+        }
     }
 }


### PR DESCRIPTION
Three parity gaps found by diffing the two carriers' rustdoc JSON — all present on `FixedUInt`, absent on `HeaplessBigInt`:

- **`DivCeil`** + inherent **`checked_div_ceil`** (Nct-only) — ceiling division; `None` on divide-by-zero or when rounding up overflows the width. Result width `max(self.len, rhs.len)`, and the aligned path is exact.
- **`CtIsPowerOfTwo`** — masked-return `is_power_of_two`, the same subtle-predicate shape as the `CtIsZero` / `CtParity` heapless already ships (`nonzero & is_zero(x & (x-1))`, all `Choice`s). It needs no `const_ct_select`, so unlike the deferred `CtChecked*`/`CtNonZero` it's implementable — and personality-generic.
- **`num_traits::Unsigned`** marker (Nct-only, matching FixedUInt's).

Independent of the companion PR (Strict* family) — split out only to keep each under ~200 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend HeaplessBigInt’s parity with FixedUInt by adding ceiling-division, constant-time power-of-two checks, and the Unsigned marker.

New Features:
- Add an inherent checked_div_ceil method and DivCeil trait implementation for HeaplessBigInt in the Nct personality.
- Provide a const-time CtIsPowerOfTwo predicate implementation for HeaplessBigInt matching existing subtle predicate traits.
- Mark HeaplessBigInt<Nct> as num_traits::Unsigned to align with FixedUInt’s trait coverage.

Tests:
- Add unit tests validating HeaplessBigInt’s div_ceil and checked_div_ceil behavior, including rounding and edge cases.
- Add unit tests ensuring ct_is_power_of_two matches the standard boolean power-of-two predicate.