### PR TITLE
Gate the shift-assign operators and heapless Shl/Shr<u32>

### DIFF
--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -136,6 +136,39 @@ emit_shr_usize!(ct_fix__A__shr_usize__u32__N4, u32, 4);
 emit_shr_usize!(ct_fix__A__shr_usize__u32__N16, u32, 16);
 emit_shr_usize!(ct_fix__A__shr_usize__u64__N4, u64, 4);
 
+// `<<=` / `>>=` — the assign forms have their own P::TAG dispatch (distinct
+// impls from the by-value operators), routing the Ct arm through the same
+// const_shl_ct/const_shr_ct barrels.
+macro_rules! emit_shl_assign {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, usize, |a, n| {
+            let mut x = FixedUInt::<$T, $N, Ct>::from(a);
+            x <<= n;
+            *x.words()
+        });
+    };
+}
+emit_shl_assign!(ct_fix__A__shl_assign__u8__N16, u8, 16);
+emit_shl_assign!(ct_fix__A__shl_assign__u16__N16, u16, 16);
+emit_shl_assign!(ct_fix__A__shl_assign__u32__N4, u32, 4);
+emit_shl_assign!(ct_fix__A__shl_assign__u32__N16, u32, 16);
+emit_shl_assign!(ct_fix__A__shl_assign__u64__N4, u64, 4);
+
+macro_rules! emit_shr_assign {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, usize, |a, n| {
+            let mut x = FixedUInt::<$T, $N, Ct>::from(a);
+            x >>= n;
+            *x.words()
+        });
+    };
+}
+emit_shr_assign!(ct_fix__A__shr_assign__u8__N16, u8, 16);
+emit_shr_assign!(ct_fix__A__shr_assign__u16__N16, u16, 16);
+emit_shr_assign!(ct_fix__A__shr_assign__u32__N4, u32, 4);
+emit_shr_assign!(ct_fix__A__shr_assign__u32__N16, u32, 16);
+emit_shr_assign!(ct_fix__A__shr_assign__u64__N4, u64, 4);
+
 // =============================================================================
 // UnboundedShl::unbounded_shl / UnboundedShr::unbounded_shr
 // =============================================================================

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -79,6 +79,68 @@ emit_h_shr_usize!(ct_fix__HA__shr_usize__u32__N4, u32, 4);
 emit_h_shr_usize!(ct_fix__HA__shr_usize__u32__N16, u32, 16);
 emit_h_shr_usize!(ct_fix__HA__shr_usize__u64__N4, u64, 4);
 
+// `<<=` / `>>=` — distinct assign impls with their own P::TAG dispatch,
+// routing the Ct arm through the same barrels as `<<`/`>>`.
+macro_rules! emit_h_shl_assign {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, usize, |a, n| {
+            let mut x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            x <<= n;
+            *x.all_limbs()
+        });
+    };
+}
+emit_h_shl_assign!(ct_fix__HA__shl_assign__u8__N16, u8, 16);
+emit_h_shl_assign!(ct_fix__HA__shl_assign__u16__N16, u16, 16);
+emit_h_shl_assign!(ct_fix__HA__shl_assign__u32__N4, u32, 4);
+emit_h_shl_assign!(ct_fix__HA__shl_assign__u32__N16, u32, 16);
+emit_h_shl_assign!(ct_fix__HA__shl_assign__u64__N4, u64, 4);
+
+macro_rules! emit_h_shr_assign {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, usize, |a, n| {
+            let mut x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            x >>= n;
+            *x.all_limbs()
+        });
+    };
+}
+emit_h_shr_assign!(ct_fix__HA__shr_assign__u8__N16, u8, 16);
+emit_h_shr_assign!(ct_fix__HA__shr_assign__u16__N16, u16, 16);
+emit_h_shr_assign!(ct_fix__HA__shr_assign__u32__N4, u32, 4);
+emit_h_shr_assign!(ct_fix__HA__shr_assign__u32__N16, u32, 16);
+emit_h_shr_assign!(ct_fix__HA__shr_assign__u64__N4, u64, 4);
+
+// `Shl<u32>` / `Shr<u32>` — the u32 operator forms delegate to the usize
+// impls; fixtured here since the FixedUInt side only covers `<< u32` (asym).
+macro_rules! emit_h_shl_u32 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, u32, |a, n| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            *(x << n).all_limbs()
+        });
+    };
+}
+emit_h_shl_u32!(ct_fix__HA__shl_u32__u8__N16, u8, 16);
+emit_h_shl_u32!(ct_fix__HA__shl_u32__u16__N16, u16, 16);
+emit_h_shl_u32!(ct_fix__HA__shl_u32__u32__N4, u32, 4);
+emit_h_shl_u32!(ct_fix__HA__shl_u32__u32__N16, u32, 16);
+emit_h_shl_u32!(ct_fix__HA__shl_u32__u64__N4, u64, 4);
+
+macro_rules! emit_h_shr_u32 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_shift!($name, $T, $N, u32, |a, n| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            *(x >> n).all_limbs()
+        });
+    };
+}
+emit_h_shr_u32!(ct_fix__HA__shr_u32__u8__N16, u8, 16);
+emit_h_shr_u32!(ct_fix__HA__shr_u32__u16__N16, u16, 16);
+emit_h_shr_u32!(ct_fix__HA__shr_u32__u32__N4, u32, 4);
+emit_h_shr_u32!(ct_fix__HA__shr_u32__u32__N16, u32, 16);
+emit_h_shr_u32!(ct_fix__HA__shr_u32__u64__N4, u64, 4);
+
 macro_rules! emit_h_unbounded_shl {
     ($name:ident, $T:ty, $N:literal) => {
         ct_fix_shift!($name, $T, $N, u32, |a, n| {

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -111,35 +111,11 @@ emit_h_shr_assign!(ct_fix__HA__shr_assign__u32__N4, u32, 4);
 emit_h_shr_assign!(ct_fix__HA__shr_assign__u32__N16, u32, 16);
 emit_h_shr_assign!(ct_fix__HA__shr_assign__u64__N4, u64, 4);
 
-// `Shl<u32>` / `Shr<u32>` — the u32 operator forms delegate to the usize
-// impls; fixtured here since the FixedUInt side only covers `<< u32` (asym).
-macro_rules! emit_h_shl_u32 {
-    ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, u32, |a, n| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            *(x << n).all_limbs()
-        });
-    };
-}
-emit_h_shl_u32!(ct_fix__HA__shl_u32__u8__N16, u8, 16);
-emit_h_shl_u32!(ct_fix__HA__shl_u32__u16__N16, u16, 16);
-emit_h_shl_u32!(ct_fix__HA__shl_u32__u32__N4, u32, 4);
-emit_h_shl_u32!(ct_fix__HA__shl_u32__u32__N16, u32, 16);
-emit_h_shl_u32!(ct_fix__HA__shl_u32__u64__N4, u64, 4);
-
-macro_rules! emit_h_shr_u32 {
-    ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, u32, |a, n| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            *(x >> n).all_limbs()
-        });
-    };
-}
-emit_h_shr_u32!(ct_fix__HA__shr_u32__u8__N16, u8, 16);
-emit_h_shr_u32!(ct_fix__HA__shr_u32__u16__N16, u16, 16);
-emit_h_shr_u32!(ct_fix__HA__shr_u32__u32__N4, u32, 4);
-emit_h_shr_u32!(ct_fix__HA__shr_u32__u32__N16, u32, 16);
-emit_h_shr_u32!(ct_fix__HA__shr_u32__u64__N4, u64, 4);
+// `Shl<u32>` / `Shr<u32>` are intentionally NOT fixtured: they delegate to the
+// `usize` impls and compile to code identical to `shl_usize` / `unbounded_shl`
+// (all route through the `const_shl_ct` barrel), so identical-code-folding
+// aliases their symbols onto those already-gated blocks — separate fixtures
+// would add names but no distinct scanned coverage.
 
 macro_rules! emit_h_unbounded_shl {
     ($name:ident, $T:ty, $N:literal) => {


### PR DESCRIPTION
## What

Follow-up to #180. `<<=` / `>>=` are **distinct impls** from the by-value `<<` / `>>` operators — each carries its own `match P::TAG` dispatch — so gating the operators in #180 left the assign forms unverified. Adds fixtures for them (both carriers).

## Why it's a clean slice

The assign forms' Ct arms route through the **same** `const_shl_ct` / `const_shr_ct` barrels #180 already allowlisted, so this needs **no library change and no new allowlist entry** — pure fixture additions through the existing `ct_fix_shift` macro (which also carries the ctgrind taint registration, so these land in both the asm-grep and taint checks).

20 fixtures across the standard 5 `(T, CAP)` diagonals:
- FixedUInt `shl_assign` / `shr_assign`
- Heapless `shl_assign` / `shr_assign`
- (heapless `Shl<u32>`/`Shr<u32>` were dropped after review: they compile identically to `shl_usize`/`unbounded_shl` and fold away, adding no distinct coverage)

419 fixtures, 0 violations across all 8 targets; negative controls still trip.

## Remaining backlog (not this PR)

The other post-#180 distinct-Ct-arm gaps stay for follow-ups: `wrapping_next_power_of_two`, `NonZero::conditional_select`, and the carry-tail fixtures (`borrowing_sub` / `carrying_mul`) — the last of which needs a `ctgrind_*` macro added to krabi-caliper first, since only `carrying_add` has one today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add constant-time verification fixtures for shift-assign and u32-based shift operators on FixedUInt and Heapless big integers.

New Features:
- Introduce fixtures for HeaplessBigInt shift-assign operators (`<<=` and `>>=`) across multiple limb sizes and integer types.
- Add fixtures for FixedUInt shift-assign operators to ensure their constant-time behavior is covered.
- Add fixtures for HeaplessBigInt `Shl<u32>` and `Shr<u32>` operator forms to exercise the u32-based shift paths.

Tests:
- Expand the ct-verify fixture set with additional shift operator cases for both FixedUInt and Heapless categories, covering multiple diagonals and operand types.