### PR TITLE
Constant-time shift-by-secret (ct_shl) + CT next_power_of_two for HeaplessBigInt

### DIFF
--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -32,7 +32,7 @@ use core::marker::PhantomData;
 // `max(a.len, b.len)`, matching `FixedUInt<T, width>::max_value()`. It is NOT
 // `Bounded::max_value()`, which on this carrier is the CAP-wide max.
 #[inline]
-fn max_at_len<T: MachineWord, const CAP: usize, P: Personality>(
+pub(crate) fn max_at_len<T: MachineWord, const CAP: usize, P: Personality>(
     len: u16,
 ) -> HeaplessBigInt<T, CAP, P> {
     let mut limbs = [zero::<T>(); CAP];

--- a/src/heapless/power_of_two.rs
+++ b/src/heapless/power_of_two.rs
@@ -1,17 +1,24 @@
 //! `const_num_traits::IsPowerOfTwo` / `NextPowerOfTwo` for `HeaplessBigInt`.
 //!
 //! `is_power_of_two` is personality-generic (the Ct arm is `black_box`-guarded,
-//! no branch). `NextPowerOfTwo` is Nct-only: its Ct variant needs a branchless
-//! whole-value select (FixedUInt's `const_ct_select`), which heapless doesn't
-//! carry, and even FixedUInt notes `checked_next_power_of_two` isn't CT.
+//! no branch). `NextPowerOfTwo` is implemented for both personalities: the
+//! `Nct` arm branches on overflow (panic / wrap-to-zero); the `Ct` arm is
+//! constant-time — the `1 << bits` shift by a secret `bits` goes through the
+//! [`ct_shl`](super::shift::ct_shl) barrel shifter (a plain `<<` would leak the
+//! magnitude), and the overflow/zero selects use [`ct_select`]. Both arms share
+//! the value-based `checked_next_pow2` helper; `checked_next_power_of_two`
+//! itself stays branchful (its `Option` reveals the overflow bit) — not CT,
+//! same caveat as FixedUInt — so Ct callers use `next`/`wrapping`.
 //!
-//! Result width is the operand width: `one` is widened before the `<< bits`
-//! so the power of two lands at `len`, not the minimal identity width.
+//! Result width is the operand width: `one` is widened before the shift so the
+//! power of two lands at `len`, not the minimal identity width.
 
-use super::HeaplessBigInt;
+use super::cmp::ct_select;
+use super::shift::ct_shl;
+use super::{HeaplessBigInt, arith::max_at_len};
 use crate::MachineWord;
 use const_num_traits::{
-    IsPowerOfTwo, Nct, NextPowerOfTwo, One, Personality, PersonalityTag, PrimBits, WrappingSub,
+    Ct, IsPowerOfTwo, Nct, NextPowerOfTwo, One, Personality, PersonalityTag, PrimBits, WrappingSub,
     Zero,
 };
 
@@ -39,6 +46,31 @@ where
     }
 }
 
+// Shared value-based checked next-power-of-two, P-generic. Branchful (the
+// `Option` reveals the overflow bit), so on `Ct` it is NOT constant-time — Ct
+// callers use `next`/`wrapping`, which are constant-time. `wrapping_sub` keeps
+// it usable on `Ct` without the Nct underflow panic; `self` is non-zero there.
+impl<T, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    fn checked_next_pow2(self) -> Option<Self> {
+        let width = self.len();
+        let word_bits = core::mem::size_of::<T>() as u32 * 8;
+        let width_bits = width as u32 * word_bits;
+        if <Self as Zero>::is_zero(&self) {
+            return Some(<Self as One>::one().widened(core::cmp::max(1, width)));
+        }
+        // `(n - 1).leading_zeros()` gives the position of the next power of two.
+        let m_one = <Self as WrappingSub>::wrapping_sub(self, <Self as One>::one());
+        let bits = width_bits - PrimBits::leading_zeros(m_one);
+        if bits >= width_bits {
+            return None; // 2^width_bits doesn't fit the value width
+        }
+        Some(<Self as One>::one().widened(core::cmp::max(1, width)) << (bits as usize))
+    }
+}
+
 impl<T, const CAP: usize> NextPowerOfTwo for HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord,
@@ -47,33 +79,68 @@ where
 
     fn wrapping_next_power_of_two(self) -> Self {
         let width = self.len();
-        match self.checked_next_power_of_two() {
-            Some(v) => v,
-            None => Self::new_zero_with_len(width), // overflow wraps to zero
-        }
+        self.checked_next_pow2()
+            .unwrap_or_else(|| Self::new_zero_with_len(width))
     }
 
     fn next_power_of_two(self) -> Self {
-        match self.checked_next_power_of_two() {
-            Some(v) => v,
-            None => panic!("HeaplessBigInt::next_power_of_two overflow: exceeds the value width"),
-        }
+        self.checked_next_pow2().unwrap_or_else(|| {
+            panic!("HeaplessBigInt::next_power_of_two overflow: exceeds the value width")
+        })
     }
 
     fn checked_next_power_of_two(self) -> Option<Self> {
-        let width = self.len();
-        let word_bits = core::mem::size_of::<T>() as u32 * 8;
-        let width_bits = width as u32 * word_bits;
-        if <Self as Zero>::is_zero(&self) {
-            return Some(<Self as One>::one().widened(core::cmp::max(1, width)));
-        }
-        // `(n - 1).leading_zeros()` gives the position of the next power of two.
-        let m_one = self - <Self as One>::one();
-        let bits = width_bits - PrimBits::leading_zeros(m_one);
-        if bits >= width_bits {
-            return None; // 2^width_bits doesn't fit the value width
-        }
-        Some(<Self as One>::one().widened(core::cmp::max(1, width)) << (bits as usize))
+        self.checked_next_pow2()
+    }
+}
+
+// Constant-time Ct core, shared by `next`/`wrapping` (differ only in the
+// `overflow_sentinel`: width-max for `next`, zero for `wrapping`). Mirrors
+// FixedUInt's Ct `next_power_of_two` but the secret-amount `1 << bits` shift
+// goes through `ct_shl` (a barrel shifter) rather than the leaky `<<`, and the
+// overflow flag is combined with `&` (not short-circuiting `&&`) so nothing
+// branches on the secret.
+#[inline]
+fn ct_next_pow2<T, const CAP: usize>(
+    x: HeaplessBigInt<T, CAP, Ct>,
+    overflow_sentinel: HeaplessBigInt<T, CAP, Ct>,
+) -> HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type H<T, const CAP: usize> = HeaplessBigInt<T, CAP, Ct>;
+    let width = x.len();
+    let word_bits = core::mem::size_of::<T>() as u32 * 8;
+    let width_bits = width as u32 * word_bits;
+    let one_w = <H<T, CAP> as One>::one().widened(core::cmp::max(1, width));
+    let m_one = <H<T, CAP> as WrappingSub>::wrapping_sub(x, one_w);
+    let bits = width_bits - PrimBits::leading_zeros(m_one);
+    let shifted = ct_shl(one_w, bits); // CT shift by the secret `bits`
+    let is_zero = <H<T, CAP> as Zero>::is_zero(&x);
+    let overflow = (bits >= width_bits) & !is_zero;
+    let saturated = ct_select(&shifted, &overflow_sentinel, overflow);
+    ct_select(&saturated, &one_w, is_zero)
+}
+
+impl<T, const CAP: usize> NextPowerOfTwo for HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = Self;
+
+    fn next_power_of_two(self) -> Self {
+        // Saturate to the width-max on overflow (the Nct panic is value-
+        // dependent, so unavailable here — a defined sentinel beats a wrong one).
+        ct_next_pow2(self, max_at_len(self.len()))
+    }
+
+    fn wrapping_next_power_of_two(self) -> Self {
+        ct_next_pow2(self, Self::new_zero_with_len(self.len()))
+    }
+
+    fn checked_next_power_of_two(self) -> Option<Self> {
+        // Branchful (see `checked_next_pow2`): NOT constant-time on Ct.
+        self.checked_next_pow2()
     }
 }
 
@@ -142,5 +209,37 @@ mod tests {
             let ct = bool::from(h.ct_is_power_of_two());
             assert_eq!(ct, v != 0 && v & (v - 1) == 0, "ct_is_power_of_two({v})");
         }
+    }
+
+    #[test]
+    fn ct_next_power_of_two_matches_and_saturates() {
+        use const_num_traits::Ct;
+        type HC = HeaplessBigInt<u8, 4, Ct>;
+
+        // Non-overflow values agree with std (via the CT barrel-shift path).
+        for v in [1u32, 5, 128, 0x4000_0000] {
+            assert_eq!(
+                NextPowerOfTwo::next_power_of_two(HC::from(v)),
+                HC::from(v.next_power_of_two()),
+                "ct next_power_of_two({v})"
+            );
+        }
+        // 0 -> 1 at the operand width.
+        assert_eq!(
+            NextPowerOfTwo::next_power_of_two(HC::from(0u8).widened(4)),
+            HC::from(1u8)
+        );
+        // 2^31+1 rounds to 2^32, past the 32-bit width: `next` saturates to the
+        // width-max, `wrapping` wraps to zero, `checked` is None.
+        let big = HC::from(0x8000_0001u32);
+        assert_eq!(
+            NextPowerOfTwo::next_power_of_two(big),
+            HC::from(0xFFFF_FFFFu32)
+        );
+        assert_eq!(
+            NextPowerOfTwo::wrapping_next_power_of_two(big),
+            HC::from(0u8)
+        );
+        assert_eq!(NextPowerOfTwo::checked_next_power_of_two(big), None);
     }
 }

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -49,7 +49,10 @@ where
     // Public loop bound: stages cover bit positions `0..ceil(log2(width_bits))`.
     let mut k = 0u32;
     while (1u32 << k) < width_bits {
-        let shifted = result << (1usize << k); // fixed, public shift by 2^k
+        // Stage amount `2^k` stays in `u32` (< width_bits < 2^32) — `1usize << k`
+        // would overflow on a 16-bit-usize target once k >= 16. The `Shl<u32>`
+        // it routes through carries the same over-width cast guard as elsewhere.
+        let shifted = result << (1u32 << k); // fixed, public shift by 2^k
         let bit_k = (amount >> k) & 1;
         result = ct_select(&result, &shifted, bit_k != 0);
         k += 1;

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -17,11 +17,47 @@
 //! Iteration count is derived from `self.len` + shift amount — both
 //! public — so the Nct and Ct arms share the same body.
 
+use super::cmp::ct_select;
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
 use const_num_traits::Personality;
 use core::marker::PhantomData;
 use core::ops::{Shl, ShlAssign, Shr, ShrAssign};
+
+/// Constant-time left shift by a **secret** `amount`: a barrel shifter.
+///
+/// The inherent `Shl<usize>` branches and cache-indexes on the shift amount
+/// (`word_shift`/`bit_shift`), so shifting by a secret leaks it. Here the
+/// secret never drives control flow: each stage `k` shifts by the **public**
+/// constant `2^k` and applies-or-not via a masked [`ct_select`] on bit `k` of
+/// `amount`. Amounts `>= self.len·word_bits` yield zero (masked). The only
+/// operations that touch `amount` are the arithmetic `>> k & 1` and the u32
+/// `>=` — no branch or memory access depends on it.
+///
+/// Cost is `O(width · log(width_bits))`. Result width is `self.len`, as `<<`.
+pub(crate) fn ct_shl<T, const CAP: usize, P: Personality>(
+    value: HeaplessBigInt<T, CAP, P>,
+    amount: u32,
+) -> HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    let width = value.len();
+    let word_bits = core::mem::size_of::<T>() as u32 * 8;
+    let width_bits = width as u32 * word_bits;
+    let mut result = value;
+    // Public loop bound: stages cover bit positions `0..ceil(log2(width_bits))`.
+    let mut k = 0u32;
+    while (1u32 << k) < width_bits {
+        let shifted = result << (1usize << k); // fixed, public shift by 2^k
+        let bit_k = (amount >> k) & 1;
+        result = ct_select(&result, &shifted, bit_k != 0);
+        k += 1;
+    }
+    // Over-width amount shifts everything out.
+    let zero_w = HeaplessBigInt::<T, CAP, P>::new_zero_with_len(width);
+    ct_select(&result, &zero_w, amount >= width_bits)
+}
 
 // `Shl<u32>` / `Shr<u32>` delegate to the `usize` impls, matching `FixedUInt`.
 // The `num_traits` shift traits (`WrappingShl`, `CheckedShl`, …) require these
@@ -146,6 +182,30 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Shr<usize> for HeaplessBi
             limbs,
             len: out_len as u16,
             _p: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod ct_shl_tests {
+    use super::{HeaplessBigInt, ct_shl};
+    use const_num_traits::Ct;
+
+    type HC = HeaplessBigInt<u8, 4, Ct>; // 32-bit width
+
+    #[test]
+    fn ct_shl_matches_plain_shift_all_amounts() {
+        // The barrel shifter must produce the same value as the (leaky) `<<`
+        // for every amount, including over-width (both yield 0 at the width).
+        for &raw in &[1u32, 0x1234_5678, 0xFFFF_FFFF, 0x8000_0000] {
+            let v = HC::from(raw);
+            for amount in 0u32..=40 {
+                assert_eq!(
+                    ct_shl(v, amount),
+                    v << (amount as usize),
+                    "ct_shl({raw:#x}, {amount})"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Closes the heapless half of #171 — reinstates the Ct `NextPowerOfTwo` that was dropped in #170, now genuinely constant-time.

### `ct_shl` — barrel shifter (shift.rs)
A constant-time left shift by a **secret** amount. The inherent `Shl<usize>` branches and cache-indexes on `word_shift`/`bit_shift`, so shifting by a secret leaks it (that was #170's P1). The barrel shifter never lets the secret drive control flow:
- each stage `k` shifts by the **public** constant `2^k` (so `Shl`'s internal branches depend only on public `k`),
- and applies-or-not via a masked `ct_select` on bit `k` of the amount,
- over-width amounts mask to zero.

The only operations that touch the secret are `amount >> k & 1` and a `u32 >=` — both branchless. `O(width · log width)`, result width `self.len`.

### CT `next_power_of_two` (power_of_two.rs)
`next`/`wrapping_next_power_of_two` route their `1 << bits` (where `bits = width_bits - leading_zeros`, secret-derived) through `ct_shl` instead of `<<`, and combine the overflow flag with `&` (not short-circuiting `&&`). `leading_zeros`/`is_zero` already take the CT path on the `Ct` carrier. `checked_next_power_of_two` stays branchful (its `Option` reveals the overflow bit) — not CT, same documented caveat as FixedUInt; Ct callers use `next`/`wrapping`.

### Verification
CT is argued **by construction** (every secret-touching op enumerated above is branchless) and **correctness-tested**: `ct_shl` matches `<<` for all amounts incl. over-width; `next_power_of_two` matches std across normal / saturate / wrap / `None` cases.

**Empirical `ct-verify` coverage is a known gap, not addressed here:** the fixture harness is FixedUInt-only, and its asm-grep gate assumes straight-line branchless code — incompatible with a barrel-shifter's (public-bound) loop. Extending it to heapless + teaching the gate about public loops is separate infra work, and the **FixedUInt twin** (its Ct `next_power_of_two` has the same latent leak) is still open — both remain tracked in #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a constant-time left shift primitive for HeaplessBigInt and use it to implement a constant-time NextPowerOfTwo for the Ct personality while preserving existing Nct behavior.

New Features:
- Introduce ct_shl, a barrel-shift based constant-time left shift by a secret amount for HeaplessBigInt.
- Implement Ct-specific NextPowerOfTwo for HeaplessBigInt that uses ct_shl to avoid leaking the secret-derived shift amount.

Enhancements:
- Refactor HeaplessBigInt next_power_of_two logic into a shared checked_next_pow2 helper reusable across personalities.
- Expose max_at_len from heapless arithmetic as a reusable helper for computing width-dependent maximum values.

Tests:
- Add tests verifying ct_shl matches the standard left shift for all relevant shift amounts, including over-width.
- Add tests ensuring Ct next_power_of_two semantics match the standard behavior for non-overflow cases and handle zero and overflow (saturating, wrapping, checked) correctly.