### PR TITLE
Add ct_select + Ct arms for Saturating*/AbsDiff on HeaplessBigInt

### DIFF
--- a/src/heapless/abs_diff.rs
+++ b/src/heapless/abs_diff.rs
@@ -8,7 +8,7 @@
 use super::HeaplessBigInt;
 use super::cmp::ct_select;
 use crate::MachineWord;
-use const_num_traits::{AbsDiff, Ct, Nct, WrappingSub, Zero};
+use const_num_traits::{AbsDiff, Ct, Nct, OverflowingSub, WrappingSub, Zero};
 
 impl<T, const CAP: usize> AbsDiff for HeaplessBigInt<T, CAP, Nct>
 where
@@ -32,9 +32,8 @@ where
     fn abs_diff(self, other: Self) -> Self {
         // `a - b` wraps to `-(b - a)` when `a < b` (borrow set), so the branchless
         // result is `select(diff, -diff, borrow)`.
-        let (diff, borrow) =
-            <Self as const_num_traits::OverflowingSub>::overflowing_sub(self, other);
-        let neg_diff = <Self as WrappingSub>::wrapping_sub(<Self as Zero>::zero(), diff);
+        let (diff, borrow) = OverflowingSub::overflowing_sub(self, other);
+        let neg_diff = WrappingSub::wrapping_sub(Self::zero(), diff);
         ct_select(&diff, &neg_diff, borrow)
     }
 }

--- a/src/heapless/abs_diff.rs
+++ b/src/heapless/abs_diff.rs
@@ -1,12 +1,14 @@
-//! `const_num_traits::AbsDiff` for `HeaplessBigInt<_, Nct>`.
+//! `const_num_traits::AbsDiff` for `HeaplessBigInt`.
 //!
-//! `|a - b|` = the larger minus the smaller. Nct-only: the branch on the
-//! comparison isn't constant-time (FixedUInt's Ct arm uses a branchless
-//! select; heapless keeps its Ct trait surface minimal).
+//! `|a - b|` = the larger minus the smaller. The `Nct` arm branches on the
+//! comparison; the `Ct` arm computes `a - b` (with its borrow) and `b - a`
+//! and picks branchlessly with `ct_select`, mirroring `FixedUInt`'s Ct
+//! `abs_diff`.
 
 use super::HeaplessBigInt;
+use super::cmp::ct_select;
 use crate::MachineWord;
-use const_num_traits::{AbsDiff, Nct};
+use const_num_traits::{AbsDiff, Ct, Nct, WrappingSub, Zero};
 
 impl<T, const CAP: usize> AbsDiff for HeaplessBigInt<T, CAP, Nct>
 where
@@ -18,6 +20,46 @@ where
             self - other
         } else {
             other - self
+        }
+    }
+}
+
+impl<T, const CAP: usize> AbsDiff for HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = Self;
+    fn abs_diff(self, other: Self) -> Self {
+        // `a - b` wraps to `-(b - a)` when `a < b` (borrow set), so the branchless
+        // result is `select(diff, -diff, borrow)`.
+        let (diff, borrow) =
+            <Self as const_num_traits::OverflowingSub>::overflowing_sub(self, other);
+        let neg_diff = <Self as WrappingSub>::wrapping_sub(<Self as Zero>::zero(), diff);
+        ct_select(&diff, &neg_diff, borrow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HeaplessBigInt;
+    use const_num_traits::{AbsDiff, Ct, Nct};
+
+    type HN = HeaplessBigInt<u8, 4, Nct>;
+    type HC = HeaplessBigInt<u8, 4, Ct>;
+
+    #[test]
+    fn ct_abs_diff_matches_nct_and_value() {
+        for (a, b) in [(10u32, 3), (3, 10), (0, 0), (u32::MAX, 1), (1, u32::MAX)] {
+            let expected = a.abs_diff(b);
+            assert_eq!(
+                AbsDiff::abs_diff(HC::from(a), HC::from(b)),
+                HC::from(expected),
+                "ct abs_diff({a}, {b})"
+            );
+            assert_eq!(
+                AbsDiff::abs_diff(HN::from(a), HN::from(b)),
+                HN::from(expected)
+            );
         }
     }
 }

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -12,10 +12,11 @@
 //! "len is public" invariant regardless of Personality — the Nct and Ct
 //! arms share one body.
 
+use super::cmp::ct_select;
 use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
 use const_num_traits::{
-    BorrowingSub, Bounded, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, CheckedSub, Nct,
+    BorrowingSub, Bounded, CarryingAdd, CarryingMul, CheckedAdd, CheckedMul, CheckedSub, Ct, Nct,
     OverflowingAdd, OverflowingMul, OverflowingSub, Personality, PersonalityTag, SaturatingAdd,
     SaturatingMul, SaturatingSub, WrappingAdd, WrappingMul, WrappingSub,
 };
@@ -386,6 +387,47 @@ where
     }
 }
 
+// ── Ct saturating: branchless select on the overflow/borrow flag ──
+//
+// The `Nct` forms above branch on the flag; the `Ct` forms pick the
+// saturated sentinel vs the wrapped result with `ct_select` (the whole-value
+// masked select), so timing doesn't reveal whether saturation happened. The
+// sentinel is the operand-width max/zero, same as the Nct path. Additive —
+// the `Nct` impls are untouched.
+
+impl<T, const CAP: usize> SaturatingAdd for HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = Self;
+    fn saturating_add(self, v: Self) -> Self {
+        let (res, overflow) = OverflowingAdd::overflowing_add(self, v);
+        ct_select(&res, &max_at_len(res.len), overflow)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingSub for HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = Self;
+    fn saturating_sub(self, v: Self) -> Self {
+        let (res, borrow) = OverflowingSub::overflowing_sub(self, v);
+        ct_select(&res, &Self::new_zero_with_len(res.len), borrow)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingMul for HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T> + subtle::ConditionallySelectable,
+{
+    type Output = Self;
+    fn saturating_mul(self, v: Self) -> Self {
+        let (res, overflow) = OverflowingMul::overflowing_mul(self, v);
+        ct_select(&res, &max_at_len(res.len), overflow)
+    }
+}
+
 // `num_traits::Saturating` (add/sub only) — deprecated upstream but still
 // required by `num_traits::PrimInt`. Nct-only, matching the trait forms above.
 #[cfg(feature = "num-traits")]
@@ -436,10 +478,9 @@ impl<T: MachineWord, const CAP: usize> HeaplessBigInt<T, CAP, Nct> {
 
     /// Saturating addition: on overflow, the all-ones value at the operands'
     /// width `max(a.len, b.len)` (not the CAP-wide max), matching
-    /// `FixedUInt<T, width>::saturating_add`. Nct-only: the branch on the
-    /// overflow flag is not constant-time, so `Ct` does not expose it (a
-    /// branchless Ct saturating, like FixedUInt's `const_ct_select`, is not
-    /// yet provided).
+    /// `FixedUInt<T, width>::saturating_add`. This inherent form branches on
+    /// the overflow flag; the `Ct` carrier's branchless `SaturatingAdd` impl
+    /// (via `ct_select`) is defined separately.
     pub fn saturating_add(&self, other: &Self) -> Self {
         let (res, overflow) = self.overflowing_add(other);
         if overflow { max_at_len(res.len) } else { res }
@@ -931,5 +972,34 @@ mod tests {
         let seven = H::from_le_bytes(&7u32.to_le_bytes());
         assert_eq!(a.checked_div(&seven).unwrap().limbs[0], 14);
         assert_eq!(a.checked_rem(&seven).unwrap().limbs[0], 2);
+    }
+
+    // The branchless Ct saturating impls must produce the same values as the
+    // Nct ones (including the saturate/clamp cases), at the operand width.
+    #[test]
+    fn ct_saturating_matches_nct() {
+        type Cn = HeaplessBigInt<u8, 4, Nct>;
+        type Cc = HeaplessBigInt<u8, 4, Ct>;
+        let cases = [(100u32, 50u32), (u32::MAX, 1), (u32::MAX, u32::MAX), (5, 9)];
+        for (a, b) in cases {
+            assert_eq!(
+                SaturatingAdd::saturating_add(Cc::from(a), Cc::from(b)),
+                Cc::from(a.saturating_add(b)),
+                "ct saturating_add({a},{b})"
+            );
+            assert_eq!(
+                SaturatingSub::saturating_sub(Cc::from(a), Cc::from(b)),
+                Cc::from(a.saturating_sub(b))
+            );
+            assert_eq!(
+                SaturatingMul::saturating_mul(Cc::from(a), Cc::from(b)),
+                Cc::from(a.saturating_mul(b))
+            );
+            // Cross-check the Nct forms agree with std too.
+            assert_eq!(
+                SaturatingAdd::saturating_add(Cn::from(a), Cn::from(b)),
+                Cn::from(a.saturating_add(b))
+            );
+        }
     }
 }

--- a/src/heapless/cmp.rs
+++ b/src/heapless/cmp.rs
@@ -176,6 +176,29 @@ where
     }
 }
 
+/// Branchless select for the `Ct` arms of value-returning ops: returns
+/// `if_true` when `flag`, else `if_false`, with no branch on `flag`. A thin
+/// wrapper over `conditional_select` (the whole-value masked select above) —
+/// the runtime-impl analog of `FixedUInt::const_ct_select` (heapless doesn't
+/// need a `const fn` variant since its impls aren't const-evaluated). The
+/// result width is `max(if_false.len, if_true.len)`, a public shape, never
+/// derived from `flag`.
+#[inline]
+pub(crate) fn ct_select<T, const CAP: usize, P: Personality>(
+    if_false: &HeaplessBigInt<T, CAP, P>,
+    if_true: &HeaplessBigInt<T, CAP, P>,
+    flag: bool,
+) -> HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    <HeaplessBigInt<T, CAP, P> as subtle::ConditionallySelectable>::conditional_select(
+        if_false,
+        if_true,
+        subtle::Choice::from(flag as u8),
+    )
+}
+
 // ── const_num_traits::CtIsZero ──
 
 impl<T, const CAP: usize, P: Personality> const_num_traits::ops::ct::CtIsZero


### PR DESCRIPTION
Wires up the constant-time whole-value select primitive on `HeaplessBigInt` and the immediate dependents that were `Nct`-only for lack of it.

### The primitive
`ct_select(if_false, if_true, flag)` (cmp.rs) — a thin wrapper over the `subtle::ConditionallySelectable` masked whole-value select heapless already carries. It's the runtime-impl analog of `FixedUInt::const_ct_select`; heapless needs no `const fn` variant because its impls aren't const-evaluated (that's the *only* reason FixedUInt hand-rolls its own). Result width is `max(if_false.len, if_true.len)` — a public shape, never derived from `flag`.

### Immediate dependents (now `Ct`-capable)
- **`SaturatingAdd`/`Sub`/`Mul`** — branchlessly pick the saturation sentinel (operand-width max / zero) vs the wrapped result on the overflow/borrow flag.
- **`AbsDiff`** — pick `a-b` vs `-(a-b)` on the borrow, mirroring FixedUInt's Ct `abs_diff`.

All **additive**: the existing `Nct` impls are untouched, so there's no bound cascade into the shared carrier harness. The new `Ct` impls carry the extra `T: subtle::ConditionallySelectable` bound (every `MachineWord` satisfies it).

### Scope
`NextPowerOfTwo` is the one remaining `const_ct_select` dependent on `FixedUInt`; it's a more involved bit-scan + zero-handling case, so it's left for a follow-up to keep this PR focused.

Tests assert the `Ct` results match the `Nct`/std values across normal, saturating, and clamp cases. (CT-ness itself is branchless by construction via `subtle`; empirical verification through the `ct-verify` harness would be a natural follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add constant-time selection support for HeaplessBigInt and use it to provide Ct implementations of saturating arithmetic and absolute difference that match existing Nct behavior.

New Features:
- Provide a ct_select helper for HeaplessBigInt as a branchless, constant-time value selector based on subtle::ConditionallySelectable.
- Add Ct carrier implementations of SaturatingAdd, SaturatingSub, and SaturatingMul for HeaplessBigInt using ct_select to choose between wrapped and saturated results.
- Add a Ct carrier implementation of AbsDiff for HeaplessBigInt that mirrors FixedUInt's constant-time abs_diff semantics.

Enhancements:
- Clarify heapless saturating_add documentation to reference the separate Ct branchless implementation.
- Extend HeaplessBigInt trait imports and bounds to support Ct personality for newly added constant-time operations.

Tests:
- Add tests ensuring Ct saturating operations produce the same results as Nct implementations and standard saturating arithmetic across normal and clamp cases.
- Add tests verifying Ct AbsDiff matches both Nct AbsDiff and the standard abs_diff value semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added constant-time absolute-difference support for heapless big integers.
  * Added constant-time saturating addition, subtraction, and multiplication.
  * Saturating operations now correctly clamp results on overflow and underflow.

* **Bug Fixes**
  * Improved consistency between constant-time and non-constant-time arithmetic results across edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->