### PR TITLE
Add CtCheckedAdd/Sub/Mul to HeaplessBigInt

### DIFF
--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -32,7 +32,7 @@ use core::marker::PhantomData;
 // `max(a.len, b.len)`, matching `FixedUInt<T, width>::max_value()`. It is NOT
 // `Bounded::max_value()`, which on this carrier is the CAP-wide max.
 #[inline]
-pub(crate) fn max_at_len<T: MachineWord, const CAP: usize, P: Personality>(
+fn max_at_len<T: MachineWord, const CAP: usize, P: Personality>(
     len: u16,
 ) -> HeaplessBigInt<T, CAP, P> {
     let mut limbs = [zero::<T>(); CAP];

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -32,7 +32,7 @@ use core::marker::PhantomData;
 // `max(a.len, b.len)`, matching `FixedUInt<T, width>::max_value()`. It is NOT
 // `Bounded::max_value()`, which on this carrier is the CAP-wide max.
 #[inline]
-fn max_at_len<T: MachineWord, const CAP: usize, P: Personality>(
+pub(crate) fn max_at_len<T: MachineWord, const CAP: usize, P: Personality>(
     len: u16,
 ) -> HeaplessBigInt<T, CAP, P> {
     let mut limbs = [zero::<T>(); CAP];
@@ -425,6 +425,47 @@ where
     fn saturating_mul(self, v: Self) -> Self {
         let (res, overflow) = OverflowingMul::overflowing_mul(self, v);
         ct_select(&res, &max_at_len(res.len), overflow)
+    }
+}
+
+// ── Ct checked arithmetic: masked-return `CtOption` ──
+//
+// The overflow flag gates the `CtOption` mask instead of a branch, so a
+// secret operand's overflow isn't leaked through an `Option` discriminant.
+// No `ct_select` (or `ConditionallySelectable` bound) needed — the value is
+// always the wrapped result; only its observability is masked. P-generic,
+// like FixedUInt's.
+
+impl<T, const CAP: usize, P: Personality> const_num_traits::ops::ct::CtCheckedAdd
+    for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    fn ct_checked_add(&self, v: &Self) -> subtle::CtOption<Self> {
+        let (val, overflow) = self.overflowing_add(v);
+        subtle::CtOption::new(val, subtle::Choice::from(!overflow as u8))
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> const_num_traits::ops::ct::CtCheckedSub
+    for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    fn ct_checked_sub(&self, v: &Self) -> subtle::CtOption<Self> {
+        let (val, borrow) = self.overflowing_sub(v);
+        subtle::CtOption::new(val, subtle::Choice::from(!borrow as u8))
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> const_num_traits::ops::ct::CtCheckedMul
+    for HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn ct_checked_mul(&self, v: &Self) -> subtle::CtOption<Self> {
+        let (val, overflow) = self.overflowing_mul(v);
+        subtle::CtOption::new(val, subtle::Choice::from(!overflow as u8))
     }
 }
 
@@ -972,6 +1013,38 @@ mod tests {
         let seven = H::from_le_bytes(&7u32.to_le_bytes());
         assert_eq!(a.checked_div(&seven).unwrap().limbs[0], 14);
         assert_eq!(a.checked_rem(&seven).unwrap().limbs[0], 2);
+    }
+
+    // CtCheckedAdd/Sub/Mul: the value is always the wrapped result; is_some
+    // masks overflow. Matches the plain checked_* value + overflow status.
+    #[test]
+    fn ct_checked_arithmetic() {
+        use const_num_traits::ops::ct::{CtCheckedAdd, CtCheckedMul, CtCheckedSub};
+        type Cc = HeaplessBigInt<u8, 4, Ct>;
+
+        // No overflow: is_some, value matches.
+        let a = Cc::from(100u32);
+        let b = Cc::from(50u32);
+        let s = a.ct_checked_add(&b);
+        assert!(bool::from(s.is_some()));
+        assert_eq!(s.unwrap(), Cc::from(150u32));
+        assert!(bool::from(a.ct_checked_sub(&b).is_some()));
+        assert!(bool::from(
+            Cc::from(7u32).ct_checked_mul(&Cc::from(9u32)).is_some()
+        ));
+
+        // Overflow / underflow: is_none (masked).
+        assert!(!bool::from(
+            Cc::from(u32::MAX).ct_checked_add(&Cc::from(1u32)).is_some()
+        ));
+        assert!(!bool::from(
+            Cc::from(0u32).ct_checked_sub(&Cc::from(1u32)).is_some()
+        ));
+        assert!(!bool::from(
+            Cc::from(0x1_0000u32)
+                .ct_checked_mul(&Cc::from(0x1_0000u32))
+                .is_some()
+        ));
     }
 
     // The branchless Ct saturating impls must produce the same values as the

--- a/src/heapless/power_of_two.rs
+++ b/src/heapless/power_of_two.rs
@@ -1,17 +1,21 @@
 //! `const_num_traits::IsPowerOfTwo` / `NextPowerOfTwo` for `HeaplessBigInt`.
 //!
 //! `is_power_of_two` is personality-generic (the Ct arm is `black_box`-guarded,
-//! no branch). `NextPowerOfTwo` is Nct-only: its Ct variant needs a branchless
-//! whole-value select (FixedUInt's `const_ct_select`), which heapless doesn't
-//! carry, and even FixedUInt notes `checked_next_power_of_two` isn't CT.
+//! no branch). `NextPowerOfTwo` is implemented for both personalities: the
+//! `Nct` arm branches on the overflow (panic / wrap-to-zero); the `Ct` arm is
+//! branchless via `ct_select` (saturate to the width-max / wrap to zero). Both
+//! share the value-based `checked` helper — note `checked_next_power_of_two`
+//! itself is NOT constant-time (its `Option` leaks the overflow bit), same
+//! caveat as FixedUInt; Ct callers use `next`/`wrapping`.
 //!
 //! Result width is the operand width: `one` is widened before the `<< bits`
 //! so the power of two lands at `len`, not the minimal identity width.
 
-use super::HeaplessBigInt;
+use super::cmp::ct_select;
+use super::{HeaplessBigInt, arith::max_at_len};
 use crate::MachineWord;
 use const_num_traits::{
-    IsPowerOfTwo, Nct, NextPowerOfTwo, One, Personality, PersonalityTag, PrimBits, WrappingSub,
+    Ct, IsPowerOfTwo, Nct, NextPowerOfTwo, One, Personality, PersonalityTag, PrimBits, WrappingSub,
     Zero,
 };
 
@@ -39,6 +43,32 @@ where
     }
 }
 
+// Shared value-based checked next-power-of-two, P-generic. Branchful (the
+// `Option` reveals the overflow bit), so on `Ct` it is NOT constant-time — Ct
+// callers use `next`/`wrapping`, which are branchless. `wrapping_sub` (rather
+// than `-`) keeps it usable on `Ct` without the Nct underflow panic; `self`
+// is guaranteed non-zero at that point anyway.
+impl<T, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    fn checked_next_pow2(self) -> Option<Self> {
+        let width = self.len();
+        let word_bits = core::mem::size_of::<T>() as u32 * 8;
+        let width_bits = width as u32 * word_bits;
+        if <Self as Zero>::is_zero(&self) {
+            return Some(<Self as One>::one().widened(core::cmp::max(1, width)));
+        }
+        // `(n - 1).leading_zeros()` gives the position of the next power of two.
+        let m_one = <Self as WrappingSub>::wrapping_sub(self, <Self as One>::one());
+        let bits = width_bits - PrimBits::leading_zeros(m_one);
+        if bits >= width_bits {
+            return None; // 2^width_bits doesn't fit the value width
+        }
+        Some(<Self as One>::one().widened(core::cmp::max(1, width)) << (bits as usize))
+    }
+}
+
 impl<T, const CAP: usize> NextPowerOfTwo for HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord,
@@ -47,33 +77,67 @@ where
 
     fn wrapping_next_power_of_two(self) -> Self {
         let width = self.len();
-        match self.checked_next_power_of_two() {
-            Some(v) => v,
-            None => Self::new_zero_with_len(width), // overflow wraps to zero
-        }
+        self.checked_next_pow2()
+            .unwrap_or_else(|| Self::new_zero_with_len(width)) // overflow wraps to zero
     }
 
     fn next_power_of_two(self) -> Self {
-        match self.checked_next_power_of_two() {
-            Some(v) => v,
-            None => panic!("HeaplessBigInt::next_power_of_two overflow: exceeds the value width"),
-        }
+        self.checked_next_pow2().unwrap_or_else(|| {
+            panic!("HeaplessBigInt::next_power_of_two overflow: exceeds the value width")
+        })
     }
 
     fn checked_next_power_of_two(self) -> Option<Self> {
-        let width = self.len();
-        let word_bits = core::mem::size_of::<T>() as u32 * 8;
-        let width_bits = width as u32 * word_bits;
-        if <Self as Zero>::is_zero(&self) {
-            return Some(<Self as One>::one().widened(core::cmp::max(1, width)));
-        }
-        // `(n - 1).leading_zeros()` gives the position of the next power of two.
-        let m_one = self - <Self as One>::one();
-        let bits = width_bits - PrimBits::leading_zeros(m_one);
-        if bits >= width_bits {
-            return None; // 2^width_bits doesn't fit the value width
-        }
-        Some(<Self as One>::one().widened(core::cmp::max(1, width)) << (bits as usize))
+        self.checked_next_pow2()
+    }
+}
+
+// Branchless Ct core shared by `next`/`wrapping` — identical up to the value
+// selected on overflow (`overflow_sentinel`: width-max for `next`, zero for
+// `wrapping`). Mirrors FixedUInt's Ct `next_power_of_two`.
+#[inline]
+fn ct_next_pow2<T, const CAP: usize>(
+    x: HeaplessBigInt<T, CAP, Ct>,
+    overflow_sentinel: HeaplessBigInt<T, CAP, Ct>,
+) -> HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type H<T, const CAP: usize> = HeaplessBigInt<T, CAP, Ct>;
+    let width = x.len();
+    let word_bits = core::mem::size_of::<T>() as u32 * 8;
+    let width_bits = width as u32 * word_bits;
+    let one_w = <H<T, CAP> as One>::one().widened(core::cmp::max(1, width));
+    let m_one = <H<T, CAP> as WrappingSub>::wrapping_sub(x, one_w);
+    let bits = width_bits - PrimBits::leading_zeros(m_one);
+    // `<< bits` yields 0 once bits reach the width; that limb is only observed
+    // in the non-overflow arm, which the select below discards on overflow.
+    let shifted = one_w << (bits as usize);
+    let is_zero = <H<T, CAP> as Zero>::is_zero(&x);
+    let overflow = bits >= width_bits && !is_zero;
+    let saturated = ct_select(&shifted, &overflow_sentinel, overflow);
+    ct_select(&saturated, &one_w, is_zero)
+}
+
+impl<T, const CAP: usize> NextPowerOfTwo for HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = Self;
+
+    fn next_power_of_two(self) -> Self {
+        // Saturate to the width-max on overflow (the Nct panic is value-
+        // dependent, so unavailable here — a defined sentinel beats a wrong one).
+        ct_next_pow2(self, max_at_len(self.len()))
+    }
+
+    fn wrapping_next_power_of_two(self) -> Self {
+        ct_next_pow2(self, Self::new_zero_with_len(self.len()))
+    }
+
+    fn checked_next_power_of_two(self) -> Option<Self> {
+        // Branchful (see `checked_next_pow2`): NOT constant-time on Ct.
+        self.checked_next_pow2()
     }
 }
 
@@ -142,5 +206,37 @@ mod tests {
             let ct = bool::from(h.ct_is_power_of_two());
             assert_eq!(ct, v != 0 && v & (v - 1) == 0, "ct_is_power_of_two({v})");
         }
+    }
+
+    #[test]
+    fn ct_next_power_of_two_matches_and_saturates() {
+        use const_num_traits::Ct;
+        type HC = HeaplessBigInt<u8, 4, Ct>;
+
+        // Non-overflow values agree with std's next_power_of_two.
+        for v in [1u32, 5, 128, 0x4000_0000] {
+            assert_eq!(
+                NextPowerOfTwo::next_power_of_two(HC::from(v)),
+                HC::from(v.next_power_of_two()),
+                "ct next_power_of_two({v})"
+            );
+        }
+        // 0 -> 1 (at the operand width).
+        assert_eq!(
+            NextPowerOfTwo::next_power_of_two(HC::from(0u8).widened(4)),
+            HC::from(1u8)
+        );
+        // 2^31+1 rounds to 2^32, past the 32-bit width: `next` saturates to the
+        // width-max, `wrapping` wraps to zero, `checked` is None.
+        let big = HC::from(0x8000_0001u32);
+        assert_eq!(
+            NextPowerOfTwo::next_power_of_two(big),
+            HC::from(0xFFFF_FFFFu32)
+        );
+        assert_eq!(
+            NextPowerOfTwo::wrapping_next_power_of_two(big),
+            HC::from(0u8)
+        );
+        assert_eq!(NextPowerOfTwo::checked_next_power_of_two(big), None);
     }
 }

--- a/src/heapless/power_of_two.rs
+++ b/src/heapless/power_of_two.rs
@@ -1,21 +1,17 @@
 //! `const_num_traits::IsPowerOfTwo` / `NextPowerOfTwo` for `HeaplessBigInt`.
 //!
 //! `is_power_of_two` is personality-generic (the Ct arm is `black_box`-guarded,
-//! no branch). `NextPowerOfTwo` is implemented for both personalities: the
-//! `Nct` arm branches on the overflow (panic / wrap-to-zero); the `Ct` arm is
-//! branchless via `ct_select` (saturate to the width-max / wrap to zero). Both
-//! share the value-based `checked` helper — note `checked_next_power_of_two`
-//! itself is NOT constant-time (its `Option` leaks the overflow bit), same
-//! caveat as FixedUInt; Ct callers use `next`/`wrapping`.
+//! no branch). `NextPowerOfTwo` is Nct-only: its Ct variant needs a branchless
+//! whole-value select (FixedUInt's `const_ct_select`), which heapless doesn't
+//! carry, and even FixedUInt notes `checked_next_power_of_two` isn't CT.
 //!
 //! Result width is the operand width: `one` is widened before the `<< bits`
 //! so the power of two lands at `len`, not the minimal identity width.
 
-use super::cmp::ct_select;
-use super::{HeaplessBigInt, arith::max_at_len};
+use super::HeaplessBigInt;
 use crate::MachineWord;
 use const_num_traits::{
-    Ct, IsPowerOfTwo, Nct, NextPowerOfTwo, One, Personality, PersonalityTag, PrimBits, WrappingSub,
+    IsPowerOfTwo, Nct, NextPowerOfTwo, One, Personality, PersonalityTag, PrimBits, WrappingSub,
     Zero,
 };
 
@@ -43,32 +39,6 @@ where
     }
 }
 
-// Shared value-based checked next-power-of-two, P-generic. Branchful (the
-// `Option` reveals the overflow bit), so on `Ct` it is NOT constant-time — Ct
-// callers use `next`/`wrapping`, which are branchless. `wrapping_sub` (rather
-// than `-`) keeps it usable on `Ct` without the Nct underflow panic; `self`
-// is guaranteed non-zero at that point anyway.
-impl<T, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
-where
-    T: MachineWord,
-{
-    fn checked_next_pow2(self) -> Option<Self> {
-        let width = self.len();
-        let word_bits = core::mem::size_of::<T>() as u32 * 8;
-        let width_bits = width as u32 * word_bits;
-        if <Self as Zero>::is_zero(&self) {
-            return Some(<Self as One>::one().widened(core::cmp::max(1, width)));
-        }
-        // `(n - 1).leading_zeros()` gives the position of the next power of two.
-        let m_one = <Self as WrappingSub>::wrapping_sub(self, <Self as One>::one());
-        let bits = width_bits - PrimBits::leading_zeros(m_one);
-        if bits >= width_bits {
-            return None; // 2^width_bits doesn't fit the value width
-        }
-        Some(<Self as One>::one().widened(core::cmp::max(1, width)) << (bits as usize))
-    }
-}
-
 impl<T, const CAP: usize> NextPowerOfTwo for HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord,
@@ -77,67 +47,33 @@ where
 
     fn wrapping_next_power_of_two(self) -> Self {
         let width = self.len();
-        self.checked_next_pow2()
-            .unwrap_or_else(|| Self::new_zero_with_len(width)) // overflow wraps to zero
+        match self.checked_next_power_of_two() {
+            Some(v) => v,
+            None => Self::new_zero_with_len(width), // overflow wraps to zero
+        }
     }
 
     fn next_power_of_two(self) -> Self {
-        self.checked_next_pow2().unwrap_or_else(|| {
-            panic!("HeaplessBigInt::next_power_of_two overflow: exceeds the value width")
-        })
+        match self.checked_next_power_of_two() {
+            Some(v) => v,
+            None => panic!("HeaplessBigInt::next_power_of_two overflow: exceeds the value width"),
+        }
     }
 
     fn checked_next_power_of_two(self) -> Option<Self> {
-        self.checked_next_pow2()
-    }
-}
-
-// Branchless Ct core shared by `next`/`wrapping` — identical up to the value
-// selected on overflow (`overflow_sentinel`: width-max for `next`, zero for
-// `wrapping`). Mirrors FixedUInt's Ct `next_power_of_two`.
-#[inline]
-fn ct_next_pow2<T, const CAP: usize>(
-    x: HeaplessBigInt<T, CAP, Ct>,
-    overflow_sentinel: HeaplessBigInt<T, CAP, Ct>,
-) -> HeaplessBigInt<T, CAP, Ct>
-where
-    T: MachineWord + subtle::ConditionallySelectable,
-{
-    type H<T, const CAP: usize> = HeaplessBigInt<T, CAP, Ct>;
-    let width = x.len();
-    let word_bits = core::mem::size_of::<T>() as u32 * 8;
-    let width_bits = width as u32 * word_bits;
-    let one_w = <H<T, CAP> as One>::one().widened(core::cmp::max(1, width));
-    let m_one = <H<T, CAP> as WrappingSub>::wrapping_sub(x, one_w);
-    let bits = width_bits - PrimBits::leading_zeros(m_one);
-    // `<< bits` yields 0 once bits reach the width; that limb is only observed
-    // in the non-overflow arm, which the select below discards on overflow.
-    let shifted = one_w << (bits as usize);
-    let is_zero = <H<T, CAP> as Zero>::is_zero(&x);
-    let overflow = bits >= width_bits && !is_zero;
-    let saturated = ct_select(&shifted, &overflow_sentinel, overflow);
-    ct_select(&saturated, &one_w, is_zero)
-}
-
-impl<T, const CAP: usize> NextPowerOfTwo for HeaplessBigInt<T, CAP, Ct>
-where
-    T: MachineWord + subtle::ConditionallySelectable,
-{
-    type Output = Self;
-
-    fn next_power_of_two(self) -> Self {
-        // Saturate to the width-max on overflow (the Nct panic is value-
-        // dependent, so unavailable here — a defined sentinel beats a wrong one).
-        ct_next_pow2(self, max_at_len(self.len()))
-    }
-
-    fn wrapping_next_power_of_two(self) -> Self {
-        ct_next_pow2(self, Self::new_zero_with_len(self.len()))
-    }
-
-    fn checked_next_power_of_two(self) -> Option<Self> {
-        // Branchful (see `checked_next_pow2`): NOT constant-time on Ct.
-        self.checked_next_pow2()
+        let width = self.len();
+        let word_bits = core::mem::size_of::<T>() as u32 * 8;
+        let width_bits = width as u32 * word_bits;
+        if <Self as Zero>::is_zero(&self) {
+            return Some(<Self as One>::one().widened(core::cmp::max(1, width)));
+        }
+        // `(n - 1).leading_zeros()` gives the position of the next power of two.
+        let m_one = self - <Self as One>::one();
+        let bits = width_bits - PrimBits::leading_zeros(m_one);
+        if bits >= width_bits {
+            return None; // 2^width_bits doesn't fit the value width
+        }
+        Some(<Self as One>::one().widened(core::cmp::max(1, width)) << (bits as usize))
     }
 }
 
@@ -206,37 +142,5 @@ mod tests {
             let ct = bool::from(h.ct_is_power_of_two());
             assert_eq!(ct, v != 0 && v & (v - 1) == 0, "ct_is_power_of_two({v})");
         }
-    }
-
-    #[test]
-    fn ct_next_power_of_two_matches_and_saturates() {
-        use const_num_traits::Ct;
-        type HC = HeaplessBigInt<u8, 4, Ct>;
-
-        // Non-overflow values agree with std's next_power_of_two.
-        for v in [1u32, 5, 128, 0x4000_0000] {
-            assert_eq!(
-                NextPowerOfTwo::next_power_of_two(HC::from(v)),
-                HC::from(v.next_power_of_two()),
-                "ct next_power_of_two({v})"
-            );
-        }
-        // 0 -> 1 (at the operand width).
-        assert_eq!(
-            NextPowerOfTwo::next_power_of_two(HC::from(0u8).widened(4)),
-            HC::from(1u8)
-        );
-        // 2^31+1 rounds to 2^32, past the 32-bit width: `next` saturates to the
-        // width-max, `wrapping` wraps to zero, `checked` is None.
-        let big = HC::from(0x8000_0001u32);
-        assert_eq!(
-            NextPowerOfTwo::next_power_of_two(big),
-            HC::from(0xFFFF_FFFFu32)
-        );
-        assert_eq!(
-            NextPowerOfTwo::wrapping_next_power_of_two(big),
-            HC::from(0u8)
-        );
-        assert_eq!(NextPowerOfTwo::checked_next_power_of_two(big), None);
     }
 }


### PR DESCRIPTION
Adds the masked-return checked arithmetic traits to `HeaplessBigInt`:

`CtCheckedAdd` / `CtCheckedSub` / `CtCheckedMul` — `Overflowing*` + `subtle::CtOption::new(val, !flag)`. The overflow flag gates the `CtOption` mask instead of a branch, so a secret operand's overflow isn't leaked through an `Option` discriminant. P-generic, no `ct_select` needed (same shape as `CtNonZero`) — genuinely constant-time (no secret-dependent ops).

### Dropped from this PR
Originally also added a Ct `NextPowerOfTwo` arm, but review (codex, P1) correctly caught that it **isn't actually constant-time**: it shifts by a secret-derived amount (`bits = width_bits - leading_zeros(value)`) into `Shl<usize>`, which branches and cache-indexes on the shift amount — leaking the input magnitude despite the trailing `ct_select`. Reverted; a real CT `next_power_of_two` needs a constant-time shift-by-secret primitive neither carrier has (FixedUInt's Ct `next_power_of_two` has the same latent leak). Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)