### PR TITLE
Add &Self reference-receiver mirrors for HeaplessBigInt (#167)

### DIFF
--- a/src/heapless/abs_diff.rs
+++ b/src/heapless/abs_diff.rs
@@ -38,6 +38,27 @@ where
     }
 }
 
+// `&Self` mirrors so `(&h).abs_diff(&g)` resolves without an explicit copy.
+impl<T, const CAP: usize> AbsDiff for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn abs_diff(self, other: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as AbsDiff>::abs_diff(*self, *other)
+    }
+}
+
+impl<T, const CAP: usize> AbsDiff for &HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = HeaplessBigInt<T, CAP, Ct>;
+    fn abs_diff(self, other: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Ct> as AbsDiff>::abs_diff(*self, *other)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::HeaplessBigInt;
@@ -60,5 +81,13 @@ mod tests {
                 HN::from(expected)
             );
         }
+    }
+
+    #[test]
+    fn byref_matches_value() {
+        let (an, bn) = (HN::from(10u8), HN::from(3u8));
+        assert_eq!(AbsDiff::abs_diff(&an, &bn), AbsDiff::abs_diff(an, bn));
+        let (ac, bc) = (HC::from(3u8), HC::from(10u8));
+        assert_eq!(AbsDiff::abs_diff(&ac, &bc), AbsDiff::abs_diff(ac, bc));
     }
 }

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -314,6 +314,40 @@ where
     }
 }
 
+// Reference-receiver mirrors: `(&h).checked_add(&g)` binds the same generic
+// trait bound as the value form. `HeaplessBigInt: Copy`, so the deref-and-
+// forward is a no-op at runtime.
+
+impl<T, const CAP: usize> CheckedAdd for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn checked_add(self, v: Self) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedAdd>::checked_add(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> CheckedMul for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn checked_mul(self, v: Self) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedMul>::checked_mul(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> CheckedSub for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn checked_sub(self, v: Self) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedSub>::checked_sub(*self, *v)
+    }
+}
+
 // ── num_traits Checked{Add,Sub,Mul} (Nct only) ──
 //
 // The `num_traits::PrimInt` supertraits, bridging its by-reference receiver to
@@ -425,6 +459,70 @@ where
     fn saturating_mul(self, v: Self) -> Self {
         let (res, overflow) = OverflowingMul::overflowing_mul(self, v);
         ct_select(&res, &max_at_len(res.len), overflow)
+    }
+}
+
+// Reference-receiver mirrors for both personalities: deref and forward to the
+// matching value impl (`HeaplessBigInt: Copy`), so `(&h).saturating_add(&g)`
+// resolves the same way `h.saturating_add(g)` does.
+
+impl<T, const CAP: usize> SaturatingAdd for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn saturating_add(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as SaturatingAdd>::saturating_add(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingSub for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn saturating_sub(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as SaturatingSub>::saturating_sub(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingMul for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn saturating_mul(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as SaturatingMul>::saturating_mul(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingAdd for &HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = HeaplessBigInt<T, CAP, Ct>;
+    fn saturating_add(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Ct> as SaturatingAdd>::saturating_add(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingSub for &HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = HeaplessBigInt<T, CAP, Ct>;
+    fn saturating_sub(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Ct> as SaturatingSub>::saturating_sub(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> SaturatingMul for &HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T> + subtle::ConditionallySelectable,
+{
+    type Output = HeaplessBigInt<T, CAP, Ct>;
+    fn saturating_mul(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Ct> as SaturatingMul>::saturating_mul(*self, *v)
     }
 }
 
@@ -814,6 +912,18 @@ where
     }
 }
 
+// Reference-receiver mirror (deref and forward, `HeaplessBigInt: Copy`).
+
+impl<T, const CAP: usize, P: Personality> CarryingAdd for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn carrying_add(self, rhs: Self, carry_in: bool) -> (Self::Output, bool) {
+        <HeaplessBigInt<T, CAP, P> as CarryingAdd>::carrying_add(*self, *rhs, carry_in)
+    }
+}
+
 // `self - rhs - borrow_in` with borrow_out, over the operands' width
 // (`max(self.len, rhs.len)`) — same width rule as `wrapping_sub`, so
 // underflow wraps at the value's width. Used by multi-precision reduction.
@@ -843,6 +953,18 @@ where
             },
             borrow,
         )
+    }
+}
+
+// Reference-receiver mirror (deref and forward, `HeaplessBigInt: Copy`).
+
+impl<T, const CAP: usize, P: Personality> BorrowingSub for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn borrowing_sub(self, rhs: Self, borrow_in: bool) -> (Self::Output, bool) {
+        <HeaplessBigInt<T, CAP, P> as BorrowingSub>::borrowing_sub(*self, *rhs, borrow_in)
     }
 }
 
@@ -954,6 +1076,26 @@ where
             _p: PhantomData,
         };
         (lo, hi)
+    }
+}
+
+// Reference-receiver mirror: both widening-mul methods deref and forward to
+// the value impl (`HeaplessBigInt: Copy`). Mirrors `FixedUInt`'s `&Self`
+// `CarryingMul` in `extended_precision_impl.rs`.
+
+impl<T, const CAP: usize, P: Personality> CarryingMul for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Unsigned = HeaplessBigInt<T, CAP, P>;
+    type Output = HeaplessBigInt<T, CAP, P>;
+
+    fn carrying_mul(self, rhs: Self, carry: Self) -> (Self::Unsigned, Self::Output) {
+        <HeaplessBigInt<T, CAP, P> as CarryingMul>::carrying_mul(*self, *rhs, *carry)
+    }
+
+    fn carrying_mul_add(self, rhs: Self, carry: Self, add: Self) -> (Self::Unsigned, Self::Output) {
+        <HeaplessBigInt<T, CAP, P> as CarryingMul>::carrying_mul_add(*self, *rhs, *carry, *add)
     }
 }
 
@@ -1074,5 +1216,64 @@ mod tests {
                 Cn::from(a.saturating_add(b))
             );
         }
+    }
+
+    // Reference-receiver trait forms resolve to the same value as the by-value
+    // forms — one representative per family (Checked / Saturating / Carrying /
+    // Borrowing), covering both the Nct and Ct saturating personalities.
+    #[test]
+    fn by_ref_matches_value() {
+        let a = H::from(100u32);
+        let b = H::from(7u32);
+        assert_eq!(
+            CheckedAdd::checked_add(&a, &b),
+            CheckedAdd::checked_add(a, b)
+        );
+        assert_eq!(
+            CheckedSub::checked_sub(&a, &b),
+            CheckedSub::checked_sub(a, b)
+        );
+        assert_eq!(
+            CheckedMul::checked_mul(&a, &b),
+            CheckedMul::checked_mul(a, b)
+        );
+        assert_eq!(
+            SaturatingAdd::saturating_add(&a, &b),
+            SaturatingAdd::saturating_add(a, b)
+        );
+        assert_eq!(
+            SaturatingSub::saturating_sub(&a, &b),
+            SaturatingSub::saturating_sub(a, b)
+        );
+        assert_eq!(
+            SaturatingMul::saturating_mul(&a, &b),
+            SaturatingMul::saturating_mul(a, b)
+        );
+        assert_eq!(
+            CarryingAdd::carrying_add(&a, &b, true),
+            CarryingAdd::carrying_add(a, b, true)
+        );
+        assert_eq!(
+            BorrowingSub::borrowing_sub(&a, &b, true),
+            BorrowingSub::borrowing_sub(a, b, true)
+        );
+        let z = <H as Zero>::zero();
+        assert_eq!(
+            CarryingMul::carrying_mul(&a, &b, &z),
+            CarryingMul::carrying_mul(a, b, z)
+        );
+        assert_eq!(
+            CarryingMul::carrying_mul_add(&a, &b, &z, &b),
+            CarryingMul::carrying_mul_add(a, b, z, b)
+        );
+
+        // Ct saturating &Self mirror resolves to the value form too.
+        type Cc = HeaplessBigInt<u8, 4, Ct>;
+        let ca = Cc::from(u32::MAX);
+        let cb = Cc::from(1u32);
+        assert_eq!(
+            SaturatingAdd::saturating_add(&ca, &cb),
+            SaturatingAdd::saturating_add(ca, cb)
+        );
     }
 }

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -315,8 +315,9 @@ where
 }
 
 // Reference-receiver mirrors: `(&h).checked_add(&g)` binds the same generic
-// trait bound as the value form. `HeaplessBigInt: Copy`, so the deref-and-
-// forward is a no-op at runtime.
+// trait bound as the value form. The receiver and operand are already `&Self`,
+// so these forward to the inherent by-ref methods (`checked_add(&self, &Self)`)
+// rather than the by-value trait — no `[T; CAP]` copy of either operand.
 
 impl<T, const CAP: usize> CheckedAdd for &HeaplessBigInt<T, CAP, Nct>
 where
@@ -324,7 +325,7 @@ where
 {
     type Output = HeaplessBigInt<T, CAP, Nct>;
     fn checked_add(self, v: Self) -> Option<Self::Output> {
-        <HeaplessBigInt<T, CAP, Nct> as CheckedAdd>::checked_add(*self, *v)
+        HeaplessBigInt::<T, CAP, Nct>::checked_add(self, v)
     }
 }
 
@@ -334,7 +335,7 @@ where
 {
     type Output = HeaplessBigInt<T, CAP, Nct>;
     fn checked_mul(self, v: Self) -> Option<Self::Output> {
-        <HeaplessBigInt<T, CAP, Nct> as CheckedMul>::checked_mul(*self, *v)
+        HeaplessBigInt::<T, CAP, Nct>::checked_mul(self, v)
     }
 }
 
@@ -344,7 +345,7 @@ where
 {
     type Output = HeaplessBigInt<T, CAP, Nct>;
     fn checked_sub(self, v: Self) -> Option<Self::Output> {
-        <HeaplessBigInt<T, CAP, Nct> as CheckedSub>::checked_sub(*self, *v)
+        HeaplessBigInt::<T, CAP, Nct>::checked_sub(self, v)
     }
 }
 

--- a/src/heapless/bit_deposit.rs
+++ b/src/heapless/bit_deposit.rs
@@ -76,6 +76,30 @@ where
     }
 }
 
+// Reference-receiver mirrors (`&HeaplessBigInt`), so `(&h).deposit_bits(m)`
+// resolves. `HeaplessBigInt` is `Copy`; each delegates to the value impl,
+// dereferencing both `self` and the `mask` operand.
+
+impl<T, const CAP: usize> DepositBits for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn deposit_bits(self, mask: Self) -> HeaplessBigInt<T, CAP, Nct> {
+        <HeaplessBigInt<T, CAP, Nct> as DepositBits>::deposit_bits(*self, *mask)
+    }
+}
+
+impl<T, const CAP: usize> ExtractBits for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn extract_bits(self, mask: Self) -> HeaplessBigInt<T, CAP, Nct> {
+        <HeaplessBigInt<T, CAP, Nct> as ExtractBits>::extract_bits(*self, *mask)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::HeaplessBigInt;
@@ -120,5 +144,20 @@ mod tests {
         let z0 = H::new_zero_with_len(0);
         assert_eq!(DepositBits::deposit_bits(z0, z0).len(), 0);
         assert_eq!(ExtractBits::extract_bits(z0, z0).len(), 0);
+    }
+
+    // The `&Self` mirrors agree with the value impls.
+    #[test]
+    fn by_ref_matches_value() {
+        let mask = H::from(0b0101_0101u8).widened(4);
+        let src = H::from(0b1011u8).widened(4);
+        assert_eq!(
+            DepositBits::deposit_bits(&src, &mask),
+            DepositBits::deposit_bits(src, mask)
+        );
+        assert_eq!(
+            ExtractBits::extract_bits(&src, &mask),
+            ExtractBits::extract_bits(src, mask)
+        );
     }
 }

--- a/src/heapless/bit_scan.rs
+++ b/src/heapless/bit_scan.rs
@@ -72,6 +72,48 @@ where
     }
 }
 
+// Reference-receiver mirrors (`&HeaplessBigInt`), so `(&h).highest_one()` etc.
+// resolve. `HeaplessBigInt` is `Copy`, so each delegates to the value impl on
+// `*self`.
+
+impl<T, const CAP: usize, P: Personality> HighestOne for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    fn highest_one(self) -> Option<u32> {
+        <HeaplessBigInt<T, CAP, P> as HighestOne>::highest_one(*self)
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> LowestOne for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    fn lowest_one(self) -> Option<u32> {
+        <HeaplessBigInt<T, CAP, P> as LowestOne>::lowest_one(*self)
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> IsolateHighestOne for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn isolate_highest_one(self) -> HeaplessBigInt<T, CAP, P> {
+        <HeaplessBigInt<T, CAP, P> as IsolateHighestOne>::isolate_highest_one(*self)
+    }
+}
+
+impl<T, const CAP: usize, P: Personality> IsolateLowestOne for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn isolate_lowest_one(self) -> HeaplessBigInt<T, CAP, P> {
+        <HeaplessBigInt<T, CAP, P> as IsolateLowestOne>::isolate_lowest_one(*self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::HeaplessBigInt;
@@ -110,5 +152,22 @@ mod tests {
         let z0 = H::new_zero_with_len(0);
         assert_eq!(IsolateHighestOne::isolate_highest_one(z0).len(), 0);
         assert_eq!(IsolateLowestOne::isolate_lowest_one(z0).len(), 0);
+    }
+
+    // The `&Self` mirrors agree with the value impls.
+    #[test]
+    fn by_ref_matches_value() {
+        let v = H::from(0xB4u8).widened(8);
+        let r = &v; // dispatch through the `&Self` mirror
+        assert_eq!(HighestOne::highest_one(r), HighestOne::highest_one(v));
+        assert_eq!(LowestOne::lowest_one(r), LowestOne::lowest_one(v));
+        assert_eq!(
+            IsolateHighestOne::isolate_highest_one(r),
+            IsolateHighestOne::isolate_highest_one(v)
+        );
+        assert_eq!(
+            IsolateLowestOne::isolate_lowest_one(r),
+            IsolateLowestOne::isolate_lowest_one(v)
+        );
     }
 }

--- a/src/heapless/div_rem.rs
+++ b/src/heapless/div_rem.rs
@@ -217,6 +217,40 @@ where
     }
 }
 
+// Reference-receiver mirrors: `(&h).checked_div(&g)` binds the same generic
+// trait bound as the value form. `HeaplessBigInt: Copy`, so the deref-and-
+// forward is a no-op at runtime. Nct-only, matching the value forms.
+
+impl<T, const CAP: usize> CheckedDiv for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn checked_div(self, v: Self) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedDiv>::checked_div(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> CheckedRem for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn checked_rem(self, v: Self) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedRem>::checked_rem(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> DivCeil for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn div_ceil(self, rhs: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as DivCeil>::div_ceil(*self, *rhs)
+    }
+}
+
 #[cfg(feature = "num-traits")]
 impl<T, const CAP: usize> num_traits::CheckedDiv for HeaplessBigInt<T, CAP, Nct>
 where
@@ -283,7 +317,7 @@ where
 #[cfg(test)]
 mod div_ceil_tests {
     use super::HeaplessBigInt;
-    use const_num_traits::DivCeil;
+    use const_num_traits::{CheckedDiv, CheckedRem, DivCeil};
 
     type H = HeaplessBigInt<u8, 4>;
 
@@ -304,5 +338,22 @@ mod div_ceil_tests {
             H::from(u32::MAX).checked_div_ceil(&H::from(2u8)),
             Some(H::from(0x8000_0000u32))
         );
+    }
+
+    // Reference-receiver trait forms resolve to the same value as the by-value
+    // forms for the const_num_traits div/rem/ceil family.
+    #[test]
+    fn by_ref_matches_value() {
+        let a = H::from(100u8);
+        let b = H::from(7u8);
+        assert_eq!(
+            CheckedDiv::checked_div(&a, &b),
+            CheckedDiv::checked_div(a, b)
+        );
+        assert_eq!(
+            CheckedRem::checked_rem(&a, &b),
+            CheckedRem::checked_rem(a, b)
+        );
+        assert_eq!(DivCeil::div_ceil(&a, &b), DivCeil::div_ceil(a, b));
     }
 }

--- a/src/heapless/euclid.rs
+++ b/src/heapless/euclid.rs
@@ -43,3 +43,67 @@ where
         }
     }
 }
+
+// `&Self` mirrors so `(&h).div_euclid(&g)` resolves without an explicit copy.
+impl<T, const CAP: usize> Euclid for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn div_euclid(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as Euclid>::div_euclid(*self, *v)
+    }
+    fn rem_euclid(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as Euclid>::rem_euclid(*self, *v)
+    }
+    fn div_rem_euclid(self, v: Self) -> (Self::Output, Self::Output) {
+        <HeaplessBigInt<T, CAP, Nct> as Euclid>::div_rem_euclid(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> CheckedEuclid for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn checked_div_euclid(self, v: Self) -> Option<<Self as Euclid>::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedEuclid>::checked_div_euclid(*self, *v)
+    }
+    fn checked_rem_euclid(self, v: Self) -> Option<<Self as Euclid>::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedEuclid>::checked_rem_euclid(*self, *v)
+    }
+    fn checked_div_rem_euclid(
+        self,
+        v: Self,
+    ) -> Option<(<Self as Euclid>::Output, <Self as Euclid>::Output)> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedEuclid>::checked_div_rem_euclid(*self, *v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HeaplessBigInt;
+    use const_num_traits::{CheckedEuclid, Euclid};
+
+    type H = HeaplessBigInt<u8, 4>;
+
+    #[test]
+    fn byref_matches_value() {
+        let a = H::from(17u8);
+        let b = H::from(5u8);
+        assert_eq!(Euclid::div_euclid(&a, &b), Euclid::div_euclid(a, b));
+        assert_eq!(Euclid::rem_euclid(&a, &b), Euclid::rem_euclid(a, b));
+        assert_eq!(Euclid::div_rem_euclid(&a, &b), Euclid::div_rem_euclid(a, b));
+        assert_eq!(
+            CheckedEuclid::checked_div_euclid(&a, &b),
+            CheckedEuclid::checked_div_euclid(a, b)
+        );
+        assert_eq!(
+            CheckedEuclid::checked_rem_euclid(&a, &b),
+            CheckedEuclid::checked_rem_euclid(a, b)
+        );
+        assert_eq!(
+            CheckedEuclid::checked_div_rem_euclid(&a, &b),
+            CheckedEuclid::checked_div_rem_euclid(a, b)
+        );
+    }
+}

--- a/src/heapless/ilog.rs
+++ b/src/heapless/ilog.rs
@@ -93,6 +93,46 @@ where
     }
 }
 
+// `&Self` mirrors so `(&h).ilog(&base)` resolves without an explicit copy.
+impl<T, const CAP: usize> Ilog2 for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    fn ilog2(self) -> u32 {
+        <HeaplessBigInt<T, CAP, Nct> as Ilog2>::ilog2(*self)
+    }
+
+    fn checked_ilog2(self) -> Option<u32> {
+        <HeaplessBigInt<T, CAP, Nct> as Ilog2>::checked_ilog2(*self)
+    }
+}
+
+impl<T, const CAP: usize> Ilog10 for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn ilog10(self) -> u32 {
+        <HeaplessBigInt<T, CAP, Nct> as Ilog10>::ilog10(*self)
+    }
+
+    fn checked_ilog10(self) -> Option<u32> {
+        <HeaplessBigInt<T, CAP, Nct> as Ilog10>::checked_ilog10(*self)
+    }
+}
+
+impl<T, const CAP: usize> Ilog for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn ilog(self, base: Self) -> u32 {
+        <HeaplessBigInt<T, CAP, Nct> as Ilog>::ilog(*self, *base)
+    }
+
+    fn checked_ilog(self, base: Self) -> Option<u32> {
+        <HeaplessBigInt<T, CAP, Nct> as Ilog>::checked_ilog(*self, *base)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::HeaplessBigInt;
@@ -143,5 +183,18 @@ mod tests {
                 "ilog(base 10, {n})"
             );
         }
+    }
+
+    #[test]
+    fn byref_matches_value() {
+        let a = H::from(27u8);
+        let base = H::from(3u8);
+        let r = &a; // dispatch through the `&Self` mirror
+        assert_eq!(Ilog2::ilog2(r), Ilog2::ilog2(a));
+        assert_eq!(Ilog2::checked_ilog2(r), Ilog2::checked_ilog2(a));
+        assert_eq!(Ilog10::ilog10(r), Ilog10::ilog10(a));
+        assert_eq!(Ilog10::checked_ilog10(r), Ilog10::checked_ilog10(a));
+        assert_eq!(Ilog::ilog(r, &base), Ilog::ilog(a, base));
+        assert_eq!(Ilog::checked_ilog(r, &base), Ilog::checked_ilog(a, base));
     }
 }

--- a/src/heapless/isqrt.rs
+++ b/src/heapless/isqrt.rs
@@ -47,6 +47,17 @@ where
     }
 }
 
+// `&Self` mirror so `(&h).isqrt()` resolves without an explicit copy.
+impl<T, const CAP: usize> Isqrt for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn isqrt(self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as Isqrt>::isqrt(*self)
+    }
+}
+
 impl<T, const CAP: usize> HeaplessBigInt<T, CAP, Nct>
 where
     T: MachineWord,
@@ -111,5 +122,11 @@ mod tests {
         // Zero keeps its width too.
         let z = H::new_zero_with_len(8);
         assert_eq!(Isqrt::isqrt(z).len(), 8);
+    }
+
+    #[test]
+    fn byref_matches_value() {
+        let a = H::from(10000u16);
+        assert_eq!(Isqrt::isqrt(&a), Isqrt::isqrt(a));
     }
 }

--- a/src/heapless/midpoint.rs
+++ b/src/heapless/midpoint.rs
@@ -18,3 +18,29 @@ where
         (self & rhs) + ((self ^ rhs) >> 1usize)
     }
 }
+
+// `&Self` mirror so `(&h).midpoint(&g)` resolves without an explicit copy.
+impl<T, const CAP: usize, P: Personality> Midpoint for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn midpoint(self, rhs: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, P> as Midpoint>::midpoint(*self, *rhs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HeaplessBigInt;
+    use const_num_traits::Midpoint;
+
+    type H = HeaplessBigInt<u8, 4>;
+
+    #[test]
+    fn byref_matches_value() {
+        let a = H::from(10u8);
+        let b = H::from(21u8);
+        assert_eq!(Midpoint::midpoint(&a, &b), Midpoint::midpoint(a, b));
+    }
+}

--- a/src/heapless/multiple.rs
+++ b/src/heapless/multiple.rs
@@ -51,6 +51,31 @@ where
     }
 }
 
+// `&Self` mirrors so `(&h).is_multiple_of(&g)` resolves without an explicit copy.
+impl<T, const CAP: usize> MultipleOf for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    fn is_multiple_of(self, rhs: Self) -> bool {
+        <HeaplessBigInt<T, CAP, Nct> as MultipleOf>::is_multiple_of(*self, *rhs)
+    }
+}
+
+impl<T, const CAP: usize> NextMultipleOf for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+
+    fn next_multiple_of(self, rhs: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as NextMultipleOf>::next_multiple_of(*self, *rhs)
+    }
+
+    fn checked_next_multiple_of(self, rhs: Self) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as NextMultipleOf>::checked_next_multiple_of(*self, *rhs)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::HeaplessBigInt;
@@ -76,5 +101,24 @@ mod tests {
         // 3's next multiple of 10 is 10 itself (the `self + (rhs - rem)` path).
         let out = NextMultipleOf::next_multiple_of(H::from(3u8), H::from(10u8));
         assert_eq!(out, H::from(10u8));
+    }
+
+    #[test]
+    fn byref_matches_value() {
+        use const_num_traits::MultipleOf;
+        let a = H::from(12u8);
+        let b = H::from(5u8);
+        assert_eq!(
+            MultipleOf::is_multiple_of(&a, &b),
+            MultipleOf::is_multiple_of(a, b)
+        );
+        assert_eq!(
+            NextMultipleOf::next_multiple_of(&a, &b),
+            NextMultipleOf::next_multiple_of(a, b)
+        );
+        assert_eq!(
+            NextMultipleOf::checked_next_multiple_of(&a, &b),
+            NextMultipleOf::checked_next_multiple_of(a, b)
+        );
     }
 }

--- a/src/heapless/pow.rs
+++ b/src/heapless/pow.rs
@@ -84,6 +84,29 @@ where
     }
 }
 
+// `&Self` reference-receiver mirrors. `HeaplessBigInt` is `Copy`, so each
+// mirror derefs its receiver and forwards to the value impl above.
+
+impl<T, const CAP: usize> CheckedPow for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn checked_pow(self, exp: u32) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as CheckedPow>::checked_pow(*self, exp)
+    }
+}
+
+impl<T, const CAP: usize> StrictPow for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn strict_pow(self, exp: u32) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as StrictPow>::strict_pow(*self, exp)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,5 +140,18 @@ mod tests {
     fn strict_pow_panics_on_overflow() {
         let base = H::from_le_bytes(&2u32.to_le_bytes());
         let _ = StrictPow::strict_pow(base, 32);
+    }
+
+    #[test]
+    fn byref_matches_value() {
+        let base = H::from_le_bytes(&2u32.to_le_bytes());
+        assert_eq!(
+            CheckedPow::checked_pow(&base, 10),
+            CheckedPow::checked_pow(base, 10)
+        );
+        assert_eq!(
+            StrictPow::strict_pow(&base, 10),
+            StrictPow::strict_pow(base, 10)
+        );
     }
 }

--- a/src/heapless/power_of_two.rs
+++ b/src/heapless/power_of_two.rs
@@ -144,6 +144,54 @@ where
     }
 }
 
+// `&Self` mirrors so `(&h).next_power_of_two()` resolves without an explicit copy.
+impl<T, const CAP: usize, P: Personality> IsPowerOfTwo for &HeaplessBigInt<T, CAP, P>
+where
+    T: MachineWord,
+{
+    fn is_power_of_two(self) -> bool {
+        <HeaplessBigInt<T, CAP, P> as IsPowerOfTwo>::is_power_of_two(*self)
+    }
+}
+
+impl<T, const CAP: usize> NextPowerOfTwo for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+
+    fn wrapping_next_power_of_two(self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as NextPowerOfTwo>::wrapping_next_power_of_two(*self)
+    }
+
+    fn next_power_of_two(self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as NextPowerOfTwo>::next_power_of_two(*self)
+    }
+
+    fn checked_next_power_of_two(self) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Nct> as NextPowerOfTwo>::checked_next_power_of_two(*self)
+    }
+}
+
+impl<T, const CAP: usize> NextPowerOfTwo for &HeaplessBigInt<T, CAP, Ct>
+where
+    T: MachineWord + subtle::ConditionallySelectable,
+{
+    type Output = HeaplessBigInt<T, CAP, Ct>;
+
+    fn next_power_of_two(self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Ct> as NextPowerOfTwo>::next_power_of_two(*self)
+    }
+
+    fn wrapping_next_power_of_two(self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Ct> as NextPowerOfTwo>::wrapping_next_power_of_two(*self)
+    }
+
+    fn checked_next_power_of_two(self) -> Option<Self::Output> {
+        <HeaplessBigInt<T, CAP, Ct> as NextPowerOfTwo>::checked_next_power_of_two(*self)
+    }
+}
+
 // `CtIsPowerOfTwo` — masked-return `is_power_of_two`, the same subtle-predicate
 // style as `CtIsZero`/`CtParity` (`nonzero & is_zero(x & (x - 1))` composed of
 // `Choice`s). No `const_ct_select` needed, so it's personality-generic.
@@ -241,5 +289,35 @@ mod tests {
             HC::from(0u8)
         );
         assert_eq!(NextPowerOfTwo::checked_next_power_of_two(big), None);
+    }
+
+    #[test]
+    fn byref_matches_value() {
+        use const_num_traits::{Ct, IsPowerOfTwo};
+        let a = H::from(5u8);
+        let r = &a; // dispatch through the `&Self` mirror
+        assert_eq!(
+            IsPowerOfTwo::is_power_of_two(r),
+            IsPowerOfTwo::is_power_of_two(a)
+        );
+        assert_eq!(
+            NextPowerOfTwo::next_power_of_two(r),
+            NextPowerOfTwo::next_power_of_two(a)
+        );
+        assert_eq!(
+            NextPowerOfTwo::wrapping_next_power_of_two(r),
+            NextPowerOfTwo::wrapping_next_power_of_two(a)
+        );
+        assert_eq!(
+            NextPowerOfTwo::checked_next_power_of_two(r),
+            NextPowerOfTwo::checked_next_power_of_two(a)
+        );
+
+        type HC = HeaplessBigInt<u8, 4, Ct>;
+        let c = HC::from(5u8);
+        assert_eq!(
+            NextPowerOfTwo::next_power_of_two(&c),
+            NextPowerOfTwo::next_power_of_two(c)
+        );
     }
 }

--- a/src/heapless/shift_ops.rs
+++ b/src/heapless/shift_ops.rs
@@ -185,6 +185,98 @@ impl<T: MachineWord, const CAP: usize, P: Personality> FunnelShr for HeaplessBig
     }
 }
 
+// Reference-receiver mirrors (`&HeaplessBigInt`), so `(&h).wrapping_shl(n)` etc.
+// resolve. `HeaplessBigInt` is `Copy`; each delegates to the value impl on
+// `*self` (and `*rhs` for the funnel operand). `u32` amounts pass through.
+
+impl<T: MachineWord, const CAP: usize, P: Personality> OverflowingShl
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn overflowing_shl(self, bits: u32) -> (HeaplessBigInt<T, CAP, P>, bool) {
+        <HeaplessBigInt<T, CAP, P> as OverflowingShl>::overflowing_shl(*self, bits)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> OverflowingShr
+    for &HeaplessBigInt<T, CAP, P>
+{
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn overflowing_shr(self, bits: u32) -> (HeaplessBigInt<T, CAP, P>, bool) {
+        <HeaplessBigInt<T, CAP, P> as OverflowingShr>::overflowing_shr(*self, bits)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> WrappingShl for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn wrapping_shl(self, bits: u32) -> HeaplessBigInt<T, CAP, P> {
+        <HeaplessBigInt<T, CAP, P> as WrappingShl>::wrapping_shl(*self, bits)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> WrappingShr for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn wrapping_shr(self, bits: u32) -> HeaplessBigInt<T, CAP, P> {
+        <HeaplessBigInt<T, CAP, P> as WrappingShr>::wrapping_shr(*self, bits)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> CheckedShl for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn checked_shl(self, bits: u32) -> Option<HeaplessBigInt<T, CAP, P>> {
+        <HeaplessBigInt<T, CAP, P> as CheckedShl>::checked_shl(*self, bits)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> CheckedShr for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn checked_shr(self, bits: u32) -> Option<HeaplessBigInt<T, CAP, P>> {
+        <HeaplessBigInt<T, CAP, P> as CheckedShr>::checked_shr(*self, bits)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> UnboundedShl for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn unbounded_shl(self, rhs: u32) -> HeaplessBigInt<T, CAP, P> {
+        <HeaplessBigInt<T, CAP, P> as UnboundedShl>::unbounded_shl(*self, rhs)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> UnboundedShr for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn unbounded_shr(self, rhs: u32) -> HeaplessBigInt<T, CAP, P> {
+        <HeaplessBigInt<T, CAP, P> as UnboundedShr>::unbounded_shr(*self, rhs)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> ShlExact for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn shl_exact(self, rhs: u32) -> Option<HeaplessBigInt<T, CAP, P>> {
+        <HeaplessBigInt<T, CAP, P> as ShlExact>::shl_exact(*self, rhs)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> ShrExact for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn shr_exact(self, rhs: u32) -> Option<HeaplessBigInt<T, CAP, P>> {
+        <HeaplessBigInt<T, CAP, P> as ShrExact>::shr_exact(*self, rhs)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> FunnelShl for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn funnel_shl(self, rhs: Self, n: u32) -> HeaplessBigInt<T, CAP, P> {
+        <HeaplessBigInt<T, CAP, P> as FunnelShl>::funnel_shl(*self, *rhs, n)
+    }
+}
+
+impl<T: MachineWord, const CAP: usize, P: Personality> FunnelShr for &HeaplessBigInt<T, CAP, P> {
+    type Output = HeaplessBigInt<T, CAP, P>;
+    fn funnel_shr(self, rhs: Self, n: u32) -> HeaplessBigInt<T, CAP, P> {
+        <HeaplessBigInt<T, CAP, P> as FunnelShr>::funnel_shr(*self, *rhs, n)
+    }
+}
+
 // num_traits wrappers — delegate to the const-num-traits impls above.
 #[cfg(feature = "num-traits")]
 impl<T: MachineWord, const CAP: usize, P: Personality> num_traits::WrappingShl
@@ -320,5 +412,40 @@ mod tests {
         assert_eq!(FunnelShr::funnel_shr(hi, lo, 8), H::from(0x789A_BCDEu32));
         assert_eq!(FunnelShl::funnel_shl(hi, lo, 0), hi);
         assert_eq!(FunnelShr::funnel_shr(hi, lo, 0), lo);
+    }
+
+    // The `&Self` mirrors agree with the value impls.
+    #[test]
+    fn by_ref_matches_value() {
+        let v = H::from(1u8).widened(4);
+        assert_eq!(
+            OverflowingShl::overflowing_shl(&v, 4),
+            OverflowingShl::overflowing_shl(v, 4)
+        );
+        assert_eq!(
+            WrappingShl::wrapping_shl(&v, 5),
+            WrappingShl::wrapping_shl(v, 5)
+        );
+        assert_eq!(
+            CheckedShl::checked_shl(&v, 5),
+            CheckedShl::checked_shl(v, 5)
+        );
+        assert_eq!(
+            UnboundedShl::unbounded_shl(&v, 100),
+            UnboundedShl::unbounded_shl(v, 100)
+        );
+        assert_eq!(ShlExact::shl_exact(&v, 3), ShlExact::shl_exact(v, 3));
+        assert_eq!(ShrExact::shr_exact(&v, 0), ShrExact::shr_exact(v, 0));
+
+        let hi = H::from(0x1234_5678u32);
+        let lo = H::from(0x9ABC_DEF0u32);
+        assert_eq!(
+            FunnelShl::funnel_shl(&hi, &lo, 8),
+            FunnelShl::funnel_shl(hi, lo, 8)
+        );
+        assert_eq!(
+            FunnelShr::funnel_shr(&hi, &lo, 8),
+            FunnelShr::funnel_shr(hi, lo, 8)
+        );
     }
 }

--- a/src/heapless/strict.rs
+++ b/src/heapless/strict.rs
@@ -102,6 +102,79 @@ where
     }
 }
 
+// `&Self` reference-receiver mirrors. `HeaplessBigInt` is `Copy`, so each
+// mirror derefs its receiver/operands and forwards to the value impl above.
+
+impl<T, const CAP: usize> StrictAdd for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn strict_add(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as StrictAdd>::strict_add(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> StrictSub for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn strict_sub(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as StrictSub>::strict_sub(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> StrictMul for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn strict_mul(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as StrictMul>::strict_mul(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> StrictDiv for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn strict_div(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as StrictDiv>::strict_div(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> StrictRem for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T>,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn strict_rem(self, v: Self) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as StrictRem>::strict_rem(*self, *v)
+    }
+}
+
+impl<T, const CAP: usize> StrictShl for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn strict_shl(self, rhs: u32) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as StrictShl>::strict_shl(*self, rhs)
+    }
+}
+
+impl<T, const CAP: usize> StrictShr for &HeaplessBigInt<T, CAP, Nct>
+where
+    T: MachineWord,
+{
+    type Output = HeaplessBigInt<T, CAP, Nct>;
+    fn strict_shr(self, rhs: u32) -> Self::Output {
+        <HeaplessBigInt<T, CAP, Nct> as StrictShr>::strict_shr(*self, rhs)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::HeaplessBigInt;
@@ -131,5 +204,12 @@ mod tests {
     #[should_panic(expected = "strict_shl shift exceeds")]
     fn strict_shl_over_width_panics() {
         StrictShl::strict_shl(H::from(1u8).widened(4), 32);
+    }
+
+    #[test]
+    fn byref_matches_value() {
+        let a = H::from(10u8).widened(4);
+        let b = H::from(20u8);
+        assert_eq!(StrictAdd::strict_add(&a, &b), StrictAdd::strict_add(a, b));
     }
 }


### PR DESCRIPTION
## What

Adds the missing `&Self` reference-receiver trait mirrors on `HeaplessBigInt`, closing the by-ref operand gap with `FixedUInt` tracked in #167.

## Why

`FixedUInt` gets by-ref operand impls for free: its ops are wrapped in the `c0nst!` DSL, which emits `&Self` mirror impls as a side effect. `HeaplessBigInt` deliberately does **not** use `c0nst!` — its width is a runtime `len`, not a const `N`, so const-eval doesn't apply — so it wrote plain runtime impls by hand and never inherited those mirrors. The result was ~55 convenience traits that accepted a borrowed operand on `FixedUInt` but only a value on the heapless carrier.

## What's covered

`&HeaplessBigInt` now implements, matching each value impl's exact generics / bounds / personality (Nct, Ct, or P-generic):

- **strict**: `StrictAdd/Sub/Mul/Div/Rem/Shl/Shr`, `StrictPow`, `CheckedPow`
- **checked/saturating**: `CheckedAdd/Sub/Mul`, `SaturatingAdd/Sub/Mul` (both Nct and Ct forms), `CheckedDiv/Rem`, `DivCeil`
- **extended**: `CarryingAdd`, `BorrowingSub`, `CarryingMul` (`carrying_mul` + `carrying_mul_add`)
- **scalar**: `Euclid`, `CheckedEuclid`, `MultipleOf`, `NextMultipleOf`, `AbsDiff` (Nct+Ct), `Midpoint`, `Isqrt`, `Ilog/Ilog2/Ilog10`, `IsPowerOfTwo`, `NextPowerOfTwo` (Nct+Ct)
- **bits/shifts**: `HighestOne`, `LowestOne`, `IsolateHighestOne`, `IsolateLowestOne`, `DepositBits`, `ExtractBits`, and the full `Overflowing/Wrapping/Checked/Unbounded/Exact/Funnel Shl/Shr` family

Each mirror forwards via `*self` (free — `HeaplessBigInt: Copy`) with every `Self`-typed argument dereferenced and scalar args passed through; `Output`/`Unsigned` associated types resolve to the value type. The `num_traits::*` impls that already take `&self` are untouched.

## Tests

Each touched file gets a by-ref-equals-value smoke test, dispatched through an explicit `&` binding so the reference impl is the one exercised (not elided back to the value impl).

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add by-reference (&Self) trait implementations for HeaplessBigInt to mirror existing by-value operations and align ergonomics with FixedUInt.

New Features:
- Support calling checked, saturating, strict, Euclid, power, multiple-of, abs-diff, midpoint, isqrt, ilog, bit-scan, bit-deposit/extract, and extended carrying/borrowing arithmetic traits on &HeaplessBigInt operands, matching existing value-based behavior.
- Enable calling the full family of shift and funnel shift traits on &HeaplessBigInt, returning HeaplessBigInt values without requiring explicit copies.

Tests:
- Add smoke tests ensuring each new &Self mirror trait implementation on HeaplessBigInt produces the same results as the corresponding by-value trait calls across arithmetic, bitwise, shift, and numeric utility operations.