### PR TITLE
Cover the HeaplessBigInt Ct surface + fix the Ct shift leak

### DIFF
--- a/ct-verify/ct-ctgrind/Cargo.toml
+++ b/ct-verify/ct-ctgrind/Cargo.toml
@@ -14,6 +14,8 @@ path = "src/main.rs"
 # Link the fixtures as a Rust rlib so this binary can call each
 # `extern "C"` symbol directly. `default-features = false` disables
 # ct-fixtures' `#[panic_handler]` so std's panic handler is used.
-ct-fixtures = { path = "../ct-fixtures", default-features = false, features = ["ctgrind"] }
+# `heapless` pulls the HeaplessBigInt fixtures in too, so the taint check
+# independently cross-checks the helpers the asm-grep gate only attests.
+ct-fixtures = { path = "../ct-fixtures", default-features = false, features = ["ctgrind", "heapless"] }
 
 krabi-caliper = { version = "0.1", features = ["ctgrind"] }

--- a/ct-verify/ct-driver/src/main.rs
+++ b/ct-verify/ct-driver/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> ExitCode {
             driver: DriverConfig {
                 workspace,
                 fixture_package: "ct-fixtures",
-                fixture_features: &[],
+                fixture_features: &["heapless"],
             },
             memory_class_negatives: &[],
         },

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -258,6 +258,56 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // are on the shift count, which our Ct shift helpers always pass
     // as a public-bounded `1 << k` from a public iteration counter.
     r"^__(?:ashl|ashr|lshr)[dt]i3$",
+    // The shared full-width compare scan `const_cmp_ct`. MSB-to-LSB with
+    // an `undecided` lock, no early return; loop bound is the operand
+    // length (public). Backs FixedUInt's and HeaplessBigInt's Ct `Ord::cmp`.
+    r"fixed_bigint9fixeduint12const_cmp_ct",
+    // ── HeaplessBigInt Ct helpers ──
+    //
+    // Heapless's width is a runtime `len` field, so its per-limb loops bound
+    // on `len` / `max(len)` / `CAP` — all PUBLIC shape parameters — and
+    // compile to a *register*-bounded `cmp; b.lt` rather than FixedUInt's
+    // immediate-bounded form. The source-semantic property is identical: a
+    // public-bounded loop. Each impl below was read and confirmed to branch
+    // only on those bounds (the value flows through branchless per-limb
+    // arithmetic / masked selects / xor-folds).
+    //
+    // Deliberately ABSENT: `fixed_bigint..heapless..shift`. The `<<`/`>>`
+    // operators are dual-use — reachable with a secret amount — so they are
+    // not attestable by symbol. Ops that route through them
+    // (is/next_power_of_two, midpoint) are left unfixtured, not allowlisted.
+
+    // Whole heapless per-limb modules — bitwise (Not/BitAnd/Or/Xor), cmp
+    // (PartialEq/Ord/subtle ConstantTime*/ConditionallySelectable/CtIsZero),
+    // parity (CtParity), the two bit-scan modules (leading/trailing_zeros,
+    // count_ones, swap_bytes, reverse_bits — the zero scans route through the
+    // allowlisted const_*_ct helpers), and identities' Zero (is_zero). Each
+    // was audited: loops bound on `len`/`max(len)`, value flows through
+    // branchless per-limb arithmetic / masked selects / xor-folds. `bits.rs`
+    // holds the inherent `leading_zeros`; `cmp.rs` holds `Ord::cmp`
+    // (`limbs[..len]` slice then `const_cmp_ct`). NB: `heapless::shift` is
+    // deliberately excluded (dual-use operators, see above).
+    r"fixed_bigint\d*heapless(?:7bitwise|3cmp|6parity|9prim_bits|4bits)",
+    r"fixed_bigint\d*heapless10identities.*(?:Const)?Zero",
+    // heapless arith. Div/Rem here are Nct-only and never reached from a Ct
+    // fixture; every helper a Ct op does reach — saturating (ct_select),
+    // carrying/borrowing, wrapping/overflowing, the CtChecked* traits, and the
+    // schoolbook multiply (`mul_slice`/CarryingMul, nested loops bounded on
+    // public a_n/b_n/out_n) — is public-bounded.
+    r"fixed_bigint\d*heapless5arith",
+    // heapless construction (`from_limbs`/`all_limbs`/`limbs[..len]`) and the
+    // core adapters it pulls in — `Zip`, array `IntoIter`, `RangeTo`
+    // slice-index, array `Index`. All bounded by public array/slice lengths;
+    // no fixture ever indexes by a secret. ctgrind independently taint-checks
+    // secret-dependent access on its supported targets.
+    r"fixed_bigint\d*heapless.*HeaplessBigInt.*(?:new_zero_with_len|7widened)",
+    r"core\.\.iter\.\.adapters\.\.zip\.\.Zip",
+    r"core\.\.array\.\.iter\.\.IntoIter",
+    r"core\.\.ops\.\.range\.\.RangeTo.*slice\.\.index",
+    r"core5array\d*_\$LT\$impl.*ops\.\.index\.\.Index",
+    // subtle's primitive `<u{8,16,64} as ConstantTimeGreater>::ct_gt` reached
+    // from heapless ConstantTimeGreater (the u32 form is already above).
+    r"\$LT\$u(?:8|16|64)\$u20\$as\$u20\$subtle\.\.ConstantTimeGreater\$GT\$5ct_gt",
 ];
 
 /// Thumbv6m-specific extras layered onto `HELPER_ALLOWLIST`.

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -297,12 +297,9 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // parity (CtParity), the two bit-scan modules (leading/trailing_zeros,
     // count_ones, swap_bytes, reverse_bits — the zero scans route through the
     // allowlisted const_*_ct helpers), and identities' Zero (is_zero) plus the
-    // out-of-line `const_is_one_ct` fold behind One's is_one. Each was audited:
-    // loops bound on `len`/`max(len)`, value flows through branchless per-limb
-    // arithmetic / masked selects / xor-folds. `bits.rs` holds the inherent
-    // `leading_zeros`; `cmp.rs` holds `Ord::cmp` (`limbs[..len]` slice then
-    // `const_cmp_ct`). NB: `heapless::shift` is deliberately excluded (dual-use
-    // operators, see above).
+    // out-of-line `const_is_one_ct` fold behind One's is_one. `bits.rs` holds
+    // the inherent `leading_zeros`; `cmp.rs` holds `Ord::cmp` (`limbs[..len]`
+    // slice then `const_cmp_ct`).
     r"fixed_bigint\d*heapless(?:7bitwise|3cmp|6parity|9prim_bits|4bits)",
     r"fixed_bigint\d*heapless10identities.*(?:Const)?Zero",
     r"fixed_bigint\d*heapless10identities15const_is_one_ct",

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -293,14 +293,16 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // (PartialEq/Ord/subtle ConstantTime*/ConditionallySelectable/CtIsZero),
     // parity (CtParity), the two bit-scan modules (leading/trailing_zeros,
     // count_ones, swap_bytes, reverse_bits — the zero scans route through the
-    // allowlisted const_*_ct helpers), and identities' Zero (is_zero). Each
-    // was audited: loops bound on `len`/`max(len)`, value flows through
-    // branchless per-limb arithmetic / masked selects / xor-folds. `bits.rs`
-    // holds the inherent `leading_zeros`; `cmp.rs` holds `Ord::cmp`
-    // (`limbs[..len]` slice then `const_cmp_ct`). NB: `heapless::shift` is
-    // deliberately excluded (dual-use operators, see above).
+    // allowlisted const_*_ct helpers), and identities' Zero (is_zero) plus the
+    // out-of-line `const_is_one_ct` fold behind One's is_one. Each was audited:
+    // loops bound on `len`/`max(len)`, value flows through branchless per-limb
+    // arithmetic / masked selects / xor-folds. `bits.rs` holds the inherent
+    // `leading_zeros`; `cmp.rs` holds `Ord::cmp` (`limbs[..len]` slice then
+    // `const_cmp_ct`). NB: `heapless::shift` is deliberately excluded (dual-use
+    // operators, see above).
     r"fixed_bigint\d*heapless(?:7bitwise|3cmp|6parity|9prim_bits|4bits)",
     r"fixed_bigint\d*heapless10identities.*(?:Const)?Zero",
+    r"fixed_bigint\d*heapless10identities15const_is_one_ct",
     // heapless arith. Div/Rem here are Nct-only and never reached from a Ct
     // fixture; every helper a Ct op does reach — saturating (ct_select),
     // carrying/borrowing, wrapping/overflowing, the CtChecked* traits, and the

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -172,6 +172,7 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // Loop bound is N (compile-time constant).
     r"fixed_bigint9fixeduint16const_is_zero_ct",
     r"fixed_bigint9fixeduint15const_is_one_ct",
+    r"fixed_bigint9fixeduint11const_eq_ct",
     r"fixed_bigint9fixeduint22const_leading_zeros_ct",
     r"fixed_bigint9fixeduint23const_trailing_zeros_ct",
     // Per-limb arithmetic — N-bounded loops.

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -285,10 +285,12 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // only on those bounds (the value flows through branchless per-limb
     // arithmetic / masked selects / xor-folds).
     //
-    // Deliberately ABSENT: `fixed_bigint..heapless..shift`. The `<<`/`>>`
-    // operators are dual-use — reachable with a secret amount — so they are
-    // not attestable by symbol. Ops that route through them
-    // (is/next_power_of_two, midpoint) are left unfixtured, not allowlisted.
+    // Deliberately ABSENT: the `heapless::shift` `<<`/`>>` *operator* symbols.
+    // They are dual-use — reachable with a secret amount — so an operator
+    // symbol on its own is not attestable. The `Ct` arms instead route through
+    // the dedicated barrels `const_shl_ct`/`const_shr_ct` (allowlisted below),
+    // which take a public shift amount; the ops built on them
+    // (is/next_power_of_two, midpoint) ARE fixtured through those barrels.
 
     // Whole heapless per-limb modules — bitwise (Not/BitAnd/Or/Xor), cmp
     // (PartialEq/Ord/subtle ConstantTime*/ConditionallySelectable/CtIsZero),

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -262,6 +262,18 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // an `undecided` lock, no early return; loop bound is the operand
     // length (public). Backs FixedUInt's and HeaplessBigInt's Ct `Ord::cmp`.
     r"fixed_bigint9fixeduint12const_cmp_ct",
+    // HeaplessBigInt's dedicated Ct shift barrels — the heapless twins of
+    // FixedUInt's const_shl_ct / const_shr_ct / const_sh{l,r}_impl already
+    // allowlisted above. `const_sh{l,r}_ct` loop `usize::BITS` public stages
+    // with a per-limb black_box masked select on bit `k` of the secret amount;
+    // each stage's `sh{l,r}_wp` shifts by the public `2^k`. Loop bounds are
+    // `usize::BITS` and the operand `len` (public); the secret amount only
+    // feeds `>> k & 1`. The `Ct` `<<`/`>>` operator arms route here (their
+    // `match P::TAG` folds to just this call for the Ct monomorphisation).
+    r"fixed_bigint8heapless5shift12const_shl_ct",
+    r"fixed_bigint8heapless5shift12const_shr_ct",
+    r"fixed_bigint8heapless5shift6shl_wp",
+    r"fixed_bigint8heapless5shift6shr_wp",
     // ── HeaplessBigInt Ct helpers ──
     //
     // Heapless's width is a runtime `len` field, so its per-limb loops bound
@@ -351,6 +363,10 @@ const THUMBV6M_EXTRA_HELPERS: &[&str] = &[
     // `leading_zeros` above and inherit its branches on armv6m.
     r"fixed_bigint9fixeduint17power_of_two_impl.*next_power_of_two",
     r"fixed_bigint9fixeduint.*FixedUInt.*ct_checked_next_power_of_two",
+    // HeaplessBigInt's `NextPowerOfTwo::next_power_of_two` inlines the same
+    // primitive `leading_zeros` (via `ct_next_pow2`), inheriting the armv6m
+    // software-CLZ branches — same root cause as the FixedUInt row above.
+    r"fixed_bigint8heapless12power_of_two.*NextPowerOfTwo",
     // compiler_builtins' software division — pulled in transitively
     // by the armv6m `leading_zeros` polynomial. Branchful on size.
     r"compiler_builtins3int.*specialized_div_rem",

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -20,6 +20,12 @@ default = ["panic-handler"]
 # that link ct-fixtures as rlib alongside std, which supplies its own.
 panic-handler = []
 ctgrind = ["dep:krabi-caliper"]
+# HeaplessBigInt Ct fixtures. OFF by default: the runtime-`len` carrier's
+# helpers loop over a public-but-runtime width, so their public-parameter
+# branches (a register-bounded `cmp; b.lt`, not the immediate-bounded form
+# the allowlist recognizes) trip the asm-grep gate even though they leak no
+# secret. Kept as ready-to-run scaffolding until the gate can allowlist them.
+heapless = []
 
 [dependencies]
 fixed-bigint = { path = "../.." }

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -20,11 +20,11 @@ default = ["panic-handler"]
 # that link ct-fixtures as rlib alongside std, which supplies its own.
 panic-handler = []
 ctgrind = ["dep:krabi-caliper"]
-# HeaplessBigInt Ct fixtures. OFF by default: the runtime-`len` carrier's
-# helpers loop over a public-but-runtime width, so their public-parameter
-# branches (a register-bounded `cmp; b.lt`, not the immediate-bounded form
-# the allowlist recognizes) trip the asm-grep gate even though they leak no
-# secret. Kept as ready-to-run scaffolding until the gate can allowlist them.
+# HeaplessBigInt Ct fixtures. The asm-grep driver (ct-driver) enables this;
+# the runtime-`len` carrier's per-limb helpers loop over a public-but-runtime
+# width, and each is attested public-bounded in ct-driver's HELPER_ALLOWLIST.
+# Kept as a feature so non-gate consumers can build ct-fixtures without the
+# heapless surface.
 heapless = []
 
 [dependencies]

--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -11,7 +11,27 @@ use const_num_traits::{
 };
 use fixed_bigint::FixedUInt;
 
-use crate::{ct_fix_bin, ct_fix_count, ct_fix_pred, ct_fix_shift, ct_fix_un};
+use crate::{ct_fix_bin, ct_fix_count, ct_fix_pred, ct_fix_pred2, ct_fix_shift, ct_fix_un};
+
+// =============================================================================
+// Ord::cmp — `match P::TAG` Ct arm through `const_cmp_ct` (the MSB-to-LSB
+// masked scan). Fold the Ordering to u8 (Less=255, Equal=0, Greater=1).
+// =============================================================================
+
+macro_rules! emit_cmp {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            (x.cmp(&y) as i8) as u8
+        });
+    };
+}
+emit_cmp!(ct_fix__A__cmp__u8__N16, u8, 16);
+emit_cmp!(ct_fix__A__cmp__u16__N16, u16, 16);
+emit_cmp!(ct_fix__A__cmp__u32__N4, u32, 4);
+emit_cmp!(ct_fix__A__cmp__u32__N16, u32, 16);
+emit_cmp!(ct_fix__A__cmp__u64__N4, u64, 4);
 
 // =============================================================================
 // SaturatingAdd / Sub / Mul

--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -33,6 +33,23 @@ emit_cmp!(ct_fix__A__cmp__u32__N4, u32, 4);
 emit_cmp!(ct_fix__A__cmp__u32__N16, u32, 16);
 emit_cmp!(ct_fix__A__cmp__u64__N4, u64, 4);
 
+// PartialEq::eq — the `==` operator's own branchless Ct arm (XOR-fold), a
+// distinct code path from the `subtle::ct_eq` fixtured in category B.
+macro_rules! emit_eq {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            (x == y) as u8
+        });
+    };
+}
+emit_eq!(ct_fix__A__eq__u8__N16, u8, 16);
+emit_eq!(ct_fix__A__eq__u16__N16, u16, 16);
+emit_eq!(ct_fix__A__eq__u32__N4, u32, 4);
+emit_eq!(ct_fix__A__eq__u32__N16, u32, 16);
+emit_eq!(ct_fix__A__eq__u64__N4, u64, 4);
+
 // =============================================================================
 // SaturatingAdd / Sub / Mul
 // =============================================================================

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -1,0 +1,629 @@
+//! HeaplessBigInt constant-time fixtures — the runtime-`len` carrier held at
+//! full CAP width so it behaves bit-for-bit like `FixedUInt<T, CAP>`.
+//!
+//! Mirrors the `FixedUInt` fixtures (`fixtures_cat_{a,b,c}` / `_ct_traits`)
+//! for `HeaplessBigInt<T, CAP, Ct>`. Construction is `from_limbs(a, CAP)` so
+//! `len == CAP` (no zero-tail, full-width value); extraction is `all_limbs()`.
+//! Same five `(T, CAP)` diagonals as the FixedUInt set:
+//!   (u8, 16), (u16, 16), (u32, 4), (u32, 16), (u64, 4)
+//!
+//! Symbols are prefixed `ct_fix__H<cat>__*` (H for heapless) so the driver
+//! scans them alongside the FixedUInt fixtures. Categories mirror the
+//! FixedUInt split:
+//!   - `HA`  — Ct arms dispatched via `match P::TAG`
+//!   - `HB`  — `subtle::*` trait impls (ct_eq/gt/lt, conditional_select)
+//!   - `HC`  — always-CT-by-construction ops (bitwise, wrapping/carry chains)
+//!   - `HCT` — const-num-traits `Ct*` masked-return trait impls
+//!
+//! This whole module is behind the (default-off) `heapless` cargo feature:
+//! the runtime-`len` carrier's helpers loop over a public-but-runtime width,
+//! whose register-bounded branches trip the asm-grep gate even though they
+//! leak no secret. It is ready-to-run scaffolding for when the gate can
+//! allowlist those loops.
+//!
+//! Ops that are not yet constant-time on this carrier — the variable-amount
+//! shifts, which never route through a branchless barrel shifter — are
+//! deliberately left out (a fixture for them would fail for the right reason).
+
+use core::ops::{BitAnd, BitOr, BitXor, Not};
+
+use const_num_traits::ops::ct::{
+    CtCheckedAdd, CtCheckedMul, CtCheckedSub, CtIsPowerOfTwo, CtIsZero, CtParity,
+};
+use const_num_traits::Ct;
+use const_num_traits::CtNonZero;
+use const_num_traits::{
+    AbsDiff, CarryingAdd, IsPowerOfTwo, Midpoint, NextPowerOfTwo, One, OverflowingAdd, PrimBits,
+    SaturatingAdd, SaturatingMul, SaturatingSub, WrappingMul, Zero,
+};
+use fixed_bigint::HeaplessBigInt;
+use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
+
+use crate::{
+    ct_fix_bin, ct_fix_checked_bin, ct_fix_checked_un, ct_fix_count, ct_fix_pred, ct_fix_pred2,
+    ct_fix_un,
+};
+
+// =============================================================================
+// Category HA: Ct arms dispatched via `match P::TAG`.
+// =============================================================================
+
+// SaturatingAdd / Sub / Mul
+macro_rules! emit_h_sat_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = SaturatingAdd::saturating_add(x, y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_sat_add!(ct_fix__HA__sat_add__u8__N16, u8, 16);
+emit_h_sat_add!(ct_fix__HA__sat_add__u16__N16, u16, 16);
+emit_h_sat_add!(ct_fix__HA__sat_add__u32__N4, u32, 4);
+emit_h_sat_add!(ct_fix__HA__sat_add__u32__N16, u32, 16);
+emit_h_sat_add!(ct_fix__HA__sat_add__u64__N4, u64, 4);
+
+macro_rules! emit_h_sat_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = SaturatingSub::saturating_sub(x, y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_sat_sub!(ct_fix__HA__sat_sub__u8__N16, u8, 16);
+emit_h_sat_sub!(ct_fix__HA__sat_sub__u16__N16, u16, 16);
+emit_h_sat_sub!(ct_fix__HA__sat_sub__u32__N4, u32, 4);
+emit_h_sat_sub!(ct_fix__HA__sat_sub__u32__N16, u32, 16);
+emit_h_sat_sub!(ct_fix__HA__sat_sub__u64__N4, u64, 4);
+
+macro_rules! emit_h_sat_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = SaturatingMul::saturating_mul(x, y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_sat_mul!(ct_fix__HA__sat_mul__u8__N16, u8, 16);
+emit_h_sat_mul!(ct_fix__HA__sat_mul__u16__N16, u16, 16);
+emit_h_sat_mul!(ct_fix__HA__sat_mul__u32__N4, u32, 4);
+emit_h_sat_mul!(ct_fix__HA__sat_mul__u32__N16, u32, 16);
+emit_h_sat_mul!(ct_fix__HA__sat_mul__u64__N4, u64, 4);
+
+// AbsDiff
+macro_rules! emit_h_abs_diff {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = AbsDiff::abs_diff(x, y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_abs_diff!(ct_fix__HA__abs_diff__u8__N16, u8, 16);
+emit_h_abs_diff!(ct_fix__HA__abs_diff__u16__N16, u16, 16);
+emit_h_abs_diff!(ct_fix__HA__abs_diff__u32__N4, u32, 4);
+emit_h_abs_diff!(ct_fix__HA__abs_diff__u32__N16, u32, 16);
+emit_h_abs_diff!(ct_fix__HA__abs_diff__u64__N4, u64, 4);
+
+// IsPowerOfTwo::is_power_of_two — predicate
+macro_rules! emit_h_is_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            IsPowerOfTwo::is_power_of_two(x) as u8
+        });
+    };
+}
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u8__N16, u8, 16);
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u16__N16, u16, 16);
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u32__N4, u32, 4);
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u32__N16, u32, 16);
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u64__N4, u64, 4);
+
+// NextPowerOfTwo::next_power_of_two
+macro_rules! emit_h_next_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let r = NextPowerOfTwo::next_power_of_two(x);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u8__N16, u8, 16);
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u16__N16, u16, 16);
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N4, u32, 4);
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N16, u32, 16);
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u64__N4, u64, 4);
+
+// PrimBits::leading_zeros / trailing_zeros
+macro_rules! emit_h_lz {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_count!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            PrimBits::leading_zeros(x)
+        });
+    };
+}
+emit_h_lz!(ct_fix__HA__leading_zeros__u8__N16, u8, 16);
+emit_h_lz!(ct_fix__HA__leading_zeros__u16__N16, u16, 16);
+emit_h_lz!(ct_fix__HA__leading_zeros__u32__N4, u32, 4);
+emit_h_lz!(ct_fix__HA__leading_zeros__u32__N16, u32, 16);
+emit_h_lz!(ct_fix__HA__leading_zeros__u64__N4, u64, 4);
+
+macro_rules! emit_h_tz {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_count!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            PrimBits::trailing_zeros(x)
+        });
+    };
+}
+emit_h_tz!(ct_fix__HA__trailing_zeros__u8__N16, u8, 16);
+emit_h_tz!(ct_fix__HA__trailing_zeros__u16__N16, u16, 16);
+emit_h_tz!(ct_fix__HA__trailing_zeros__u32__N4, u32, 4);
+emit_h_tz!(ct_fix__HA__trailing_zeros__u32__N16, u32, 16);
+emit_h_tz!(ct_fix__HA__trailing_zeros__u64__N4, u64, 4);
+
+// Zero::is_zero / One::is_one
+macro_rules! emit_h_is_zero {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            <HeaplessBigInt<$T, $N, Ct> as Zero>::is_zero(&x) as u8
+        });
+    };
+}
+emit_h_is_zero!(ct_fix__HA__is_zero__u8__N16, u8, 16);
+emit_h_is_zero!(ct_fix__HA__is_zero__u16__N16, u16, 16);
+emit_h_is_zero!(ct_fix__HA__is_zero__u32__N4, u32, 4);
+emit_h_is_zero!(ct_fix__HA__is_zero__u32__N16, u32, 16);
+emit_h_is_zero!(ct_fix__HA__is_zero__u64__N4, u64, 4);
+
+macro_rules! emit_h_is_one {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            <HeaplessBigInt<$T, $N, Ct> as One>::is_one(&x) as u8
+        });
+    };
+}
+emit_h_is_one!(ct_fix__HA__is_one__u8__N16, u8, 16);
+emit_h_is_one!(ct_fix__HA__is_one__u16__N16, u16, 16);
+emit_h_is_one!(ct_fix__HA__is_one__u32__N4, u32, 4);
+emit_h_is_one!(ct_fix__HA__is_one__u32__N16, u32, 16);
+emit_h_is_one!(ct_fix__HA__is_one__u64__N4, u64, 4);
+
+// =============================================================================
+// Category HB: subtle::* trait impls.
+// =============================================================================
+
+macro_rules! emit_h_ct_eq {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            x.ct_eq(&y).unwrap_u8()
+        });
+    };
+}
+emit_h_ct_eq!(ct_fix__HB__ct_eq__u8__N16, u8, 16);
+emit_h_ct_eq!(ct_fix__HB__ct_eq__u16__N16, u16, 16);
+emit_h_ct_eq!(ct_fix__HB__ct_eq__u32__N4, u32, 4);
+emit_h_ct_eq!(ct_fix__HB__ct_eq__u32__N16, u32, 16);
+emit_h_ct_eq!(ct_fix__HB__ct_eq__u64__N4, u64, 4);
+
+macro_rules! emit_h_ct_gt {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            x.ct_gt(&y).unwrap_u8()
+        });
+    };
+}
+emit_h_ct_gt!(ct_fix__HB__ct_gt__u8__N16, u8, 16);
+emit_h_ct_gt!(ct_fix__HB__ct_gt__u16__N16, u16, 16);
+emit_h_ct_gt!(ct_fix__HB__ct_gt__u32__N4, u32, 4);
+emit_h_ct_gt!(ct_fix__HB__ct_gt__u32__N16, u32, 16);
+emit_h_ct_gt!(ct_fix__HB__ct_gt__u64__N4, u64, 4);
+
+macro_rules! emit_h_ct_lt {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            x.ct_lt(&y).unwrap_u8()
+        });
+    };
+}
+emit_h_ct_lt!(ct_fix__HB__ct_lt__u8__N16, u8, 16);
+emit_h_ct_lt!(ct_fix__HB__ct_lt__u16__N16, u16, 16);
+emit_h_ct_lt!(ct_fix__HB__ct_lt__u32__N4, u32, 4);
+emit_h_ct_lt!(ct_fix__HB__ct_lt__u32__N16, u32, 16);
+emit_h_ct_lt!(ct_fix__HB__ct_lt__u64__N4, u64, 4);
+
+// ConditionallySelectable::conditional_select — takes a Choice built from an
+// extra u8 arg (0 or 1). Mirrors the FixedUInt `cond_select` fixture.
+macro_rules! emit_h_cond_select {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            choice: u8,
+            out_ptr: *mut [$T; $N],
+        ) {
+            let a_arr = core::hint::black_box(unsafe { *a_ptr });
+            let b_arr = core::hint::black_box(unsafe { *b_ptr });
+            let c = core::hint::black_box(choice);
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a_arr, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b_arr, $N as u16);
+            let r = <HeaplessBigInt<$T, $N, Ct> as subtle::ConditionallySelectable>::conditional_select(
+                &x,
+                &y,
+                subtle::Choice::from(c),
+            );
+            let result = core::hint::black_box(*r.all_limbs());
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+        #[cfg(feature = "ctgrind")]
+        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_cond_select!($name, $T, $N););
+    };
+}
+emit_h_cond_select!(ct_fix__HB__cond_select__u8__N16, u8, 16);
+emit_h_cond_select!(ct_fix__HB__cond_select__u16__N16, u16, 16);
+emit_h_cond_select!(ct_fix__HB__cond_select__u32__N4, u32, 4);
+emit_h_cond_select!(ct_fix__HB__cond_select__u32__N16, u32, 16);
+emit_h_cond_select!(ct_fix__HB__cond_select__u64__N4, u64, 4);
+
+// =============================================================================
+// Category HC: always-CT-by-construction ops (regression watch).
+// =============================================================================
+
+// Bitwise: Not / BitAnd / BitOr / BitXor
+macro_rules! emit_h_not {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let r = Not::not(x);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_not!(ct_fix__HC__not__u8__N16, u8, 16);
+emit_h_not!(ct_fix__HC__not__u16__N16, u16, 16);
+emit_h_not!(ct_fix__HC__not__u32__N4, u32, 4);
+emit_h_not!(ct_fix__HC__not__u32__N16, u32, 16);
+emit_h_not!(ct_fix__HC__not__u64__N4, u64, 4);
+
+macro_rules! emit_h_bitand {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = BitAnd::bitand(x, y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_bitand!(ct_fix__HC__bitand__u8__N16, u8, 16);
+emit_h_bitand!(ct_fix__HC__bitand__u16__N16, u16, 16);
+emit_h_bitand!(ct_fix__HC__bitand__u32__N4, u32, 4);
+emit_h_bitand!(ct_fix__HC__bitand__u32__N16, u32, 16);
+emit_h_bitand!(ct_fix__HC__bitand__u64__N4, u64, 4);
+
+macro_rules! emit_h_bitor {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = BitOr::bitor(x, y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_bitor!(ct_fix__HC__bitor__u8__N16, u8, 16);
+emit_h_bitor!(ct_fix__HC__bitor__u16__N16, u16, 16);
+emit_h_bitor!(ct_fix__HC__bitor__u32__N4, u32, 4);
+emit_h_bitor!(ct_fix__HC__bitor__u32__N16, u32, 16);
+emit_h_bitor!(ct_fix__HC__bitor__u64__N4, u64, 4);
+
+macro_rules! emit_h_bitxor {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = BitXor::bitxor(x, y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_bitxor!(ct_fix__HC__bitxor__u8__N16, u8, 16);
+emit_h_bitxor!(ct_fix__HC__bitxor__u16__N16, u16, 16);
+emit_h_bitxor!(ct_fix__HC__bitxor__u32__N4, u32, 4);
+emit_h_bitxor!(ct_fix__HC__bitxor__u32__N16, u32, 16);
+emit_h_bitxor!(ct_fix__HC__bitxor__u64__N4, u64, 4);
+
+// Overflowing / wrapping arithmetic (always-CT carry chain). Discard the
+// overflow bool; the body's branch-freeness is what we check.
+macro_rules! emit_h_overflowing_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let (r, _ov) = OverflowingAdd::overflowing_add(&x, &y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_overflowing_add!(ct_fix__HC__overflowing_add__u8__N16, u8, 16);
+emit_h_overflowing_add!(ct_fix__HC__overflowing_add__u16__N16, u16, 16);
+emit_h_overflowing_add!(ct_fix__HC__overflowing_add__u32__N4, u32, 4);
+emit_h_overflowing_add!(ct_fix__HC__overflowing_add__u32__N16, u32, 16);
+emit_h_overflowing_add!(ct_fix__HC__overflowing_add__u64__N4, u64, 4);
+
+macro_rules! emit_h_wrapping_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = WrappingMul::wrapping_mul(&x, &y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_wrapping_mul!(ct_fix__HC__wrapping_mul__u8__N16, u8, 16);
+emit_h_wrapping_mul!(ct_fix__HC__wrapping_mul__u16__N16, u16, 16);
+emit_h_wrapping_mul!(ct_fix__HC__wrapping_mul__u32__N4, u32, 4);
+emit_h_wrapping_mul!(ct_fix__HC__wrapping_mul__u32__N16, u32, 16);
+emit_h_wrapping_mul!(ct_fix__HC__wrapping_mul__u64__N4, u64, 4);
+
+// Carrying add — explicit external carry input, passed as `bool` straight
+// through `black_box` (see the FixedUInt fixture note on the AVR wrapper).
+macro_rules! emit_h_carrying_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            carry: bool,
+            out_ptr: *mut [$T; $N],
+        ) -> u8 {
+            let a_arr = core::hint::black_box(unsafe { *a_ptr });
+            let b_arr = core::hint::black_box(unsafe { *b_ptr });
+            let c = core::hint::black_box(carry);
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a_arr, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b_arr, $N as u16);
+            let (r, co) = CarryingAdd::carrying_add(x, y, c);
+            let result = core::hint::black_box(*r.all_limbs());
+            unsafe {
+                *out_ptr = result;
+            }
+            core::hint::black_box(co as u8)
+        }
+        #[cfg(feature = "ctgrind")]
+        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_carrying_add!($name, $T, $N););
+    };
+}
+emit_h_carrying_add!(ct_fix__HC__carrying_add__u8__N16, u8, 16);
+emit_h_carrying_add!(ct_fix__HC__carrying_add__u16__N16, u16, 16);
+emit_h_carrying_add!(ct_fix__HC__carrying_add__u32__N4, u32, 4);
+emit_h_carrying_add!(ct_fix__HC__carrying_add__u32__N16, u32, 16);
+emit_h_carrying_add!(ct_fix__HC__carrying_add__u64__N4, u64, 4);
+
+// Midpoint
+macro_rules! emit_h_midpoint {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let r = Midpoint::midpoint(x, y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_midpoint!(ct_fix__HC__midpoint__u8__N16, u8, 16);
+emit_h_midpoint!(ct_fix__HC__midpoint__u16__N16, u16, 16);
+emit_h_midpoint!(ct_fix__HC__midpoint__u32__N4, u32, 4);
+emit_h_midpoint!(ct_fix__HC__midpoint__u32__N16, u32, 16);
+emit_h_midpoint!(ct_fix__HC__midpoint__u64__N4, u64, 4);
+
+// Ord::cmp — folded to u8 (Less=0xFF, Equal=0, Greater=1).
+macro_rules! emit_h_cmp {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            (x.cmp(&y) as i8) as u8
+        });
+    };
+}
+emit_h_cmp!(ct_fix__HC__cmp__u8__N16, u8, 16);
+emit_h_cmp!(ct_fix__HC__cmp__u16__N16, u16, 16);
+emit_h_cmp!(ct_fix__HC__cmp__u32__N4, u32, 4);
+emit_h_cmp!(ct_fix__HC__cmp__u32__N16, u32, 16);
+emit_h_cmp!(ct_fix__HC__cmp__u64__N4, u64, 4);
+
+// Bit counts: count_ones / swap_bytes / reverse_bits
+macro_rules! emit_h_count_ones {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_count!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            PrimBits::count_ones(x)
+        });
+    };
+}
+emit_h_count_ones!(ct_fix__HC__count_ones__u8__N16, u8, 16);
+emit_h_count_ones!(ct_fix__HC__count_ones__u16__N16, u16, 16);
+emit_h_count_ones!(ct_fix__HC__count_ones__u32__N4, u32, 4);
+emit_h_count_ones!(ct_fix__HC__count_ones__u32__N16, u32, 16);
+emit_h_count_ones!(ct_fix__HC__count_ones__u64__N4, u64, 4);
+
+macro_rules! emit_h_swap_bytes {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let r = PrimBits::swap_bytes(x);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_swap_bytes!(ct_fix__HC__swap_bytes__u8__N16, u8, 16);
+emit_h_swap_bytes!(ct_fix__HC__swap_bytes__u16__N16, u16, 16);
+emit_h_swap_bytes!(ct_fix__HC__swap_bytes__u32__N4, u32, 4);
+emit_h_swap_bytes!(ct_fix__HC__swap_bytes__u32__N16, u32, 16);
+emit_h_swap_bytes!(ct_fix__HC__swap_bytes__u64__N4, u64, 4);
+
+macro_rules! emit_h_reverse_bits {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let r = PrimBits::reverse_bits(x);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_reverse_bits!(ct_fix__HC__reverse_bits__u8__N16, u8, 16);
+emit_h_reverse_bits!(ct_fix__HC__reverse_bits__u16__N16, u16, 16);
+emit_h_reverse_bits!(ct_fix__HC__reverse_bits__u32__N4, u32, 4);
+emit_h_reverse_bits!(ct_fix__HC__reverse_bits__u32__N16, u32, 16);
+emit_h_reverse_bits!(ct_fix__HC__reverse_bits__u64__N4, u64, 4);
+
+// =============================================================================
+// Category HCT: const-num-traits `Ct*` masked-return trait impls.
+// =============================================================================
+
+// CtParity::ct_is_odd
+macro_rules! emit_h_ct_is_odd {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            x.ct_is_odd().unwrap_u8()
+        });
+    };
+}
+emit_h_ct_is_odd!(ct_fix__HCT__ct_is_odd__u8__N16, u8, 16);
+emit_h_ct_is_odd!(ct_fix__HCT__ct_is_odd__u16__N16, u16, 16);
+emit_h_ct_is_odd!(ct_fix__HCT__ct_is_odd__u32__N4, u32, 4);
+emit_h_ct_is_odd!(ct_fix__HCT__ct_is_odd__u32__N16, u32, 16);
+emit_h_ct_is_odd!(ct_fix__HCT__ct_is_odd__u64__N4, u64, 4);
+
+// CtIsZero::ct_is_zero
+macro_rules! emit_h_ct_is_zero {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            CtIsZero::ct_is_zero(&x).unwrap_u8()
+        });
+    };
+}
+emit_h_ct_is_zero!(ct_fix__HCT__ct_is_zero__u8__N16, u8, 16);
+emit_h_ct_is_zero!(ct_fix__HCT__ct_is_zero__u16__N16, u16, 16);
+emit_h_ct_is_zero!(ct_fix__HCT__ct_is_zero__u32__N4, u32, 4);
+emit_h_ct_is_zero!(ct_fix__HCT__ct_is_zero__u32__N16, u32, 16);
+emit_h_ct_is_zero!(ct_fix__HCT__ct_is_zero__u64__N4, u64, 4);
+
+// CtIsPowerOfTwo::ct_is_power_of_two
+macro_rules! emit_h_ct_is_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            x.ct_is_power_of_two().unwrap_u8()
+        });
+    };
+}
+emit_h_ct_is_pow2!(ct_fix__HCT__ct_is_pow2__u8__N16, u8, 16);
+emit_h_ct_is_pow2!(ct_fix__HCT__ct_is_pow2__u16__N16, u16, 16);
+emit_h_ct_is_pow2!(ct_fix__HCT__ct_is_pow2__u32__N4, u32, 4);
+emit_h_ct_is_pow2!(ct_fix__HCT__ct_is_pow2__u32__N16, u32, 16);
+emit_h_ct_is_pow2!(ct_fix__HCT__ct_is_pow2__u64__N4, u64, 4);
+
+// CtCheckedAdd / CtCheckedSub / CtCheckedMul (CtOption-returning)
+macro_rules! emit_h_ct_checked_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let res = <HeaplessBigInt<$T, $N, Ct> as CtCheckedAdd>::ct_checked_add(&x, &y);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(HeaplessBigInt::<$T, $N, Ct>::from_limbs([0; $N], $N as u16));
+            (*value.all_limbs(), valid)
+        });
+    };
+}
+emit_h_ct_checked_add!(ct_fix__HCT__ct_checked_add__u8__N16, u8, 16);
+emit_h_ct_checked_add!(ct_fix__HCT__ct_checked_add__u16__N16, u16, 16);
+emit_h_ct_checked_add!(ct_fix__HCT__ct_checked_add__u32__N4, u32, 4);
+emit_h_ct_checked_add!(ct_fix__HCT__ct_checked_add__u32__N16, u32, 16);
+emit_h_ct_checked_add!(ct_fix__HCT__ct_checked_add__u64__N4, u64, 4);
+
+macro_rules! emit_h_ct_checked_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let res = <HeaplessBigInt<$T, $N, Ct> as CtCheckedSub>::ct_checked_sub(&x, &y);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(HeaplessBigInt::<$T, $N, Ct>::from_limbs([0; $N], $N as u16));
+            (*value.all_limbs(), valid)
+        });
+    };
+}
+emit_h_ct_checked_sub!(ct_fix__HCT__ct_checked_sub__u8__N16, u8, 16);
+emit_h_ct_checked_sub!(ct_fix__HCT__ct_checked_sub__u16__N16, u16, 16);
+emit_h_ct_checked_sub!(ct_fix__HCT__ct_checked_sub__u32__N4, u32, 4);
+emit_h_ct_checked_sub!(ct_fix__HCT__ct_checked_sub__u32__N16, u32, 16);
+emit_h_ct_checked_sub!(ct_fix__HCT__ct_checked_sub__u64__N4, u64, 4);
+
+macro_rules! emit_h_ct_checked_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let res = <HeaplessBigInt<$T, $N, Ct> as CtCheckedMul>::ct_checked_mul(&x, &y);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(HeaplessBigInt::<$T, $N, Ct>::from_limbs([0; $N], $N as u16));
+            (*value.all_limbs(), valid)
+        });
+    };
+}
+emit_h_ct_checked_mul!(ct_fix__HCT__ct_checked_mul__u8__N16, u8, 16);
+emit_h_ct_checked_mul!(ct_fix__HCT__ct_checked_mul__u16__N16, u16, 16);
+emit_h_ct_checked_mul!(ct_fix__HCT__ct_checked_mul__u32__N4, u32, 4);
+emit_h_ct_checked_mul!(ct_fix__HCT__ct_checked_mul__u32__N16, u32, 16);
+emit_h_ct_checked_mul!(ct_fix__HCT__ct_checked_mul__u64__N4, u64, 4);
+
+// CtNonZero::into_nonzero_ct (CtOption<NonZeroHeaplessBigInt>). Project to the
+// inner value via `CtOption::map(|nz| nz.get())` before materializing, so we
+// never construct a default `NonZeroHeaplessBigInt` (mirrors the FixedUInt
+// fixture's approach).
+macro_rules! emit_h_into_nonzero_ct {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_checked_un!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let res = <HeaplessBigInt<$T, $N, Ct> as CtNonZero>::into_nonzero_ct(x);
+            let valid = res.is_some().unwrap_u8();
+            let inner: subtle::CtOption<HeaplessBigInt<$T, $N, Ct>> = res.map(|nz| nz.get());
+            let value =
+                inner.unwrap_or(HeaplessBigInt::<$T, $N, Ct>::from_limbs([0; $N], $N as u16));
+            (*value.all_limbs(), valid)
+        });
+    };
+}
+emit_h_into_nonzero_ct!(ct_fix__HCT__into_nonzero_ct__u8__N16, u8, 16);
+emit_h_into_nonzero_ct!(ct_fix__HCT__into_nonzero_ct__u16__N16, u16, 16);
+emit_h_into_nonzero_ct!(ct_fix__HCT__into_nonzero_ct__u32__N4, u32, 4);
+emit_h_into_nonzero_ct!(ct_fix__HCT__into_nonzero_ct__u32__N16, u32, 16);
+emit_h_into_nonzero_ct!(ct_fix__HCT__into_nonzero_ct__u64__N4, u64, 4);

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -255,6 +255,20 @@ emit_h_is_zero!(ct_fix__HA__is_zero__u32__N4, u32, 4);
 emit_h_is_zero!(ct_fix__HA__is_zero__u32__N16, u32, 16);
 emit_h_is_zero!(ct_fix__HA__is_zero__u64__N4, u64, 4);
 
+macro_rules! emit_h_is_one {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            <HeaplessBigInt<$T, $N, Ct> as One>::is_one(&x) as u8
+        });
+    };
+}
+emit_h_is_one!(ct_fix__HA__is_one__u8__N16, u8, 16);
+emit_h_is_one!(ct_fix__HA__is_one__u16__N16, u16, 16);
+emit_h_is_one!(ct_fix__HA__is_one__u32__N4, u32, 4);
+emit_h_is_one!(ct_fix__HA__is_one__u32__N16, u32, 16);
+emit_h_is_one!(ct_fix__HA__is_one__u64__N4, u64, 4);
+
 // NOTE: is_one is intentionally NOT fixtured — the heapless `One::is_one`
 // body carries a data-dependent branch (fixture-level violation), so it is not
 // yet constant-time. Tracked in the CT-coverage backlog.

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -88,7 +88,9 @@ macro_rules! emit_h_unbounded_shl {
     };
 }
 emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u8__N16, u8, 16);
+emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u16__N16, u16, 16);
 emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u32__N4, u32, 4);
+emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u32__N16, u32, 16);
 emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u64__N4, u64, 4);
 
 macro_rules! emit_h_unbounded_shr {
@@ -100,7 +102,9 @@ macro_rules! emit_h_unbounded_shr {
     };
 }
 emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u8__N16, u8, 16);
+emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u16__N16, u16, 16);
 emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u32__N4, u32, 4);
+emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u32__N16, u32, 16);
 emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u64__N4, u64, 4);
 
 // is_power_of_two (predicate, no shift), next_power_of_two (via ct_shl barrel).
@@ -113,7 +117,9 @@ macro_rules! emit_h_is_pow2 {
     };
 }
 emit_h_is_pow2!(ct_fix__HA__is_pow2__u8__N16, u8, 16);
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u16__N16, u16, 16);
 emit_h_is_pow2!(ct_fix__HA__is_pow2__u32__N4, u32, 4);
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u32__N16, u32, 16);
 emit_h_is_pow2!(ct_fix__HA__is_pow2__u64__N4, u64, 4);
 
 macro_rules! emit_h_next_pow2 {
@@ -125,7 +131,9 @@ macro_rules! emit_h_next_pow2 {
     };
 }
 emit_h_next_pow2!(ct_fix__HA__next_pow2__u8__N16, u8, 16);
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u16__N16, u16, 16);
 emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N4, u32, 4);
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N16, u32, 16);
 emit_h_next_pow2!(ct_fix__HA__next_pow2__u64__N4, u64, 4);
 
 macro_rules! emit_h_midpoint {
@@ -138,7 +146,9 @@ macro_rules! emit_h_midpoint {
     };
 }
 emit_h_midpoint!(ct_fix__HC__midpoint__u8__N16, u8, 16);
+emit_h_midpoint!(ct_fix__HC__midpoint__u16__N16, u16, 16);
 emit_h_midpoint!(ct_fix__HC__midpoint__u32__N4, u32, 4);
+emit_h_midpoint!(ct_fix__HC__midpoint__u32__N16, u32, 16);
 emit_h_midpoint!(ct_fix__HC__midpoint__u64__N4, u64, 4);
 
 // =============================================================================

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -45,10 +45,10 @@ use crate::{
 };
 
 // =============================================================================
-// Ct shifts — now branchless barrels (const_shl_ct / const_shr_ct). The
-// `<<`/`>>` operators dispatch on P::TAG, so a secret amount routes through the
-// barrel. is_power_of_two (no shift), next_power_of_two (via ct_shl), and
-// midpoint (>> 1) come along too.
+// Ct shifts. The `<<`/`>>` operators dispatch on P::TAG, so a secret amount
+// routes through the branchless barrels (const_shl_ct / const_shr_ct). Also
+// covers is_power_of_two (no shift), next_power_of_two (via ct_shl), and
+// midpoint (>> 1).
 // =============================================================================
 
 macro_rules! emit_h_shl_usize {

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -20,14 +20,10 @@
 //! width; each is attested public-bounded in ct-driver's `HELPER_ALLOWLIST`,
 //! so these fixtures are gated on every target like the FixedUInt set.
 //!
-//! Ops NOT fixtured here (a fixture would fail for the right reason, and they
-//! are tracked in the CT-coverage backlog):
-//!   - variable-amount shifts, and anything reaching the `<<`/`>>` operator —
-//!     `is_power_of_two` / `next_power_of_two` (via `ct_shl`) and `midpoint`
-//!     (`>> 1`). The heapless shift operators are dual-use (callable with a
-//!     secret amount), so their symbol can't be allowlisted; heapless lacks a
-//!     dedicated `const_shl_ct`/`const_shr_ct` the way FixedUInt has.
-//!   - `is_one` — the heapless `One::is_one` body has a data-dependent branch.
+//! Not fixtured: `is_one` — the heapless `One::is_one` body still has a
+//! data-dependent branch (tracked in the CT-coverage backlog). Everything else,
+//! shifts included, is covered: the `Ct` `<<`/`>>` operators now dispatch to
+//! branchless barrels (`const_shl_ct`/`const_shr_ct`).
 
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
@@ -38,15 +34,112 @@ use const_num_traits::Ct;
 use const_num_traits::CtNonZero;
 use const_num_traits::{
     AbsDiff, CarryingAdd, IsPowerOfTwo, Midpoint, NextPowerOfTwo, One, OverflowingAdd, PrimBits,
-    SaturatingAdd, SaturatingMul, SaturatingSub, WrappingMul, Zero,
+    SaturatingAdd, SaturatingMul, SaturatingSub, UnboundedShl, UnboundedShr, WrappingMul, Zero,
 };
 use fixed_bigint::HeaplessBigInt;
 use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 use crate::{
     ct_fix_bin, ct_fix_checked_bin, ct_fix_checked_un, ct_fix_count, ct_fix_pred, ct_fix_pred2,
-    ct_fix_un,
+    ct_fix_shift, ct_fix_un,
 };
+
+// =============================================================================
+// Ct shifts — now branchless barrels (const_shl_ct / const_shr_ct). The
+// `<<`/`>>` operators dispatch on P::TAG, so a secret amount routes through the
+// barrel. is_power_of_two (no shift), next_power_of_two (via ct_shl), and
+// midpoint (>> 1) come along too.
+// =============================================================================
+
+macro_rules! emit_h_shl_usize {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, usize, |a, n| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            *(x << n).all_limbs()
+        });
+    };
+}
+emit_h_shl_usize!(ct_fix__HA__shl_usize__u8__N16, u8, 16);
+emit_h_shl_usize!(ct_fix__HA__shl_usize__u16__N16, u16, 16);
+emit_h_shl_usize!(ct_fix__HA__shl_usize__u32__N4, u32, 4);
+emit_h_shl_usize!(ct_fix__HA__shl_usize__u32__N16, u32, 16);
+emit_h_shl_usize!(ct_fix__HA__shl_usize__u64__N4, u64, 4);
+
+macro_rules! emit_h_shr_usize {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, usize, |a, n| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            *(x >> n).all_limbs()
+        });
+    };
+}
+emit_h_shr_usize!(ct_fix__HA__shr_usize__u8__N16, u8, 16);
+emit_h_shr_usize!(ct_fix__HA__shr_usize__u16__N16, u16, 16);
+emit_h_shr_usize!(ct_fix__HA__shr_usize__u32__N4, u32, 4);
+emit_h_shr_usize!(ct_fix__HA__shr_usize__u32__N16, u32, 16);
+emit_h_shr_usize!(ct_fix__HA__shr_usize__u64__N4, u64, 4);
+
+macro_rules! emit_h_unbounded_shl {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, u32, |a, n| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            *UnboundedShl::unbounded_shl(x, n).all_limbs()
+        });
+    };
+}
+emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u8__N16, u8, 16);
+emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u32__N4, u32, 4);
+emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u64__N4, u64, 4);
+
+macro_rules! emit_h_unbounded_shr {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, u32, |a, n| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            *UnboundedShr::unbounded_shr(x, n).all_limbs()
+        });
+    };
+}
+emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u8__N16, u8, 16);
+emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u32__N4, u32, 4);
+emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u64__N4, u64, 4);
+
+// is_power_of_two (predicate, no shift), next_power_of_two (via ct_shl barrel).
+macro_rules! emit_h_is_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            IsPowerOfTwo::is_power_of_two(x) as u8
+        });
+    };
+}
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u8__N16, u8, 16);
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u32__N4, u32, 4);
+emit_h_is_pow2!(ct_fix__HA__is_pow2__u64__N4, u64, 4);
+
+macro_rules! emit_h_next_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            *NextPowerOfTwo::next_power_of_two(x).all_limbs()
+        });
+    };
+}
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u8__N16, u8, 16);
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N4, u32, 4);
+emit_h_next_pow2!(ct_fix__HA__next_pow2__u64__N4, u64, 4);
+
+macro_rules! emit_h_midpoint {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            *Midpoint::midpoint(x, y).all_limbs()
+        });
+    };
+}
+emit_h_midpoint!(ct_fix__HC__midpoint__u8__N16, u8, 16);
+emit_h_midpoint!(ct_fix__HC__midpoint__u32__N4, u32, 4);
+emit_h_midpoint!(ct_fix__HC__midpoint__u64__N4, u64, 4);
 
 // =============================================================================
 // Category HA: Ct arms dispatched via `match P::TAG`.
@@ -117,13 +210,6 @@ emit_h_abs_diff!(ct_fix__HA__abs_diff__u16__N16, u16, 16);
 emit_h_abs_diff!(ct_fix__HA__abs_diff__u32__N4, u32, 4);
 emit_h_abs_diff!(ct_fix__HA__abs_diff__u32__N16, u32, 16);
 emit_h_abs_diff!(ct_fix__HA__abs_diff__u64__N4, u64, 4);
-
-// NOTE: is_power_of_two / next_power_of_two are intentionally NOT fixtured.
-// Their Ct path reaches the heapless `<<`/`>>` *operator* (next_pow2 via
-// `ct_shl`), which is dual-use — also callable with a secret amount — so its
-// helper symbol can't be allowlisted without risking a false pass. Heapless
-// lacks a dedicated `const_shl_ct`/`const_shr_ct` primitive to route Ct shifts
-// through (unlike FixedUInt). Tracked in the CT-coverage backlog.
 
 // PrimBits::leading_zeros / trailing_zeros
 macro_rules! emit_h_lz {
@@ -392,10 +478,6 @@ emit_h_carrying_add!(ct_fix__HC__carrying_add__u16__N16, u16, 16);
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u32__N4, u32, 4);
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u32__N16, u32, 16);
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u64__N4, u64, 4);
-
-// NOTE: midpoint is intentionally NOT fixtured — it reaches the heapless `>>`
-// operator (`>> 1`), which is the same dual-use symbol as the shifts above;
-// allowlisting it would risk a false pass. Tracked in the CT-coverage backlog.
 
 // Ord::cmp — folded to u8 (Less=0xFF, Equal=0, Greater=1).
 macro_rules! emit_h_cmp {

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -15,15 +15,19 @@
 //!   - `HC`  — always-CT-by-construction ops (bitwise, wrapping/carry chains)
 //!   - `HCT` — const-num-traits `Ct*` masked-return trait impls
 //!
-//! This whole module is behind the (default-off) `heapless` cargo feature:
-//! the runtime-`len` carrier's helpers loop over a public-but-runtime width,
-//! whose register-bounded branches trip the asm-grep gate even though they
-//! leak no secret. It is ready-to-run scaffolding for when the gate can
-//! allowlist those loops.
+//! Behind the `heapless` cargo feature, which the asm-grep driver enables.
+//! The runtime-`len` carrier's per-limb helpers loop over a public-but-runtime
+//! width; each is attested public-bounded in ct-driver's `HELPER_ALLOWLIST`,
+//! so these fixtures are gated on every target like the FixedUInt set.
 //!
-//! Ops that are not yet constant-time on this carrier — the variable-amount
-//! shifts, which never route through a branchless barrel shifter — are
-//! deliberately left out (a fixture for them would fail for the right reason).
+//! Ops NOT fixtured here (a fixture would fail for the right reason, and they
+//! are tracked in the CT-coverage backlog):
+//!   - variable-amount shifts, and anything reaching the `<<`/`>>` operator —
+//!     `is_power_of_two` / `next_power_of_two` (via `ct_shl`) and `midpoint`
+//!     (`>> 1`). The heapless shift operators are dual-use (callable with a
+//!     secret amount), so their symbol can't be allowlisted; heapless lacks a
+//!     dedicated `const_shl_ct`/`const_shr_ct` the way FixedUInt has.
+//!   - `is_one` — the heapless `One::is_one` body has a data-dependent branch.
 
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
@@ -114,36 +118,12 @@ emit_h_abs_diff!(ct_fix__HA__abs_diff__u32__N4, u32, 4);
 emit_h_abs_diff!(ct_fix__HA__abs_diff__u32__N16, u32, 16);
 emit_h_abs_diff!(ct_fix__HA__abs_diff__u64__N4, u64, 4);
 
-// IsPowerOfTwo::is_power_of_two — predicate
-macro_rules! emit_h_is_pow2 {
-    ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            IsPowerOfTwo::is_power_of_two(x) as u8
-        });
-    };
-}
-emit_h_is_pow2!(ct_fix__HA__is_pow2__u8__N16, u8, 16);
-emit_h_is_pow2!(ct_fix__HA__is_pow2__u16__N16, u16, 16);
-emit_h_is_pow2!(ct_fix__HA__is_pow2__u32__N4, u32, 4);
-emit_h_is_pow2!(ct_fix__HA__is_pow2__u32__N16, u32, 16);
-emit_h_is_pow2!(ct_fix__HA__is_pow2__u64__N4, u64, 4);
-
-// NextPowerOfTwo::next_power_of_two
-macro_rules! emit_h_next_pow2 {
-    ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let r = NextPowerOfTwo::next_power_of_two(x);
-            *r.all_limbs()
-        });
-    };
-}
-emit_h_next_pow2!(ct_fix__HA__next_pow2__u8__N16, u8, 16);
-emit_h_next_pow2!(ct_fix__HA__next_pow2__u16__N16, u16, 16);
-emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N4, u32, 4);
-emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N16, u32, 16);
-emit_h_next_pow2!(ct_fix__HA__next_pow2__u64__N4, u64, 4);
+// NOTE: is_power_of_two / next_power_of_two are intentionally NOT fixtured.
+// Their Ct path reaches the heapless `<<`/`>>` *operator* (next_pow2 via
+// `ct_shl`), which is dual-use — also callable with a secret amount — so its
+// helper symbol can't be allowlisted without risking a false pass. Heapless
+// lacks a dedicated `const_shl_ct`/`const_shr_ct` primitive to route Ct shifts
+// through (unlike FixedUInt). Tracked in the CT-coverage backlog.
 
 // PrimBits::leading_zeros / trailing_zeros
 macro_rules! emit_h_lz {
@@ -189,19 +169,9 @@ emit_h_is_zero!(ct_fix__HA__is_zero__u32__N4, u32, 4);
 emit_h_is_zero!(ct_fix__HA__is_zero__u32__N16, u32, 16);
 emit_h_is_zero!(ct_fix__HA__is_zero__u64__N4, u64, 4);
 
-macro_rules! emit_h_is_one {
-    ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            <HeaplessBigInt<$T, $N, Ct> as One>::is_one(&x) as u8
-        });
-    };
-}
-emit_h_is_one!(ct_fix__HA__is_one__u8__N16, u8, 16);
-emit_h_is_one!(ct_fix__HA__is_one__u16__N16, u16, 16);
-emit_h_is_one!(ct_fix__HA__is_one__u32__N4, u32, 4);
-emit_h_is_one!(ct_fix__HA__is_one__u32__N16, u32, 16);
-emit_h_is_one!(ct_fix__HA__is_one__u64__N4, u64, 4);
+// NOTE: is_one is intentionally NOT fixtured — the heapless `One::is_one`
+// body carries a data-dependent branch (fixture-level violation), so it is not
+// yet constant-time. Tracked in the CT-coverage backlog.
 
 // =============================================================================
 // Category HB: subtle::* trait impls.
@@ -423,22 +393,9 @@ emit_h_carrying_add!(ct_fix__HC__carrying_add__u32__N4, u32, 4);
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u32__N16, u32, 16);
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u64__N4, u64, 4);
 
-// Midpoint
-macro_rules! emit_h_midpoint {
-    ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = Midpoint::midpoint(x, y);
-            *r.all_limbs()
-        });
-    };
-}
-emit_h_midpoint!(ct_fix__HC__midpoint__u8__N16, u8, 16);
-emit_h_midpoint!(ct_fix__HC__midpoint__u16__N16, u16, 16);
-emit_h_midpoint!(ct_fix__HC__midpoint__u32__N4, u32, 4);
-emit_h_midpoint!(ct_fix__HC__midpoint__u32__N16, u32, 16);
-emit_h_midpoint!(ct_fix__HC__midpoint__u64__N4, u64, 4);
+// NOTE: midpoint is intentionally NOT fixtured — it reaches the heapless `>>`
+// operator (`>> 1`), which is the same dual-use symbol as the shifts above;
+// allowlisting it would risk a false pass. Tracked in the CT-coverage backlog.
 
 // Ord::cmp — folded to u8 (Less=0xFF, Equal=0, Greater=1).
 macro_rules! emit_h_cmp {

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -20,10 +20,10 @@
 //! width; each is attested public-bounded in ct-driver's `HELPER_ALLOWLIST`,
 //! so these fixtures are gated on every target like the FixedUInt set.
 //!
-//! Not fixtured: `is_one` — the heapless `One::is_one` body still has a
-//! data-dependent branch (tracked in the CT-coverage backlog). Everything else,
-//! shifts included, is covered: the `Ct` `<<`/`>>` operators now dispatch to
-//! branchless barrels (`const_shl_ct`/`const_shr_ct`).
+//! Shifts included: the `Ct` `<<`/`>>` operators dispatch to branchless
+//! barrels (`const_shl_ct`/`const_shr_ct`), and `is_one` folds through the
+//! out-of-line `const_is_one_ct` helper so its `len` loop lands in an
+//! attestable symbol rather than inlining into the fixture.
 
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
@@ -269,9 +269,22 @@ emit_h_is_one!(ct_fix__HA__is_one__u32__N4, u32, 4);
 emit_h_is_one!(ct_fix__HA__is_one__u32__N16, u32, 16);
 emit_h_is_one!(ct_fix__HA__is_one__u64__N4, u64, 4);
 
-// NOTE: is_one is intentionally NOT fixtured — the heapless `One::is_one`
-// body carries a data-dependent branch (fixture-level violation), so it is not
-// yet constant-time. Tracked in the CT-coverage backlog.
+// PartialEq::eq — the `==` operator's branchless Ct XOR-fold, distinct from
+// the `subtle::ct_eq` fixtured in category HB.
+macro_rules! emit_h_eq {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_pred2!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            (x == y) as u8
+        });
+    };
+}
+emit_h_eq!(ct_fix__HA__eq__u8__N16, u8, 16);
+emit_h_eq!(ct_fix__HA__eq__u16__N16, u16, 16);
+emit_h_eq!(ct_fix__HA__eq__u32__N4, u32, 4);
+emit_h_eq!(ct_fix__HA__eq__u32__N16, u32, 16);
+emit_h_eq!(ct_fix__HA__eq__u64__N4, u64, 4);
 
 // =============================================================================
 // Category HB: subtle::* trait impls.

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -28,6 +28,8 @@ mod fixtures_cat_a;
 mod fixtures_cat_b;
 mod fixtures_cat_c;
 mod fixtures_ct_traits;
+#[cfg(feature = "heapless")]
+mod fixtures_heapless;
 mod fixtures_neg;
 
 /// No-op Rust-visible anchor. Host-side consumers (ct-ctgrind) call this

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -2095,6 +2095,21 @@ mod tests {
         }
     }
 
+    // The `Ct` arm of `PartialEq::eq` folds every limb (via `const_eq_ct`)
+    // rather than short-circuiting; it must still agree with `==` bit-for-bit,
+    // whether the operands match, differ in a high limb, or differ in a low one.
+    #[test]
+    fn test_ct_eq() {
+        type C = Bn<u8, 4, const_num_traits::Ct>;
+        assert!(C::from(0x0102_0304u32) == C::from(0x0102_0304u32));
+        assert!(C::from(0u32) == C::from(0u32));
+        // high limb differs
+        assert!(C::from(0x0102_0304u32) != C::from(0x8102_0304u32));
+        // low limb differs (high limbs equal)
+        assert!(C::from(0x0102_0304u32) != C::from(0x0102_0384u32));
+        assert!(C::from(1u32) != C::from(0u32));
+    }
+
     #[test]
     fn test_const_cmp_shifted() {
         use core::cmp::Ordering;

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -1199,6 +1199,25 @@ c0nst::c0nst! {
         <T as Zero>::is_zero(&acc)
     }
 
+    /// CT equality: folds `(a[0] ^ b[0]) | (a[1] ^ b[1]) | ...` into one
+    /// accumulator, so timing does not depend on where the two arrays first
+    /// differ. Used by the `Ct`-personality arm of `PartialEq::eq`. Kept as a
+    /// named helper (like `const_cmp_ct`) so the fold's `N`-bounded loop lands
+    /// in one symbol the CT gate can attest, rather than inline in the operator.
+    pub(crate) c0nst fn const_eq_ct<T: [c0nst] ConstMachineWord, const N: usize>(
+        a: &[T; N],
+        b: &[T; N],
+    ) -> bool {
+        let mut diff = <T as ConstZero>::ZERO;
+        let mut i = 0;
+        while i < N {
+            let x = <T as core::ops::BitXor>::bitxor(a[i], b[i]);
+            diff = <T as core::ops::BitOr>::bitor(diff, x);
+            i += 1;
+        }
+        <T as Zero>::is_zero(&diff)
+    }
+
     /// Set a specific bit in the array.
     ///
     /// The array uses little-endian representation where index 0 contains
@@ -1532,16 +1551,7 @@ c0nst::c0nst! {
         fn eq(&self, other: &Self) -> bool {
             match P::TAG {
                 PersonalityTag::Nct => self.array == other.array,
-                PersonalityTag::Ct => {
-                    let mut diff = <T as ConstZero>::ZERO;
-                    let mut i = 0;
-                    while i < N {
-                        let x = <T as core::ops::BitXor>::bitxor(self.array[i], other.array[i]);
-                        diff = <T as core::ops::BitOr>::bitor(diff, x);
-                        i += 1;
-                    }
-                    <T as Zero>::is_zero(&diff)
-                }
+                PersonalityTag::Ct => const_eq_ct(&self.array, &other.array),
             }
         }
     }

--- a/src/fixeduint.rs
+++ b/src/fixeduint.rs
@@ -1199,11 +1199,11 @@ c0nst::c0nst! {
         <T as Zero>::is_zero(&acc)
     }
 
-    /// CT equality: folds `(a[0] ^ b[0]) | (a[1] ^ b[1]) | ...` into one
-    /// accumulator, so timing does not depend on where the two arrays first
-    /// differ. Used by the `Ct`-personality arm of `PartialEq::eq`. Kept as a
-    /// named helper (like `const_cmp_ct`) so the fold's `N`-bounded loop lands
-    /// in one symbol the CT gate can attest, rather than inline in the operator.
+    /// CT equality for the `Ct` arm of `PartialEq::eq`: folds
+    /// `(a[0] ^ b[0]) | (a[1] ^ b[1]) | ...` into one accumulator, so timing
+    /// does not depend on where the two arrays first differ. Kept as a named
+    /// helper (like `const_cmp_ct`) so the fold's `N`-bounded loop lands in one
+    /// symbol the CT gate can attest, rather than inline in the operator.
     pub(crate) c0nst fn const_eq_ct<T: [c0nst] ConstMachineWord, const N: usize>(
         a: &[T; N],
         b: &[T; N],

--- a/src/heapless/arith.rs
+++ b/src/heapless/arith.rs
@@ -1057,12 +1057,32 @@ where
                 cin = c;
                 i += 1;
             }
+            // Propagate the fold carry into the hi half. `Nct` may stop the
+            // moment the carry dies; `Ct` must sweep the full width so timing
+            // is independent of where — or whether — the carry chain
+            // terminates (a secret-dependent bound here leaks the operands,
+            // which the taint gate catches). A `false` carry-in makes each
+            // step a constant-time no-op.
             let mut i = 0;
-            while cin && i < w {
-                let (sum, c) = <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
-                hi_limbs[i] = sum;
-                cin = c;
-                i += 1;
+            match P::TAG {
+                PersonalityTag::Nct => {
+                    while cin && i < w {
+                        let (sum, c) =
+                            <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), true);
+                        hi_limbs[i] = sum;
+                        cin = c;
+                        i += 1;
+                    }
+                }
+                PersonalityTag::Ct => {
+                    while i < w {
+                        let (sum, c) =
+                            <T as CarryingAdd>::carrying_add(hi_limbs[i], zero::<T>(), cin);
+                        hi_limbs[i] = sum;
+                        cin = c;
+                        i += 1;
+                    }
+                }
             }
         }
 

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -90,17 +90,33 @@ impl<T: MachineWord, const CAP: usize, P: Personality> One for HeaplessBigInt<T,
                 }
                 true
             }
-            PersonalityTag::Ct => {
-                let mut acc = self.limbs[0] ^ <T as ConstOne>::ONE;
-                let mut i = 1;
-                while i < n {
-                    acc |= self.limbs[i];
-                    i += 1;
-                }
-                super::is_zero(&acc)
-            }
+            PersonalityTag::Ct => const_is_one_ct(&self.limbs, n),
         }
     }
+}
+
+/// CT fold for [`One::is_one`]: `(limbs[0] ^ 1) | limbs[1] | … | limbs[n-1]`,
+/// zero iff the value is the canonical one. Timing depends only on the public
+/// `len` (`n`), never on where the value first diverges from one. Caller
+/// guarantees `n >= 1`.
+///
+/// Kept out-of-line so the fold's `len`-bounded loop lands in one attestable
+/// helper symbol rather than being inlined into its lone caller, where the same
+/// loop would read as an un-attestable branch to the CT gate. (FixedUInt's twin
+/// unrolls instead, because its bound is the const generic `N`; the heapless
+/// bound is a runtime field, so the loop stays a loop and must be attested.)
+#[inline(never)]
+pub(crate) fn const_is_one_ct<T: MachineWord, const CAP: usize>(
+    limbs: &[T; CAP],
+    n: usize,
+) -> bool {
+    let mut acc = limbs[0] ^ <T as ConstOne>::ONE;
+    let mut i = 1;
+    while i < n {
+        acc |= limbs[i];
+        i += 1;
+    }
+    super::is_zero(&acc)
 }
 
 impl<T: MachineWord, const CAP: usize, P: Personality> Default for HeaplessBigInt<T, CAP, P> {

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -168,6 +168,25 @@ impl<T: MachineWord, const CAP: usize, P: Personality> ConstOne for HeaplessBigI
 // `min = 0` (len 0). `max` is the capacity bound: every one of `CAP` limbs
 // saturated, `len = CAP`. This is the one answer `CAP` legitimately sets —
 // it is the widest value the storage can represent, not a value width.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use const_num_traits::Ct;
+
+    type Hc = HeaplessBigInt<u8, 4, Ct>;
+
+    // `One::is_one` on the `Ct` carrier folds through `const_is_one_ct` with no
+    // early return; it must still match the predicate exactly, including the
+    // `len == 0` (zero) guard and a `1` that sits in a higher limb.
+    #[test]
+    fn ct_is_one() {
+        assert!(<Hc as One>::is_one(&<Hc as One>::one()));
+        assert!(!<Hc as One>::is_one(&<Hc as Zero>::zero()));
+        assert!(!<Hc as One>::is_one(&Hc::from_limbs([2, 0, 0, 0], 1)));
+        assert!(!<Hc as One>::is_one(&Hc::from_limbs([0, 1, 0, 0], 2)));
+    }
+}
+
 impl<T: MachineWord, const CAP: usize, P: Personality> Bounded for HeaplessBigInt<T, CAP, P> {
     #[inline]
     fn min_value() -> Self {

--- a/src/heapless/identities.rs
+++ b/src/heapless/identities.rs
@@ -100,11 +100,9 @@ impl<T: MachineWord, const CAP: usize, P: Personality> One for HeaplessBigInt<T,
 /// `len` (`n`), never on where the value first diverges from one. Caller
 /// guarantees `n >= 1`.
 ///
-/// Kept out-of-line so the fold's `len`-bounded loop lands in one attestable
-/// helper symbol rather than being inlined into its lone caller, where the same
-/// loop would read as an un-attestable branch to the CT gate. (FixedUInt's twin
-/// unrolls instead, because its bound is the const generic `N`; the heapless
-/// bound is a runtime field, so the loop stays a loop and must be attested.)
+/// `#[inline(never)]` so the fold's `len`-bounded loop lands in one attestable
+/// helper symbol; inlined into its lone fixture caller, the runtime-`len` loop
+/// would read as an un-attestable branch to the CT gate.
 #[inline(never)]
 pub(crate) fn const_is_one_ct<T: MachineWord, const CAP: usize>(
     limbs: &[T; CAP],
@@ -163,11 +161,6 @@ impl<T: MachineWord, const CAP: usize, P: Personality> ConstOne for HeaplessBigI
     const ONE: Self = Self::const_one();
 }
 
-// ── const_num_traits::Bounded ──
-//
-// `min = 0` (len 0). `max` is the capacity bound: every one of `CAP` limbs
-// saturated, `len = CAP`. This is the one answer `CAP` legitimately sets —
-// it is the widest value the storage can represent, not a value width.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -187,6 +180,11 @@ mod tests {
     }
 }
 
+// ── const_num_traits::Bounded ──
+//
+// `min = 0` (len 0). `max` is the capacity bound: every one of `CAP` limbs
+// saturated, `len = CAP`. This is the one answer `CAP` legitimately sets —
+// it is the widest value the storage can represent, not a value width.
 impl<T: MachineWord, const CAP: usize, P: Personality> Bounded for HeaplessBigInt<T, CAP, P> {
     #[inline]
     fn min_value() -> Self {

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -10,56 +10,167 @@
 //!   enters; the words beyond `len` do not exist. A caller wanting the
 //!   shifted value to occupy more words constructs it at the wider width
 //!   first (as `div_rem` does).
-//! - `Shr`: `out_len = self.len.saturating_sub(bits / word_bits)`. The
+//! - `Shr`: `out_len = self.len.saturating_sub(bits / word_bits)` on `Nct`. The
 //!   top limb may become zero — that's fine under the zero-tail invariant
-//!   and downstream can trim explicitly if needed (NCT-only).
+//!   and downstream can trim explicitly if needed.
 //!
-//! Iteration count is derived from `self.len` + shift amount — both
-//! public — so the Nct and Ct arms share the same body.
+//! Personality dispatch: the `Nct` arms take the direct word/bit shift above
+//! (branching on the amount, fine for a public amount). The `Ct` arms route
+//! through the branchless barrels [`const_shl_ct`] / [`const_shr_ct`] so a
+//! secret shift amount never drives control flow — and `Ct` `Shr` is
+//! width-preserving, since a data-dependent `len` shrink would itself leak.
 
-use super::cmp::ct_select;
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
-use const_num_traits::Personality;
+use const_num_traits::{Bounded, Personality, PersonalityTag};
 use core::marker::PhantomData;
 use core::ops::{Shl, ShlAssign, Shr, ShrAssign};
 
-/// Constant-time left shift by a **secret** `amount`: a barrel shifter.
-///
-/// The inherent `Shl<usize>` branches and cache-indexes on the shift amount
-/// (`word_shift`/`bit_shift`), so shifting by a secret leaks it. Here the
-/// secret never drives control flow: each stage `k` shifts by the **public**
-/// constant `2^k` and applies-or-not via a masked [`ct_select`] on bit `k` of
-/// `amount`. Amounts `>= self.len·word_bits` yield zero (masked). The only
-/// operations that touch `amount` are the arithmetic `>> k & 1` and the u32
-/// `>=` — no branch or memory access depends on it.
-///
-/// Cost is `O(width · log(width_bits))`. Result width is `self.len`, as `<<`.
-pub(crate) fn ct_shl<T, const CAP: usize, P: Personality>(
+/// Width-preserving left shift by a **public** `bits`: the raw word/bit-shift
+/// body, output `len == value.len`. Branches on `word_shift`/`bit_shift`, so it
+/// is only ever called with a public amount (the `Nct` operator arm, or a
+/// barrel stage `2^k`). The `Ct` operator arm routes through [`const_shl_ct`]
+/// instead so a secret amount never reaches this branchful body.
+fn shl_wp<T: MachineWord, const CAP: usize, P: Personality>(
     value: HeaplessBigInt<T, CAP, P>,
-    amount: u32,
-) -> HeaplessBigInt<T, CAP, P>
-where
-    T: MachineWord + subtle::ConditionallySelectable,
-{
-    let width = value.len();
-    let word_bits = core::mem::size_of::<T>() as u32 * 8;
-    let width_bits = width as u32 * word_bits;
-    let mut result = value;
-    // Public loop bound: stages cover bit positions `0..ceil(log2(width_bits))`.
-    let mut k = 0u32;
-    while (1u32 << k) < width_bits {
-        // Stage amount `2^k` stays in `u32` (< width_bits < 2^32) — `1usize << k`
-        // would overflow on a 16-bit-usize target once k >= 16. The `Shl<u32>`
-        // it routes through carries the same over-width cast guard as elsewhere.
-        let shifted = result << (1u32 << k); // fixed, public shift by 2^k
-        let bit_k = (amount >> k) & 1;
-        result = ct_select(&result, &shifted, bit_k != 0);
+    bits: usize,
+) -> HeaplessBigInt<T, CAP, P> {
+    let word_bits = core::mem::size_of::<T>() * 8;
+    let word_shift = bits / word_bits;
+    let bit_shift = bits % word_bits;
+    let out_len = value.len as usize;
+    let mut limbs = [zero::<T>(); CAP];
+    let mut i = 0;
+    while i < out_len {
+        let dst_lo = i + word_shift;
+        if dst_lo < out_len {
+            limbs[dst_lo] |= value.limbs[i] << bit_shift;
+            if bit_shift > 0 {
+                let dst_hi = dst_lo + 1;
+                if dst_hi < out_len {
+                    limbs[dst_hi] |= value.limbs[i] >> (word_bits - bit_shift);
+                }
+            }
+        }
+        i += 1;
+    }
+    HeaplessBigInt {
+        limbs,
+        len: value.len,
+        _p: PhantomData,
+    }
+}
+
+/// Width-preserving right shift by a **public** `bits`, output `len ==
+/// value.len` (the top limbs zero-fill rather than the `len` shrinking as the
+/// `Nct` `Shr` operator does). Same public-amount contract as [`shl_wp`]: the
+/// barrel stages and the `Ct` operator arm pass public amounts here, a secret
+/// amount goes through [`const_shr_ct`].
+fn shr_wp<T: MachineWord, const CAP: usize, P: Personality>(
+    value: HeaplessBigInt<T, CAP, P>,
+    bits: usize,
+) -> HeaplessBigInt<T, CAP, P> {
+    let word_bits = core::mem::size_of::<T>() * 8;
+    let word_shift = bits / word_bits;
+    let bit_shift = bits % word_bits;
+    let n = value.len as usize;
+    let mut limbs = [zero::<T>(); CAP];
+    let mut i = 0;
+    while i < n {
+        let src_lo = i + word_shift;
+        let lo = if src_lo < n {
+            value.limbs[src_lo] >> bit_shift
+        } else {
+            zero::<T>()
+        };
+        let hi = if bit_shift > 0 && src_lo + 1 < n {
+            value.limbs[src_lo + 1] << (word_bits - bit_shift)
+        } else {
+            zero::<T>()
+        };
+        limbs[i] = lo | hi;
+        i += 1;
+    }
+    HeaplessBigInt {
+        limbs,
+        len: value.len,
+        _p: PhantomData,
+    }
+}
+
+/// Full-`T` mask from bit 0 of a `black_box`'d choice: `0` when clear, `T::MAX`
+/// when set. Mirrors `FixedUInt::const_ct_select` — the `black_box` stops LLVM
+/// recognising the XOR-AND-XOR select and rewriting it into a secret-flag
+/// conditional move (which asm-grep can't see but ctgrind's taint pass can).
+#[inline]
+fn ct_mask<T: MachineWord>(choice_bit: u8) -> T {
+    let bit = core::hint::black_box(choice_bit & 1);
+    let bit_t = <T as core::convert::From<u8>>::from(bit);
+    <T as core::ops::Mul>::mul(bit_t, <T as Bounded>::max_value())
+}
+
+/// Constant-time left shift by a **secret** `bits`: a branchless barrel
+/// shifter, the heapless twin of `FixedUInt::const_shl_ct`. Each stage `k`
+/// shifts by the public constant `2^k` via [`shl_wp`] and applies-or-not with a
+/// per-limb masked XOR select on bit `k` of `bits`. The secret never drives
+/// control flow or a memory index. Result width is `value.len` (as `<<`).
+pub(crate) fn const_shl_ct<T: MachineWord, const CAP: usize, P: Personality>(
+    value: HeaplessBigInt<T, CAP, P>,
+    bits: usize,
+) -> HeaplessBigInt<T, CAP, P> {
+    let n = value.len as usize;
+    // `1usize << k` for `k < usize::BITS` stays in range; this covers every
+    // amount, over-width ones included (a stage that shifts past the width
+    // zeroes the operand, so the select folds to zero). Matches
+    // `FixedUInt::const_shl_ct`'s `layers`.
+    let layers = core::mem::size_of::<usize>() * 8;
+    let mut target = value;
+    let mut k = 0;
+    while k < layers {
+        let shifted = shl_wp(target, 1usize << k);
+        let mask = ct_mask::<T>(((bits >> k) & 1) as u8);
+        let mut i = 0;
+        while i < n {
+            let diff = target.limbs[i] ^ shifted.limbs[i];
+            target.limbs[i] ^= mask & diff;
+            i += 1;
+        }
         k += 1;
     }
-    // Over-width amount shifts everything out.
-    let zero_w = HeaplessBigInt::<T, CAP, P>::new_zero_with_len(width);
-    ct_select(&result, &zero_w, amount >= width_bits)
+    target
+}
+
+/// Constant-time right shift by a **secret** `bits`: mirror of
+/// [`const_shl_ct`] via [`shr_wp`]. Width-preserving (`len == value.len`).
+pub(crate) fn const_shr_ct<T: MachineWord, const CAP: usize, P: Personality>(
+    value: HeaplessBigInt<T, CAP, P>,
+    bits: usize,
+) -> HeaplessBigInt<T, CAP, P> {
+    let n = value.len as usize;
+    let layers = core::mem::size_of::<usize>() * 8;
+    let mut target = value;
+    let mut k = 0;
+    while k < layers {
+        let shifted = shr_wp(target, 1usize << k);
+        let mask = ct_mask::<T>(((bits >> k) & 1) as u8);
+        let mut i = 0;
+        while i < n {
+            let diff = target.limbs[i] ^ shifted.limbs[i];
+            target.limbs[i] ^= mask & diff;
+            i += 1;
+        }
+        k += 1;
+    }
+    target
+}
+
+/// Secret-amount left shift used by `ct_next_pow2`. Thin `u32` wrapper over
+/// [`const_shl_ct`].
+pub(crate) fn ct_shl<T: MachineWord, const CAP: usize, P: Personality>(
+    value: HeaplessBigInt<T, CAP, P>,
+    amount: u32,
+) -> HeaplessBigInt<T, CAP, P> {
+    const_shl_ct(value, amount as usize)
 }
 
 // `Shl<u32>` / `Shr<u32>` delegate to the `usize` impls, matching `FixedUInt`.
@@ -75,11 +186,20 @@ where
 impl<T: MachineWord, const CAP: usize, P: Personality> Shl<u32> for HeaplessBigInt<T, CAP, P> {
     type Output = Self;
     fn shl(self, bits: u32) -> Self::Output {
-        let value_bits = self.len as u32 * (core::mem::size_of::<T>() as u32 * 8);
-        if bits >= value_bits {
-            Self::new_zero_with_len(self.len())
-        } else {
-            self << (bits as usize)
+        match P::TAG {
+            // Ct: the over-width guard would branch on the (secret) amount, so
+            // go straight to the barrel — it collapses over-width shifts to
+            // zero on its own. `bits as usize` never truncates a meaningful
+            // amount (over-width already yields zero).
+            PersonalityTag::Ct => const_shl_ct(self, bits as usize),
+            PersonalityTag::Nct => {
+                let value_bits = self.len as u32 * (core::mem::size_of::<T>() as u32 * 8);
+                if bits >= value_bits {
+                    Self::new_zero_with_len(self.len())
+                } else {
+                    self << (bits as usize)
+                }
+            }
         }
     }
 }
@@ -87,11 +207,16 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Shl<u32> for HeaplessBigI
 impl<T: MachineWord, const CAP: usize, P: Personality> Shr<u32> for HeaplessBigInt<T, CAP, P> {
     type Output = Self;
     fn shr(self, bits: u32) -> Self::Output {
-        let value_bits = self.len as u32 * (core::mem::size_of::<T>() as u32 * 8);
-        if bits >= value_bits {
-            Self::new_zero_with_len(0)
-        } else {
-            self >> (bits as usize)
+        match P::TAG {
+            PersonalityTag::Ct => const_shr_ct(self, bits as usize),
+            PersonalityTag::Nct => {
+                let value_bits = self.len as u32 * (core::mem::size_of::<T>() as u32 * 8);
+                if bits >= value_bits {
+                    Self::new_zero_with_len(0)
+                } else {
+                    self >> (bits as usize)
+                }
+            }
         }
     }
 }
@@ -100,35 +225,12 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Shl<usize> for HeaplessBi
     type Output = Self;
 
     fn shl(self, bits: usize) -> Self::Output {
-        let word_bits = core::mem::size_of::<T>() * 8;
-        let word_shift = bits / word_bits;
-        let bit_shift = bits % word_bits;
-
-        // Width-preserving: out_len = self.len (see module doc).
-        let out_len = self.len as usize;
-        let mut limbs = [zero::<T>(); CAP];
-
-        let mut i = 0;
-        while i < out_len {
-            let dst_lo = i + word_shift;
-            if dst_lo < out_len {
-                let lo = self.limbs[i] << bit_shift;
-                limbs[dst_lo] |= lo;
-                if bit_shift > 0 {
-                    let dst_hi = dst_lo + 1;
-                    if dst_hi < out_len {
-                        let hi = self.limbs[i] >> (word_bits - bit_shift);
-                        limbs[dst_hi] |= hi;
-                    }
-                }
-            }
-            i += 1;
-        }
-
-        Self {
-            limbs,
-            len: out_len as u16,
-            _p: PhantomData,
+        // Ct routes a (possibly secret) amount through the branchless barrel;
+        // Nct takes the direct word/bit shift. `P::TAG` is a compile-time
+        // constant, so each monomorphisation keeps only its own arm.
+        match P::TAG {
+            PersonalityTag::Nct => shl_wp(self, bits),
+            PersonalityTag::Ct => const_shl_ct(self, bits),
         }
     }
 }
@@ -153,38 +255,47 @@ impl<T: MachineWord, const CAP: usize, P: Personality> Shr<usize> for HeaplessBi
     type Output = Self;
 
     fn shr(self, bits: usize) -> Self::Output {
-        let word_bits = core::mem::size_of::<T>() * 8;
-        let word_shift = bits / word_bits;
-        let bit_shift = bits % word_bits;
+        match P::TAG {
+            // Ct: branchless barrel, width-preserving (a data-dependent `len`
+            // shrink would itself leak a secret amount).
+            PersonalityTag::Ct => const_shr_ct(self, bits),
+            // Nct: direct shift, shrinking `out_len = len - word_shift` (the
+            // documented heapless `Shr` width behaviour).
+            PersonalityTag::Nct => {
+                let word_bits = core::mem::size_of::<T>() * 8;
+                let word_shift = bits / word_bits;
+                let bit_shift = bits % word_bits;
 
-        let mut limbs = [zero::<T>(); CAP];
-        if word_shift >= self.len as usize {
-            return Self {
-                limbs,
-                len: 0,
-                _p: PhantomData,
-            };
-        }
+                let mut limbs = [zero::<T>(); CAP];
+                if word_shift >= self.len as usize {
+                    return Self {
+                        limbs,
+                        len: 0,
+                        _p: PhantomData,
+                    };
+                }
 
-        let out_len = self.len as usize - word_shift;
+                let out_len = self.len as usize - word_shift;
 
-        let mut i = 0;
-        while i < out_len {
-            let src_lo = i + word_shift;
-            let lo = self.limbs[src_lo] >> bit_shift;
-            let hi = if bit_shift > 0 && src_lo + 1 < self.len as usize {
-                self.limbs[src_lo + 1] << (word_bits - bit_shift)
-            } else {
-                zero::<T>()
-            };
-            limbs[i] = lo | hi;
-            i += 1;
-        }
+                let mut i = 0;
+                while i < out_len {
+                    let src_lo = i + word_shift;
+                    let lo = self.limbs[src_lo] >> bit_shift;
+                    let hi = if bit_shift > 0 && src_lo + 1 < self.len as usize {
+                        self.limbs[src_lo + 1] << (word_bits - bit_shift)
+                    } else {
+                        zero::<T>()
+                    };
+                    limbs[i] = lo | hi;
+                    i += 1;
+                }
 
-        Self {
-            limbs,
-            len: out_len as u16,
-            _p: PhantomData,
+                Self {
+                    limbs,
+                    len: out_len as u16,
+                    _p: PhantomData,
+                }
+            }
         }
     }
 }

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -63,9 +63,8 @@ fn shl_wp<T: MachineWord, const CAP: usize, P: Personality>(
 
 /// Width-preserving right shift by a **public** `bits`, output `len ==
 /// value.len` (the top limbs zero-fill rather than the `len` shrinking as the
-/// `Nct` `Shr` operator does). Same public-amount contract as [`shl_wp`]: the
-/// barrel stages and the `Ct` operator arm pass public amounts here, a secret
-/// amount goes through [`const_shr_ct`].
+/// `Nct` `Shr` operator does). Public-only, like [`shl_wp`]; a secret amount
+/// goes through [`const_shr_ct`].
 fn shr_wp<T: MachineWord, const CAP: usize, P: Personality>(
     value: HeaplessBigInt<T, CAP, P>,
     bits: usize,
@@ -110,10 +109,10 @@ fn ct_mask<T: MachineWord>(choice_bit: u8) -> T {
 }
 
 /// Constant-time left shift by a **secret** `bits`: a branchless barrel
-/// shifter, the heapless twin of `FixedUInt::const_shl_ct`. Each stage `k`
-/// shifts by the public constant `2^k` via [`shl_wp`] and applies-or-not with a
-/// per-limb masked XOR select on bit `k` of `bits`. The secret never drives
-/// control flow or a memory index. Result width is `value.len` (as `<<`).
+/// shifter, the heapless twin of `FixedUInt::const_shl_ct`. Each public stage
+/// `2^k` is applied-or-not via a per-limb masked XOR select on bit `k` of
+/// `bits`, so the secret never drives control flow or a memory index. Result
+/// width is `value.len` (as `<<`).
 pub(crate) fn const_shl_ct<T: MachineWord, const CAP: usize, P: Personality>(
     value: HeaplessBigInt<T, CAP, P>,
     bits: usize,

--- a/src/heapless/shift.rs
+++ b/src/heapless/shift.rs
@@ -397,9 +397,10 @@ impl<T: MachineWord, const CAP: usize, P: Personality> ShrAssign<&u32>
 #[cfg(test)]
 mod ct_shl_tests {
     use super::{HeaplessBigInt, ct_shl};
-    use const_num_traits::Ct;
+    use const_num_traits::{Ct, Nct};
 
     type HC = HeaplessBigInt<u8, 4, Ct>; // 32-bit width
+    type HN = HeaplessBigInt<u8, 4, Nct>;
 
     #[test]
     fn ct_shl_matches_plain_shift_all_amounts() {
@@ -412,6 +413,37 @@ mod ct_shl_tests {
                     ct_shl(v, amount),
                     v << (amount as usize),
                     "ct_shl({raw:#x}, {amount})"
+                );
+            }
+        }
+    }
+
+    // The Ct barrels (`const_shl_ct` / `const_shr_ct`) must produce the same
+    // VALUE as the Nct reference shift at the full operand width — only timing
+    // differs. The CT fixtures check the barrels are branchless, not that they
+    // compute the right answer, so pin correctness here across both directions
+    // and all amounts (including over-width, which yields 0). `all_limbs`
+    // compares the full array, so the Ct width-preserving `>>` and the Nct
+    // len-shrinking `>>` still match limb-for-limb via the zero tail.
+    #[test]
+    fn ct_shifts_match_nct_reference() {
+        let cases = [
+            [1u8, 0, 0, 0],
+            [0x78, 0x56, 0x34, 0x12],
+            [0xFF, 0xFF, 0xFF, 0xFF],
+            [0, 0, 0, 0x80],
+        ];
+        for a in cases {
+            for amount in 0usize..=40 {
+                assert_eq!(
+                    (HC::from_limbs(a, 4) << amount).all_limbs(),
+                    (HN::from_limbs(a, 4) << amount).all_limbs(),
+                    "shl {a:?} << {amount}"
+                );
+                assert_eq!(
+                    (HC::from_limbs(a, 4) >> amount).all_limbs(),
+                    (HN::from_limbs(a, 4) >> amount).all_limbs(),
+                    "shr {a:?} >> {amount}"
                 );
             }
         }

--- a/src/heapless/shift_ops.rs
+++ b/src/heapless/shift_ops.rs
@@ -16,7 +16,8 @@ use super::HeaplessBigInt;
 use crate::MachineWord;
 use const_num_traits::{
     CheckedShl, CheckedShr, FunnelShl, FunnelShr, OverflowingShl, OverflowingShr, Personality,
-    PrimBits, ShlExact, ShrExact, UnboundedShl, UnboundedShr, WrappingShl, WrappingShr,
+    PersonalityTag, PrimBits, ShlExact, ShrExact, UnboundedShl, UnboundedShr, WrappingShl,
+    WrappingShr,
 };
 
 impl<T: MachineWord, const CAP: usize, P: Personality> HeaplessBigInt<T, CAP, P> {
@@ -97,10 +98,17 @@ impl<T: MachineWord, const CAP: usize, P: Personality> CheckedShr for HeaplessBi
 impl<T: MachineWord, const CAP: usize, P: Personality> UnboundedShl for HeaplessBigInt<T, CAP, P> {
     type Output = Self;
     fn unbounded_shl(self, rhs: u32) -> Self {
-        if rhs >= self.value_bits() {
-            Self::new_zero_with_len(self.len())
-        } else {
-            self << (rhs as usize)
+        match P::TAG {
+            // Ct: the over-width guard would branch on the (secret) amount;
+            // the Ct `<<` barrel already collapses over-width shifts to zero.
+            PersonalityTag::Ct => self << (rhs as usize),
+            PersonalityTag::Nct => {
+                if rhs >= self.value_bits() {
+                    Self::new_zero_with_len(self.len())
+                } else {
+                    self << (rhs as usize)
+                }
+            }
         }
     }
 }
@@ -108,10 +116,15 @@ impl<T: MachineWord, const CAP: usize, P: Personality> UnboundedShl for Heapless
 impl<T: MachineWord, const CAP: usize, P: Personality> UnboundedShr for HeaplessBigInt<T, CAP, P> {
     type Output = Self;
     fn unbounded_shr(self, rhs: u32) -> Self {
-        if rhs >= self.value_bits() {
-            Self::new_zero_with_len(self.len())
-        } else {
-            self >> (rhs as usize)
+        match P::TAG {
+            PersonalityTag::Ct => self >> (rhs as usize),
+            PersonalityTag::Nct => {
+                if rhs >= self.value_bits() {
+                    Self::new_zero_with_len(self.len())
+                } else {
+                    self >> (rhs as usize)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Extends the constant-time asm-grep gate from `FixedUInt` to `HeaplessBigInt`, **fixes a real Ct shift leak** in the process, and closes the FixedUInt `Ord::cmp` gap. **378 fixtures, 0 violations on all 8 targets** (thumbv6m/7m/7em, riscv32imc/imac, aarch64, x86_64, avr-none); negative controls still trip.

## The library fix — heapless Ct shifts

`Shl`/`Shr<usize>`, `<u32>`, and `UnboundedShl`/`Shr` had **no `P::TAG` dispatch**, so `ct_value << secret` ran the branchful word/bit-shift and leaked the amount (FixedUInt routes its Ct arm through `const_shl_ct`). Fixed:

- Added heapless `const_shl_ct` / `const_shr_ct` — branchless barrel shifters (twins of FixedUInt's): each stage shifts by the public `2^k` via new width-preserving `shl_wp`/`shr_wp` and applies-or-not with a per-limb `black_box`-masked XOR select. Following FixedUInt (option B), the mask is `bit * T::MAX`, **not** subtle's `ConditionallySelectable` — so no bound cascade onto the P-generic operators. Also adds `ct_shr` (there was only `ct_shl`).
- All shift operators + unbounded now `match P::TAG`: Nct keeps the direct shift; Ct routes through the barrels. Ct `Shr` is width-preserving (a data-dependent `len` shrink would itself leak).

## The fixtures + allowlist

`fixtures_heapless.rs` covers the heapless `Ct` surface (saturating/abs_diff/bit-scan/is_zero, the subtle comparisons + conditional_select, the always-CT bitwise/wrapping/carry chains, `cmp`, the masked-return `Ct*` traits) **and now the shifts** (shl/shr/unbounded, is/next_power_of_two, midpoint). Built via a `heapless` cargo feature that `ct-driver` enables.

The heapless helpers pass because their per-limb loops bound on `len`/`max(len)`/`CAP` — all **public** — and each is **attested public-bounded** in `ct-driver/src/target.rs::HELPER_ALLOWLIST`, narrowly per-module, after reading each body. The dedicated shift barrels (`const_shl_ct`/`const_shr_ct`/`shl_wp`/`shr_wp`) are allowlisted like FixedUInt's; thumbv6m's `next_power_of_two` inherits the existing armv6m software-CLZ row. (An initial draft wrongly claimed this needed a `krabi-caliper` change — the allowlist is client-owned in-repo.)

FixedUInt `Ord::cmp` fixture added too (`const_cmp_ct` is now allowlisted — a stale `11` vs `12` mangled-length had been silently dropping it).

## is_one

Heapless `One::is_one` is now fixtured and gated too. Its Ct fold was already value-independent; the fixture-level violation was that it inlined into the fixture with its `len`-loop (which the strict fixture scan cannot allowlist), where `is_zero` is emitted out-of-line and is allowlisted. Fixed by extracting the fold to an `#[inline(never)]` `const_is_one_ct` helper (mirrors FixedUInt's, minus const-N unrolling) and attesting that symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `heapless` feature for constant-time fixture generation, and enabled it in the verification driver.
  * Expanded constant-time fixture coverage for heapless big-integer operations (shifts, arithmetic, comparisons/equality, conditional selection, and bit utilities).

* **Bug Fixes**
  * Improved constant-time shift and carry behavior to avoid data-dependent control flow.
  * Fixed constant-time equality (`FixedUInt` Ct) and “is one” handling for canonical/edge cases.

* **Tests**
  * Added/expanded constant-time correctness tests for equality, “is one,” and shift matching between Ct and non-Ct personalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->