### PR TITLE
Move ctgrind ABI adapters into ct-fixtures

### DIFF
--- a/ct-verify/ct-fixtures/src/ctgrind_shapes.rs
+++ b/ct-verify/ct-fixtures/src/ctgrind_shapes.rs
@@ -1,0 +1,315 @@
+//! Fixed-bigint's ctgrind ABI adapters — one macro per fixture calling shape.
+//!
+//! The ABI these describe is ct-fixtures' own (`ct_fix_*`), so the adapters
+//! live here rather than in the shared harness. Each expands to
+//! `krabi_caliper::ctgrind_fixture!`, which owns the fixture registration; the
+//! adapter only supplies the run body: declare the fixture's `extern "C"`
+//! signature, taint the secret inputs, call it, untaint the outputs. Nothing
+//! here reaches past caliper's public surface (`ctgrind_fixture!` +
+//! `taint`/`taint_val`/`untaint`/`untaint_val`).
+//!
+//! The `extern "C"` decl sits inside the run body so it is scoped to that
+//! function, not colliding with the same-named `#[no_mangle]` fixture defined
+//! alongside it — the isolation `ctgrind_local!` provides for a top-level decl.
+//!
+//! Adding a new shape (e.g. a widening `carrying_mul` with two outputs) means
+//! adding one macro here; the harness never changes.
+//!
+//! `black_box(0)` on the scalar secrets is required: without it release-LTO
+//! constant-propagates the literal past `taint_val` (which sets Valgrind
+//! metadata, not memory) and the taint never reaches the primitive.
+
+/// Binary: `(T,N) × (T,N) → (T,N)`.
+#[macro_export]
+macro_rules! fbx_ctgrind_bin {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N], b: *const [$T; $N], out: *mut [$T; $N]);
+            }
+            let a: [$T; $N] = [0; $N];
+            let b: [$T; $N] = [0; $N];
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            krabi_caliper::host::ctgrind::taint(&b);
+            unsafe {
+                $name(&a, &b, &mut out);
+            }
+            krabi_caliper::host::ctgrind::untaint(&out);
+            let _ = ::core::hint::black_box(out);
+        });
+    };
+}
+
+/// Unary: `(T,N) → (T,N)`.
+#[macro_export]
+macro_rules! fbx_ctgrind_un {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N], out: *mut [$T; $N]);
+            }
+            let a: [$T; $N] = [0; $N];
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            unsafe {
+                $name(&a, &mut out);
+            }
+            krabi_caliper::host::ctgrind::untaint(&out);
+            let _ = ::core::hint::black_box(out);
+        });
+    };
+}
+
+/// Predicate: `(T,N) → u8`.
+#[macro_export]
+macro_rules! fbx_ctgrind_pred {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N]) -> u8;
+            }
+            let a: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            let r = unsafe { $name(&a) };
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}
+
+/// Binary predicate: `(T,N) × (T,N) → u8`.
+#[macro_export]
+macro_rules! fbx_ctgrind_pred2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N], b: *const [$T; $N]) -> u8;
+            }
+            let a: [$T; $N] = [0; $N];
+            let b: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            krabi_caliper::host::ctgrind::taint(&b);
+            let r = unsafe { $name(&a, &b) };
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}
+
+/// Bit-count: `(T,N) → u32`.
+#[macro_export]
+macro_rules! fbx_ctgrind_count {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N]) -> u32;
+            }
+            let a: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            let r = unsafe { $name(&a) };
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}
+
+/// Shift: `(T,N) × scalar → (T,N)`.
+#[macro_export]
+macro_rules! fbx_ctgrind_shift {
+    ($name:ident, $T:ty, $N:literal, $NT:ty) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N], n: $NT, out: *mut [$T; $N]);
+            }
+            let a: [$T; $N] = [0; $N];
+            let n: $NT = ::core::hint::black_box(0);
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            krabi_caliper::host::ctgrind::taint_val(&n);
+            unsafe {
+                $name(&a, n, &mut out);
+            }
+            krabi_caliper::host::ctgrind::untaint(&out);
+            let _ = ::core::hint::black_box(out);
+        });
+    };
+}
+
+/// Checked binary: `(T,N) × (T,N) → (T,N) + u8`.
+#[macro_export]
+macro_rules! fbx_ctgrind_checked_bin {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N], b: *const [$T; $N], out: *mut [$T; $N]) -> u8;
+            }
+            let a: [$T; $N] = [0; $N];
+            let b: [$T; $N] = [0; $N];
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            krabi_caliper::host::ctgrind::taint(&b);
+            let r = unsafe { $name(&a, &b, &mut out) };
+            krabi_caliper::host::ctgrind::untaint(&out);
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(out);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}
+
+/// Checked unary with scalar: `(T,N) × scalar → (T,N) + u8`.
+#[macro_export]
+macro_rules! fbx_ctgrind_checked_scalar {
+    ($name:ident, $T:ty, $N:literal, $ST:ty) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N], s: $ST, out: *mut [$T; $N]) -> u8;
+            }
+            let a: [$T; $N] = [0; $N];
+            let s: $ST = ::core::hint::black_box(0);
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            krabi_caliper::host::ctgrind::taint_val(&s);
+            let r = unsafe { $name(&a, s, &mut out) };
+            krabi_caliper::host::ctgrind::untaint(&out);
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(out);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}
+
+/// Checked unary: `(T,N) → (T,N) + u8`.
+#[macro_export]
+macro_rules! fbx_ctgrind_checked_un {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N], out: *mut [$T; $N]) -> u8;
+            }
+            let a: [$T; $N] = [0; $N];
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            let r = unsafe { $name(&a, &mut out) };
+            krabi_caliper::host::ctgrind::untaint(&out);
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(out);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}
+
+/// Conditional select: `(T,N) × (T,N) × u8 → (T,N)`.
+#[macro_export]
+macro_rules! fbx_ctgrind_cond_select {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(a: *const [$T; $N], b: *const [$T; $N], choice: u8, out: *mut [$T; $N]);
+            }
+            let a: [$T; $N] = [0; $N];
+            let b: [$T; $N] = [0; $N];
+            let choice: u8 = ::core::hint::black_box(0);
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            krabi_caliper::host::ctgrind::taint(&b);
+            krabi_caliper::host::ctgrind::taint_val(&choice);
+            unsafe {
+                $name(&a, &b, choice, &mut out);
+            }
+            krabi_caliper::host::ctgrind::untaint(&out);
+            let _ = ::core::hint::black_box(out);
+        });
+    };
+}
+
+/// Carrying add: `(T,N) × (T,N) × bool → (T,N) + u8`.
+#[macro_export]
+macro_rules! fbx_ctgrind_carrying_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(
+                    a: *const [$T; $N],
+                    b: *const [$T; $N],
+                    carry: bool,
+                    out: *mut [$T; $N],
+                ) -> u8;
+            }
+            let a: [$T; $N] = [0; $N];
+            let b: [$T; $N] = [0; $N];
+            let carry: bool = ::core::hint::black_box(false);
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            krabi_caliper::host::ctgrind::taint(&b);
+            krabi_caliper::host::ctgrind::taint_val(&carry);
+            let r = unsafe { $name(&a, &b, carry, &mut out) };
+            krabi_caliper::host::ctgrind::untaint(&out);
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(out);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}
+
+/// Pointer-based secret shift amount → array. `(*const u32) → (T,N)`.
+#[macro_export]
+macro_rules! fbx_ctgrind_asym_shl_u32 {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(amount: *const u32, out: *mut [$T; $N]);
+            }
+            let amount: u32 = ::core::hint::black_box(0);
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint_val(&amount);
+            unsafe {
+                $name(&amount, &mut out);
+            }
+            krabi_caliper::host::ctgrind::untaint(&out);
+            let _ = ::core::hint::black_box(out);
+        });
+    };
+}
+
+/// Pointer-based secret choice → array. `(*const u8) → (T,N)`.
+#[macro_export]
+macro_rules! fbx_ctgrind_asym_select_u8 {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(choice: *const u8, out: *mut [$T; $N]);
+            }
+            let choice: u8 = ::core::hint::black_box(0);
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint_val(&choice);
+            unsafe {
+                $name(&choice, &mut out);
+            }
+            krabi_caliper::host::ctgrind::untaint(&out);
+            let _ = ::core::hint::black_box(out);
+        });
+    };
+}
+
+/// Pointer-based secret exponent → array + validity byte.
+/// `(*const u32) → (T,N) + u8`.
+#[macro_export]
+macro_rules! fbx_ctgrind_asym_pow_u32 {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(exp: *const u32, out: *mut [$T; $N]) -> u8;
+            }
+            let exp: u32 = ::core::hint::black_box(0);
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint_val(&exp);
+            let r = unsafe { $name(&exp, &mut out) };
+            krabi_caliper::host::ctgrind::untaint(&out);
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(out);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}

--- a/ct-verify/ct-fixtures/src/fixtures_asym.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_asym.rs
@@ -65,7 +65,7 @@ macro_rules! emit_asym_one_shl {
             }
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_asym_shl_u32!($name, $T, $N););
+        fbx_ctgrind_asym_shl_u32!($name, $T, $N);
     };
 }
 
@@ -107,7 +107,7 @@ macro_rules! emit_asym_subtle_cond_select {
             }
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_asym_select_u8!($name, $T, $N););
+        fbx_ctgrind_asym_select_u8!($name, $T, $N);
     };
 }
 
@@ -145,7 +145,7 @@ macro_rules! emit_asym_pow_const_base {
             valid
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_asym_pow_u32!($name, $T, $N););
+        fbx_ctgrind_asym_pow_u32!($name, $T, $N);
     };
 }
 

--- a/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
@@ -89,7 +89,7 @@ macro_rules! emit_cond_select {
             }
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_cond_select!($name, $T, $N););
+        fbx_ctgrind_cond_select!($name, $T, $N);
     };
 }
 emit_cond_select!(ct_fix__B__cond_select__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
@@ -143,7 +143,7 @@ macro_rules! emit_carrying_add {
             core::hint::black_box(co as u8)
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_carrying_add!($name, $T, $N););
+        fbx_ctgrind_carrying_add!($name, $T, $N);
     };
 }
 emit_carrying_add!(ct_fix__C__carrying_add__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -361,18 +361,19 @@ macro_rules! emit_h_cond_select {
             let c = core::hint::black_box(choice);
             let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a_arr, $N as u16);
             let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b_arr, $N as u16);
-            let r = <HeaplessBigInt<$T, $N, Ct> as subtle::ConditionallySelectable>::conditional_select(
-                &x,
-                &y,
-                subtle::Choice::from(c),
-            );
+            let r =
+                <HeaplessBigInt<$T, $N, Ct> as subtle::ConditionallySelectable>::conditional_select(
+                    &x,
+                    &y,
+                    subtle::Choice::from(c),
+                );
             let result = core::hint::black_box(*r.all_limbs());
             unsafe {
                 *out_ptr = result;
             }
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_cond_select!($name, $T, $N););
+        fbx_ctgrind_cond_select!($name, $T, $N);
     };
 }
 emit_h_cond_select!(ct_fix__HB__cond_select__u8__N16, u8, 16);
@@ -507,7 +508,7 @@ macro_rules! emit_h_carrying_add {
             core::hint::black_box(co as u8)
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_carrying_add!($name, $T, $N););
+        fbx_ctgrind_carrying_add!($name, $T, $N);
     };
 }
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_neg.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_neg.rs
@@ -70,10 +70,7 @@ pub extern "C" fn nct_fix__neg__nct_ilog10__u32__N4(a_ptr: *const [u32; 4]) -> u
 }
 
 #[cfg(feature = "ctgrind")]
-krabi_caliper::ctgrind_local!(
-    nct_fix__neg__nct_ilog10__u32__N4,
-    krabi_caliper::ctgrind_count!(nct_fix__neg__nct_ilog10__u32__N4, u32, 4);
-);
+crate::fbx_ctgrind_count!(nct_fix__neg__nct_ilog10__u32__N4, u32, 4);
 
 // =============================================================================
 // nct_gcd: Stein's algorithm. Subtraction + comparison loop.

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -23,6 +23,12 @@
 #![allow(non_snake_case)]
 #![cfg_attr(not(test), allow(unused_imports))]
 
+// ct-fixtures owns its own fixture ABI, so the per-shape ctgrind adapters
+// (built on caliper's generic `ctgrind_fixture!`) live here, not in the harness.
+#[cfg(feature = "ctgrind")]
+#[macro_use]
+mod ctgrind_shapes;
+
 mod fixtures_asym;
 mod fixtures_cat_a;
 mod fixtures_cat_b;
@@ -75,7 +81,7 @@ macro_rules! ct_fix_bin {
             }
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_bin!($name, $T, $N););
+        fbx_ctgrind_bin!($name, $T, $N);
     };
 }
 
@@ -97,7 +103,7 @@ macro_rules! ct_fix_un {
             }
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_un!($name, $T, $N););
+        fbx_ctgrind_un!($name, $T, $N);
     };
 }
 
@@ -116,7 +122,7 @@ macro_rules! ct_fix_pred {
             core::hint::black_box(result)
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_pred!($name, $T, $N););
+        fbx_ctgrind_pred!($name, $T, $N);
     };
 }
 
@@ -132,7 +138,7 @@ macro_rules! ct_fix_pred2 {
             core::hint::black_box(result)
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_pred2!($name, $T, $N););
+        fbx_ctgrind_pred2!($name, $T, $N);
     };
 }
 
@@ -150,7 +156,7 @@ macro_rules! ct_fix_count {
             core::hint::black_box(result)
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_count!($name, $T, $N););
+        fbx_ctgrind_count!($name, $T, $N);
     };
 }
 
@@ -173,7 +179,7 @@ macro_rules! ct_fix_shift {
             }
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_shift!($name, $T, $N, $NT););
+        fbx_ctgrind_shift!($name, $T, $N, $NT);
     };
 }
 
@@ -202,7 +208,7 @@ macro_rules! ct_fix_checked_bin {
             valid
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_checked_bin!($name, $T, $N););
+        fbx_ctgrind_checked_bin!($name, $T, $N);
     };
 }
 
@@ -226,7 +232,7 @@ macro_rules! ct_fix_checked_scalar {
             valid
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_checked_scalar!($name, $T, $N, $ST););
+        fbx_ctgrind_checked_scalar!($name, $T, $N, $ST);
     };
 }
 
@@ -248,6 +254,6 @@ macro_rules! ct_fix_checked_un {
             valid
         }
         #[cfg(feature = "ctgrind")]
-        krabi_caliper::ctgrind_local!($name, krabi_caliper::ctgrind_checked_un!($name, $T, $N););
+        fbx_ctgrind_checked_un!($name, $T, $N);
     };
 }


### PR DESCRIPTION
## What

Relocates the 14 `ctgrind_*` shape macros from krabi-caliper into a local `ct-fixtures` module (`ctgrind_shapes.rs`), so ct-fixtures owns the description of its own fixture ABI.

## Why

Those macros (`bin`/`un`/`pred`/`pred2`/`count`/`shift`/`checked_bin`/`checked_scalar`/`checked_un`/`cond_select`/`carrying_add`/`asym_shl_u32`/`asym_select_u8`/`asym_pow_u32`) are named after representative methods but contain **zero method logic** — each is just an `extern "C"` signature plus taint/untaint of its arguments, i.e. a calling-convention template. That's ct-fixtures' ABI, not a shared concern. Keeping it in the harness meant a new fixture shape (e.g. a widening `carrying_mul` with two array outputs, needed for the CT-coverage backlog) couldn't be added without a harness release.

## How

Each adapter is reimplemented as `fbx_ctgrind_*`, expanding to caliper's generic `ctgrind_fixture!` plus the public `taint`/`taint_val`/`untaint`/`untaint_val` calls — nothing reaches past that public surface (no `__ctgrind_private`, no direct `CtgrindFixture`). The `extern "C"` decl now lives **inside** the generated run body, so it's function-scoped and no longer collides with the same-named `#[no_mangle]` fixture — which is what `ctgrind_local!`'s module wrapper existed to prevent, so that wrapper drops away for these sites.

After this, ct-fixtures consumes only caliper's generic facilities: `ctgrind_fixture!`, `ctgrind_standard_controls!`, and the four taint fns. A new ABI shape becomes a one-macro local change.

## Validation

- `ct-ctgrind` compiles with `heapless` + `ctgrind`; **454 fixtures register** into the taint runner (every category: A/B/C/CT/ASYM/HA/HB/HC/HCT), unchanged from before.
- asm-grep gate green on all 8 targets (this PR doesn't touch the fixtures the gate scans, only their ctgrind registration).
- The taint/untaint/`black_box` logic in each adapter is a line-for-line port of the caliper macro it replaces; the Valgrind behavior is exercised by the ctgrind CI job.

Independent of #181 (shift-assign coverage). The caliper-side deletion of the now-unused shape macros is a separate 0.2 change and needs no coordination — ct-fixtures already stops consuming them here, against caliper 0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Move ct-fixtures’ ctgrind ABI adapters into a local module and switch all fixtures to use the new macros for ctgrind registration.

Enhancements:
- Introduce a dedicated ctgrind_shapes module that defines ct-fixtures’ ctgrind ABI adapter macros per fixture shape.
- Replace harness-level krabi_caliper ctgrind_* and ctgrind_local! usages with local fbx_ctgrind_* macros across all fixture categories to localize ABI ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CTGrind instrumentation across arithmetic, comparison, shifting, selection, carrying-add, checked-operation, and asymmetric fixtures.
  * Standardized taint tracking and output validation for broader fixture shapes.
  * Preserved existing fixture behavior and external interfaces while improving analysis coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->