### PR TITLE
Gate the remaining distinct-Ct-arm ops on both carriers

### DIFF
--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -181,6 +181,14 @@ const HELPER_ALLOWLIST: &[&str] = &[
     r"fixed_bigint9fixeduint9const_mul",
     r"fixed_bigint9fixeduint8add_impl",
     r"fixed_bigint9fixeduint8sub_impl",
+    // Widening carrying multiply: schoolbook full product + the CarryingMul
+    // impl tail. Nested `i,j < N` loops over const N; `get_at`/`set_at` branch
+    // on `pos = i+j < N` / `< 2N` (public counters), inlined here. The Ct
+    // monomorph carries only the full-sweep carry tail (`while p < 2*N`) — the
+    // Nct early-exit (`while carry && …`) folds away — so no secret-dependent
+    // bound survives. Reached by the `carrying_mul` fixtures.
+    r"fixed_bigint9fixeduint23extended_precision_impl14schoolbook_mul",
+    r"fixed_bigint9fixeduint23extended_precision_impl126.*carrying_mul",
     // ct_checked_pow's square-and-multiply ladder iterates u32::BITS
     // times.
     r"fixed_bigint9fixeduint.*ct_checked_pow",
@@ -365,10 +373,14 @@ const THUMBV6M_EXTRA_HELPERS: &[&str] = &[
     // `leading_zeros` above and inherit its branches on armv6m.
     r"fixed_bigint9fixeduint17power_of_two_impl.*next_power_of_two",
     r"fixed_bigint9fixeduint.*FixedUInt.*ct_checked_next_power_of_two",
-    // HeaplessBigInt's `NextPowerOfTwo::next_power_of_two` inlines the same
-    // primitive `leading_zeros` (via `ct_next_pow2`), inheriting the armv6m
-    // software-CLZ branches — same root cause as the FixedUInt row above.
+    // HeaplessBigInt's `NextPowerOfTwo::{next,wrapping_next}_power_of_two`
+    // share the branchless `ct_next_pow2` helper, whose `leading_zeros`
+    // lowers to armv6m software CLZ — same root cause as the FixedUInt row
+    // above. With both callers present LLVM outlines `ct_next_pow2` into its
+    // own symbol (with one caller it inlined into the trait method), so both
+    // the trait-method and the free-helper symbol are attested here.
     r"fixed_bigint8heapless12power_of_two.*NextPowerOfTwo",
+    r"fixed_bigint8heapless12power_of_two12ct_next_pow2",
     // compiler_builtins' software division — pulled in transitively
     // by the armv6m `leading_zeros` polynomial. Branchful on size.
     r"compiler_builtins3int.*specialized_div_rem",

--- a/ct-verify/ct-fixtures/src/ctgrind_shapes.rs
+++ b/ct-verify/ct-fixtures/src/ctgrind_shapes.rs
@@ -224,6 +224,41 @@ macro_rules! fbx_ctgrind_cond_select {
     };
 }
 
+/// Widening carrying mul: `(T,N) × (T,N) × (T,N) → (T,N) lo + (T,N) hi`.
+/// A two-array-output shape unique to ct-fixtures — the kind that used to
+/// require a harness release before the adapters moved local.
+#[macro_export]
+macro_rules! fbx_ctgrind_carrying_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(
+                    a: *const [$T; $N],
+                    b: *const [$T; $N],
+                    carry: *const [$T; $N],
+                    lo: *mut [$T; $N],
+                    hi: *mut [$T; $N],
+                );
+            }
+            let a: [$T; $N] = [0; $N];
+            let b: [$T; $N] = [0; $N];
+            let carry: [$T; $N] = [0; $N];
+            let mut lo: [$T; $N] = [0; $N];
+            let mut hi: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&a);
+            krabi_caliper::host::ctgrind::taint(&b);
+            krabi_caliper::host::ctgrind::taint(&carry);
+            unsafe {
+                $name(&a, &b, &carry, &mut lo, &mut hi);
+            }
+            krabi_caliper::host::ctgrind::untaint(&lo);
+            krabi_caliper::host::ctgrind::untaint(&hi);
+            let _ = ::core::hint::black_box(lo);
+            let _ = ::core::hint::black_box(hi);
+        });
+    };
+}
+
 /// Carrying add: `(T,N) × (T,N) × bool → (T,N) + u8`.
 #[macro_export]
 macro_rules! fbx_ctgrind_carrying_add {

--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -260,6 +260,23 @@ emit_next_pow2!(ct_fix__A__next_pow2__u32__N4, u32, 4);
 emit_next_pow2!(ct_fix__A__next_pow2__u32__N16, u32, 16);
 emit_next_pow2!(ct_fix__A__next_pow2__u64__N4, u64, 4);
 
+// NextPowerOfTwo::wrapping_next_power_of_two — distinct Ct arm from
+// next_power_of_two: same branchless body but selects ZERO on overflow
+// (not MAX) via its own const_ct_select chain.
+macro_rules! emit_wrapping_next_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            *NextPowerOfTwo::wrapping_next_power_of_two(x).words()
+        });
+    };
+}
+emit_wrapping_next_pow2!(ct_fix__A__wrapping_next_pow2__u8__N16, u8, 16);
+emit_wrapping_next_pow2!(ct_fix__A__wrapping_next_pow2__u16__N16, u16, 16);
+emit_wrapping_next_pow2!(ct_fix__A__wrapping_next_pow2__u32__N4, u32, 4);
+emit_wrapping_next_pow2!(ct_fix__A__wrapping_next_pow2__u32__N16, u32, 16);
+emit_wrapping_next_pow2!(ct_fix__A__wrapping_next_pow2__u64__N4, u64, 4);
+
 // =============================================================================
 // PrimBits::leading_zeros / trailing_zeros
 // =============================================================================

--- a/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
@@ -3,8 +3,8 @@
 //! Includes the inherent `ct_checked_*` methods, the four `subtle::*`
 //! trait impls, and `forget_ct` (the Ct → Nct explicit downgrade).
 
-use const_num_traits::{Ct, Nct};
-use fixed_bigint::FixedUInt;
+use const_num_traits::{Ct, CtNonZero, Nct};
+use fixed_bigint::{FixedUInt, NonZeroFixedUInt};
 use subtle::{ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 use crate::{
@@ -97,6 +97,51 @@ emit_cond_select!(ct_fix__B__cond_select__u16__N16, u16, 16);
 emit_cond_select!(ct_fix__B__cond_select__u32__N4, u32, 4);
 emit_cond_select!(ct_fix__B__cond_select__u32__N16, u32, 16);
 emit_cond_select!(ct_fix__B__cond_select__u64__N4, u64, 4);
+
+// NonZero conditional_select — `Ct`-only `ConditionallySelectable` on the
+// NonZero newtype, distinct from the plain-type select above (it delegates to
+// the inner carrier's gated select). Inputs are forced non-zero (OR 1 into the
+// low limb, constant-time) so `into_nonzero_ct` always yields `Some`; the
+// wrapper is extracted branchlessly via `unwrap_or`.
+macro_rules! emit_nz_cond_select {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            choice: u8,
+            out_ptr: *mut [$T; $N],
+        ) {
+            let mut a_arr = core::hint::black_box(unsafe { *a_ptr });
+            let mut b_arr = core::hint::black_box(unsafe { *b_ptr });
+            a_arr[0] |= 1;
+            b_arr[0] |= 1;
+            let c = core::hint::black_box(choice);
+            let na = FixedUInt::<$T, $N, Ct>::from(a_arr)
+                .into_nonzero_ct()
+                .unwrap_or(NonZeroFixedUInt::<$T, $N, Ct>::default());
+            let nb = FixedUInt::<$T, $N, Ct>::from(b_arr)
+                .into_nonzero_ct()
+                .unwrap_or(NonZeroFixedUInt::<$T, $N, Ct>::default());
+            let r = NonZeroFixedUInt::<$T, $N, Ct>::conditional_select(
+                &na,
+                &nb,
+                subtle::Choice::from(c),
+            );
+            let result = core::hint::black_box(*r.get().words());
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_cond_select!($name, $T, $N);
+    };
+}
+emit_nz_cond_select!(ct_fix__B__nz_cond_select__u8__N16, u8, 16);
+emit_nz_cond_select!(ct_fix__B__nz_cond_select__u16__N16, u16, 16);
+emit_nz_cond_select!(ct_fix__B__nz_cond_select__u32__N4, u32, 4);
+emit_nz_cond_select!(ct_fix__B__nz_cond_select__u32__N16, u32, 16);
+emit_nz_cond_select!(ct_fix__B__nz_cond_select__u64__N4, u64, 4);
 
 // =============================================================================
 // ct_checked_add / sub / mul

--- a/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
@@ -7,7 +7,10 @@
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
 use const_num_traits::Ct;
-use const_num_traits::{CarryingAdd, Midpoint, OverflowingAdd, PrimBits, WrappingMul};
+use const_num_traits::{
+    BorrowingSub, CarryingAdd, CarryingMul, Midpoint, OverflowingAdd, OverflowingMul,
+    OverflowingSub, PrimBits, WrappingAdd, WrappingMul, WrappingSub,
+};
 use fixed_bigint::FixedUInt;
 
 use crate::{ct_fix_bin, ct_fix_count, ct_fix_un};
@@ -150,6 +153,129 @@ emit_carrying_add!(ct_fix__C__carrying_add__u8__N16, u8, 16);
 emit_carrying_add!(ct_fix__C__carrying_add__u32__N4, u32, 4);
 emit_carrying_add!(ct_fix__C__carrying_add__u32__N16, u32, 16);
 emit_carrying_add!(ct_fix__C__carrying_add__u64__N4, u64, 4);
+
+// Borrowing sub — the CT counterpart of `carrying_add`; identical ABI
+// (a, b, borrow) → (out, borrow_out), so it reuses the carrying_add shape.
+macro_rules! emit_borrowing_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            borrow: bool,
+            out_ptr: *mut [$T; $N],
+        ) -> u8 {
+            let a_arr = core::hint::black_box(unsafe { *a_ptr });
+            let b_arr = core::hint::black_box(unsafe { *b_ptr });
+            let bin = core::hint::black_box(borrow);
+            let x = FixedUInt::<$T, $N, Ct>::from(a_arr);
+            let y = FixedUInt::<$T, $N, Ct>::from(b_arr);
+            let (r, bo) = BorrowingSub::borrowing_sub(x, y, bin);
+            let result = core::hint::black_box(*r.words());
+            unsafe {
+                *out_ptr = result;
+            }
+            core::hint::black_box(bo as u8)
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_carrying_add!($name, $T, $N);
+    };
+}
+emit_borrowing_sub!(ct_fix__C__borrowing_sub__u8__N16, u8, 16);
+emit_borrowing_sub!(ct_fix__C__borrowing_sub__u32__N4, u32, 4);
+emit_borrowing_sub!(ct_fix__C__borrowing_sub__u32__N16, u32, 16);
+emit_borrowing_sub!(ct_fix__C__borrowing_sub__u64__N4, u64, 4);
+
+// Regression-watch bins — always-CT by construction (no `P::TAG` split), but
+// pinned so a future change can't silently introduce a branch. Overflowing
+// forms discard the flag; the body's branch-freeness is what's scanned.
+macro_rules! emit_wrapping_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            *WrappingAdd::wrapping_add(&x, &y).words()
+        });
+    };
+}
+emit_wrapping_add!(ct_fix__C__wrapping_add__u8__N16, u8, 16);
+emit_wrapping_add!(ct_fix__C__wrapping_add__u32__N4, u32, 4);
+emit_wrapping_add!(ct_fix__C__wrapping_add__u64__N4, u64, 4);
+
+macro_rules! emit_wrapping_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            *WrappingSub::wrapping_sub(&x, &y).words()
+        });
+    };
+}
+emit_wrapping_sub!(ct_fix__C__wrapping_sub__u8__N16, u8, 16);
+emit_wrapping_sub!(ct_fix__C__wrapping_sub__u32__N4, u32, 4);
+emit_wrapping_sub!(ct_fix__C__wrapping_sub__u64__N4, u64, 4);
+
+macro_rules! emit_overflowing_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let (r, _ov) = OverflowingSub::overflowing_sub(&x, &y);
+            *r.words()
+        });
+    };
+}
+emit_overflowing_sub!(ct_fix__C__overflowing_sub__u8__N16, u8, 16);
+emit_overflowing_sub!(ct_fix__C__overflowing_sub__u32__N4, u32, 4);
+emit_overflowing_sub!(ct_fix__C__overflowing_sub__u64__N4, u64, 4);
+
+macro_rules! emit_overflowing_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let (r, _ov) = OverflowingMul::overflowing_mul(&x, &y);
+            *r.words()
+        });
+    };
+}
+emit_overflowing_mul!(ct_fix__C__overflowing_mul__u8__N16, u8, 16);
+emit_overflowing_mul!(ct_fix__C__overflowing_mul__u32__N4, u32, 4);
+emit_overflowing_mul!(ct_fix__C__overflowing_mul__u64__N4, u64, 4);
+
+// Widening carrying mul — `(a, b, carry) → (lo, hi)`. Pins the full-width
+// carry-propagation tail of the schoolbook multiply *directly*, not just
+// transitively through wrapping/saturating mul. Two array outputs (lo, hi).
+macro_rules! emit_carrying_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            carry_ptr: *const [$T; $N],
+            lo_ptr: *mut [$T; $N],
+            hi_ptr: *mut [$T; $N],
+        ) {
+            let a = core::hint::black_box(unsafe { *a_ptr });
+            let b = core::hint::black_box(unsafe { *b_ptr });
+            let cy = core::hint::black_box(unsafe { *carry_ptr });
+            let x = FixedUInt::<$T, $N, Ct>::from(a);
+            let y = FixedUInt::<$T, $N, Ct>::from(b);
+            let cin = FixedUInt::<$T, $N, Ct>::from(cy);
+            let (lo, hi) = CarryingMul::carrying_mul(x, y, cin);
+            unsafe {
+                *lo_ptr = core::hint::black_box(*lo.words());
+                *hi_ptr = core::hint::black_box(*hi.words());
+            }
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_carrying_mul!($name, $T, $N);
+    };
+}
+emit_carrying_mul!(ct_fix__C__carrying_mul__u8__N16, u8, 16);
+emit_carrying_mul!(ct_fix__C__carrying_mul__u32__N4, u32, 4);
+emit_carrying_mul!(ct_fix__C__carrying_mul__u32__N16, u32, 16);
+emit_carrying_mul!(ct_fix__C__carrying_mul__u64__N4, u64, 4);
 
 // =============================================================================
 // Midpoint

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -33,10 +33,11 @@ use const_num_traits::ops::ct::{
 use const_num_traits::Ct;
 use const_num_traits::CtNonZero;
 use const_num_traits::{
-    AbsDiff, CarryingAdd, IsPowerOfTwo, Midpoint, NextPowerOfTwo, One, OverflowingAdd, PrimBits,
-    SaturatingAdd, SaturatingMul, SaturatingSub, UnboundedShl, UnboundedShr, WrappingMul, Zero,
+    AbsDiff, BorrowingSub, CarryingAdd, CarryingMul, IsPowerOfTwo, Midpoint, NextPowerOfTwo, One,
+    OverflowingAdd, OverflowingMul, OverflowingSub, PrimBits, SaturatingAdd, SaturatingMul,
+    SaturatingSub, UnboundedShl, UnboundedShr, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
-use fixed_bigint::HeaplessBigInt;
+use fixed_bigint::{HeaplessBigInt, NonZeroHeaplessBigInt};
 use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 use crate::{
@@ -173,6 +174,22 @@ emit_h_next_pow2!(ct_fix__HA__next_pow2__u16__N16, u16, 16);
 emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N4, u32, 4);
 emit_h_next_pow2!(ct_fix__HA__next_pow2__u32__N16, u32, 16);
 emit_h_next_pow2!(ct_fix__HA__next_pow2__u64__N4, u64, 4);
+
+// wrapping_next_power_of_two — distinct Ct arm from next_power_of_two
+// (ZERO on overflow, not MAX).
+macro_rules! emit_h_wrapping_next_pow2 {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_un!($name, $T, $N, |a| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            *NextPowerOfTwo::wrapping_next_power_of_two(x).all_limbs()
+        });
+    };
+}
+emit_h_wrapping_next_pow2!(ct_fix__HA__wrapping_next_pow2__u8__N16, u8, 16);
+emit_h_wrapping_next_pow2!(ct_fix__HA__wrapping_next_pow2__u16__N16, u16, 16);
+emit_h_wrapping_next_pow2!(ct_fix__HA__wrapping_next_pow2__u32__N4, u32, 4);
+emit_h_wrapping_next_pow2!(ct_fix__HA__wrapping_next_pow2__u32__N16, u32, 16);
+emit_h_wrapping_next_pow2!(ct_fix__HA__wrapping_next_pow2__u64__N4, u64, 4);
 
 macro_rules! emit_h_midpoint {
     ($name:ident, $T:ty, $N:literal) => {
@@ -420,6 +437,50 @@ emit_h_cond_select!(ct_fix__HB__cond_select__u32__N4, u32, 4);
 emit_h_cond_select!(ct_fix__HB__cond_select__u32__N16, u32, 16);
 emit_h_cond_select!(ct_fix__HB__cond_select__u64__N4, u64, 4);
 
+// NonZero conditional_select — the `Ct`-only `ConditionallySelectable` on the
+// NonZero newtype (delegates to the inner carrier's gated select). Inputs are
+// forced non-zero (OR 1 into the low limb, constant-time) so `into_nonzero_ct`
+// always yields `Some`; the wrapper is extracted branchlessly via `unwrap_or`.
+macro_rules! emit_h_nz_cond_select {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            choice: u8,
+            out_ptr: *mut [$T; $N],
+        ) {
+            let mut a_arr = core::hint::black_box(unsafe { *a_ptr });
+            let mut b_arr = core::hint::black_box(unsafe { *b_ptr });
+            a_arr[0] |= 1;
+            b_arr[0] |= 1;
+            let c = core::hint::black_box(choice);
+            let na = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a_arr, $N as u16)
+                .into_nonzero_ct()
+                .unwrap_or(NonZeroHeaplessBigInt::<$T, $N, Ct>::default());
+            let nb = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b_arr, $N as u16)
+                .into_nonzero_ct()
+                .unwrap_or(NonZeroHeaplessBigInt::<$T, $N, Ct>::default());
+            let r = <NonZeroHeaplessBigInt<$T, $N, Ct> as subtle::ConditionallySelectable>::conditional_select(
+                &na,
+                &nb,
+                subtle::Choice::from(c),
+            );
+            let result = core::hint::black_box(*r.get().all_limbs());
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_cond_select!($name, $T, $N);
+    };
+}
+emit_h_nz_cond_select!(ct_fix__HB__nz_cond_select__u8__N16, u8, 16);
+emit_h_nz_cond_select!(ct_fix__HB__nz_cond_select__u16__N16, u16, 16);
+emit_h_nz_cond_select!(ct_fix__HB__nz_cond_select__u32__N4, u32, 4);
+emit_h_nz_cond_select!(ct_fix__HB__nz_cond_select__u32__N16, u32, 16);
+emit_h_nz_cond_select!(ct_fix__HB__nz_cond_select__u64__N4, u64, 4);
+
 // =============================================================================
 // Category HC: always-CT-by-construction ops (regression watch).
 // =============================================================================
@@ -554,6 +615,128 @@ emit_h_carrying_add!(ct_fix__HC__carrying_add__u16__N16, u16, 16);
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u32__N4, u32, 4);
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u32__N16, u32, 16);
 emit_h_carrying_add!(ct_fix__HC__carrying_add__u64__N4, u64, 4);
+
+// Borrowing sub — CT counterpart of carrying_add; same ABI, reuses the shape.
+macro_rules! emit_h_borrowing_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            borrow: bool,
+            out_ptr: *mut [$T; $N],
+        ) -> u8 {
+            let a_arr = core::hint::black_box(unsafe { *a_ptr });
+            let b_arr = core::hint::black_box(unsafe { *b_ptr });
+            let bin = core::hint::black_box(borrow);
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a_arr, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b_arr, $N as u16);
+            let (r, bo) = BorrowingSub::borrowing_sub(x, y, bin);
+            let result = core::hint::black_box(*r.all_limbs());
+            unsafe {
+                *out_ptr = result;
+            }
+            core::hint::black_box(bo as u8)
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_carrying_add!($name, $T, $N);
+    };
+}
+emit_h_borrowing_sub!(ct_fix__HC__borrowing_sub__u8__N16, u8, 16);
+emit_h_borrowing_sub!(ct_fix__HC__borrowing_sub__u16__N16, u16, 16);
+emit_h_borrowing_sub!(ct_fix__HC__borrowing_sub__u32__N4, u32, 4);
+emit_h_borrowing_sub!(ct_fix__HC__borrowing_sub__u32__N16, u32, 16);
+emit_h_borrowing_sub!(ct_fix__HC__borrowing_sub__u64__N4, u64, 4);
+
+// Regression-watch bins — always-CT by construction, pinned against a future
+// branch. Overflowing forms discard the flag.
+macro_rules! emit_h_wrapping_add {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            *WrappingAdd::wrapping_add(&x, &y).all_limbs()
+        });
+    };
+}
+emit_h_wrapping_add!(ct_fix__HC__wrapping_add__u8__N16, u8, 16);
+emit_h_wrapping_add!(ct_fix__HC__wrapping_add__u32__N4, u32, 4);
+emit_h_wrapping_add!(ct_fix__HC__wrapping_add__u64__N4, u64, 4);
+
+macro_rules! emit_h_wrapping_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            *WrappingSub::wrapping_sub(&x, &y).all_limbs()
+        });
+    };
+}
+emit_h_wrapping_sub!(ct_fix__HC__wrapping_sub__u8__N16, u8, 16);
+emit_h_wrapping_sub!(ct_fix__HC__wrapping_sub__u32__N4, u32, 4);
+emit_h_wrapping_sub!(ct_fix__HC__wrapping_sub__u64__N4, u64, 4);
+
+macro_rules! emit_h_overflowing_sub {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let (r, _ov) = OverflowingSub::overflowing_sub(&x, &y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_overflowing_sub!(ct_fix__HC__overflowing_sub__u8__N16, u8, 16);
+emit_h_overflowing_sub!(ct_fix__HC__overflowing_sub__u32__N4, u32, 4);
+emit_h_overflowing_sub!(ct_fix__HC__overflowing_sub__u64__N4, u64, 4);
+
+macro_rules! emit_h_overflowing_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        ct_fix_bin!($name, $T, $N, |a, b| {
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let (r, _ov) = OverflowingMul::overflowing_mul(&x, &y);
+            *r.all_limbs()
+        });
+    };
+}
+emit_h_overflowing_mul!(ct_fix__HC__overflowing_mul__u8__N16, u8, 16);
+emit_h_overflowing_mul!(ct_fix__HC__overflowing_mul__u32__N4, u32, 4);
+emit_h_overflowing_mul!(ct_fix__HC__overflowing_mul__u64__N4, u64, 4);
+
+// Widening carrying mul — `(a, b, carry) → (lo, hi)`. Pins the full-width
+// carry tail of the schoolbook multiply directly (the `carrying_mul_add` path
+// #180 fixed; this gates it head-on, not just via saturating/checked mul).
+macro_rules! emit_h_carrying_mul {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            a_ptr: *const [$T; $N],
+            b_ptr: *const [$T; $N],
+            carry_ptr: *const [$T; $N],
+            lo_ptr: *mut [$T; $N],
+            hi_ptr: *mut [$T; $N],
+        ) {
+            let a = core::hint::black_box(unsafe { *a_ptr });
+            let b = core::hint::black_box(unsafe { *b_ptr });
+            let cy = core::hint::black_box(unsafe { *carry_ptr });
+            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
+            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
+            let cin = HeaplessBigInt::<$T, $N, Ct>::from_limbs(cy, $N as u16);
+            let (lo, hi) = CarryingMul::carrying_mul(x, y, cin);
+            unsafe {
+                *lo_ptr = core::hint::black_box(*lo.all_limbs());
+                *hi_ptr = core::hint::black_box(*hi.all_limbs());
+            }
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_carrying_mul!($name, $T, $N);
+    };
+}
+emit_h_carrying_mul!(ct_fix__HC__carrying_mul__u8__N16, u8, 16);
+emit_h_carrying_mul!(ct_fix__HC__carrying_mul__u32__N4, u32, 4);
+emit_h_carrying_mul!(ct_fix__HC__carrying_mul__u32__N16, u32, 16);
+emit_h_carrying_mul!(ct_fix__HC__carrying_mul__u64__N4, u64, 4);
 
 // Ord::cmp — folded to u8 (Less=0xFF, Equal=0, Greater=1).
 macro_rules! emit_h_cmp {


### PR DESCRIPTION
## What

Closes the standing CT-coverage backlog in one PR (per request). New fixtures on **both** carriers (`FixedUInt` + `HeaplessBigInt`), all 8 targets green, negative controls still trip. ~61 new fixtures; count 419 → **480**.

| Op | Why it was a gap | Shape |
|---|---|---|
| **`wrapping_next_power_of_two`** | Distinct Ct body — ZERO-on-overflow, separate `const_ct_select` chain from the gated `next_power_of_two`. | `ct_fix_un` |
| **`NonZero::conditional_select`** | `Ct`-only `ConditionallySelectable` on the NonZero newtype; the `into_nonzero_ct` fixtures unwrap before the select runs. | `cond_select` (inputs forced non-zero via `\|= 1`; wrapper via `into_nonzero_ct().unwrap_or(default())`) |
| **`borrowing_sub`** | CT counterpart of the gated `carrying_add`, never fixtured. | reuses `carrying_add` ABI |
| **`carrying_mul`** (widening) | The `(lo, hi)` multiply — pins the schoolbook carry tail **directly**, closing the §180 follow-up TODO (it was only gated transitively via saturating/checked mul). | **new** two-output `fbx_ctgrind_carrying_mul` ABI adapter |
| **wrapping_add/sub, overflowing_sub/mul** | Regression-watch (always-CT); pinned against future drift. | `ct_fix_bin` |

## Notes

- **The new two-output ABI shape** (`(a,b,carry) → (lo,hi)`) is the concrete payoff of #182: adding it was a one-macro local change in `ctgrind_shapes.rs`, no harness release.
- **`carrying_mul` surfaced `schoolbook_mul` / the `CarryingMul` impl to the gate for the first time.** Both are const-`N`-bounded (`get_at`/`set_at` branch on the public position counter; the `Ct` monomorph carries only the full-sweep carry tail). Notably `schoolbook_mul` was **already** written with the exact `match P::TAG` full-sweep split #180 added to heapless — so no library fix, just allowlist attestation.
- **thumbv6m:** `wrapping_next_power_of_two`'s second call to the shared `ct_next_pow2` made LLVM outline that helper; added one thumbv6m allowlist row for its armv6m software-CLZ (the documented per-arch gap — the existing comment already named `ct_next_pow2`).

## Deferred: `CiosRowOps`

`mul_acc_row` is **always-CT** (no `P::TAG` split — regression tier, not a distinct-Ct-arm), and fixturing it needs the whole `cios` feature wired into ct-fixtures + a `modmath-cios` dependency + a bespoke two-scalar ABI shape + a likely new heapless allowlist entry. That infrastructure is disproportionate to one niche modmul-only op — it belongs in its own PR. (Its sibling `mul_acc_shift_row` on heapless ends in an `if top_hi_bit {…}` branch worth a closer look if that path is ever gated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add constant-time fixtures and ctgrind coverage for remaining distinct constant-time arithmetic operations on both FixedUInt and HeaplessBigInt carriers, including new widening multiply and helper allowlist entries.

New Features:
- Add fixtures for NextPowerOfTwo::wrapping_next_power_of_two on FixedUInt and HeaplessBigInt carriers.
- Add fixtures for NonZero conditional_select on FixedUInt and HeaplessBigInt NonZero newtypes.
- Introduce fixtures for widening CarryingMul with a new two-array-output ctgrind shape.
- Add fixtures for BorrowingSub as the constant-time counterpart to CarryingAdd on both carriers.

Enhancements:
- Add regression-watch fixtures for always-constant-time wrapping_add, wrapping_sub, overflowing_sub, and overflowing_mul on both carriers.
- Extend ctgrind helper allowlist for FixedUInt schoolbook multiplication and CarryingMul implementations.
- Update thumbv6m extra helper allowlist to cover outlined ct_next_pow2 helper shared by next_power_of_two and wrapping_next_power_of_two.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added constant-time verification coverage for borrowing subtraction, carrying multiplication, and wrapping or overflowing arithmetic.
  * Added support for constant-time conditional selection of non-zero integer values.
  * Added coverage for wrapping next-power-of-two behavior, including overflow handling.
  * Added fixtures for extended-precision multiplication with carry inputs and separate low/high outputs.

* **Bug Fixes**
  * Improved verification coverage for target-specific helper operations and arithmetic implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->