### PR TITLE
Gate CiosRowOps — and fix the secret-dependent branch it exposed

### DIFF
--- a/ct-verify/ct-ctgrind/Cargo.toml
+++ b/ct-verify/ct-ctgrind/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 # Link the fixtures as a Rust rlib so this binary can call each
 # `extern "C"` symbol directly. `default-features = false` disables
 # ct-fixtures' `#[panic_handler]` so std's panic handler is used.
-# `heapless` pulls the HeaplessBigInt fixtures in too, so the taint check
+# `heapless` + `cios` pull those fixture surfaces in too, so the taint check
 # independently cross-checks the helpers the asm-grep gate only attests.
-ct-fixtures = { path = "../ct-fixtures", default-features = false, features = ["ctgrind", "heapless"] }
+ct-fixtures = { path = "../ct-fixtures", default-features = false, features = ["ctgrind", "heapless", "cios"] }
 
 krabi-caliper = { version = "0.1", features = ["ctgrind"] }

--- a/ct-verify/ct-driver/src/main.rs
+++ b/ct-verify/ct-driver/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> ExitCode {
             driver: DriverConfig {
                 workspace,
                 fixture_package: "ct-fixtures",
-                fixture_features: &["heapless"],
+                fixture_features: &["heapless", "cios"],
             },
             memory_class_negatives: &[],
         },

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -192,7 +192,11 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // CIOS Montgomery row ops (`mul_acc_row`, `mul_acc_shift_row`). One body
     // generic over `P`, looping `j < N` over const N (the shift row's
     // `carrying_add`-based bool→word fold is branchless — no `if` on the
-    // secret carry bit). Reached by the `cios_*` fixtures.
+    // secret carry bit). Reached by the `cios_*` fixtures. Whole-symbol
+    // exemption here rests on the taint axis for the value-branch check: the
+    // `cios_*` fixtures taint scalar/carry/acc, so a re-introduced secret
+    // branch (e.g. the old `if top_hi_bit`) trips ctgrind, as the analogous
+    // `heapless::arith` carry-tail leak did in PR #180.
     r"fixed_bigint9fixeduint17cios_row_ops_impl.*mul_acc",
     // ct_checked_pow's square-and-multiply ladder iterates u32::BITS
     // times.

--- a/ct-verify/ct-driver/src/target.rs
+++ b/ct-verify/ct-driver/src/target.rs
@@ -189,6 +189,11 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // bound survives. Reached by the `carrying_mul` fixtures.
     r"fixed_bigint9fixeduint23extended_precision_impl14schoolbook_mul",
     r"fixed_bigint9fixeduint23extended_precision_impl126.*carrying_mul",
+    // CIOS Montgomery row ops (`mul_acc_row`, `mul_acc_shift_row`). One body
+    // generic over `P`, looping `j < N` over const N (the shift row's
+    // `carrying_add`-based bool→word fold is branchless — no `if` on the
+    // secret carry bit). Reached by the `cios_*` fixtures.
+    r"fixed_bigint9fixeduint17cios_row_ops_impl.*mul_acc",
     // ct_checked_pow's square-and-multiply ladder iterates u32::BITS
     // times.
     r"fixed_bigint9fixeduint.*ct_checked_pow",
@@ -317,6 +322,11 @@ const HELPER_ALLOWLIST: &[&str] = &[
     // schoolbook multiply (`mul_slice`/CarryingMul, nested loops bounded on
     // public a_n/b_n/out_n) — is public-bounded.
     r"fixed_bigint\d*heapless5arith",
+    // heapless CIOS row ops (`mul_acc_row`, `mul_acc_shift_row`): per-limb
+    // loops bound on the public `multiplicand.len`, value through
+    // `carrying_mul`/`carrying_add`. The shift row folds its final carry bool
+    // to a word via `carrying_add(0, 0, bit)` — branchless, not `if bit`.
+    r"fixed_bigint\d*heapless4cios.*mul_acc",
     // heapless construction (`from_limbs`/`all_limbs`/`limbs[..len]`) and the
     // core adapters it pulls in — `Zip`, array `IntoIter`, `RangeTo`
     // slice-index, array `Index`. All bounded by public array/slice lengths;

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -26,9 +26,14 @@ ctgrind = ["dep:krabi-caliper"]
 # Kept as a feature so non-gate consumers can build ct-fixtures without the
 # heapless surface.
 heapless = []
+# CiosRowOps (Montgomery row-op kernels) fixtures. Enables fixed-bigint's
+# `cios` feature and pulls modmath-cios in to name the trait. The driver turns
+# this on alongside `heapless` so both carriers' row ops are gated.
+cios = ["fixed-bigint/cios", "dep:modmath-cios"]
 
 [dependencies]
 fixed-bigint = { path = "../.." }
+modmath-cios = { version = "0.1.2", default-features = false, optional = true }
 const-num-traits = { version = "0.2.1", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/ct-fixtures/src/ctgrind_shapes.rs
+++ b/ct-verify/ct-fixtures/src/ctgrind_shapes.rs
@@ -259,6 +259,40 @@ macro_rules! fbx_ctgrind_carrying_mul {
     };
 }
 
+/// CIOS row op: `(mult:[T,N], acc:[T,N], scalar:T, carry:T) → acc'[T,N] + T`.
+/// Two single-limb `T` scalar secrets alongside two arrays — another shape
+/// unique to ct-fixtures, added locally.
+#[macro_export]
+macro_rules! fbx_ctgrind_mul_acc {
+    ($name:ident, $T:ty, $N:literal) => {
+        krabi_caliper::ctgrind_fixture!($name, {
+            unsafe extern "C" {
+                fn $name(
+                    mult: *const [$T; $N],
+                    acc: *const [$T; $N],
+                    scalar: $T,
+                    carry: $T,
+                    out: *mut [$T; $N],
+                ) -> $T;
+            }
+            let mult: [$T; $N] = [0; $N];
+            let acc: [$T; $N] = [0; $N];
+            let scalar: $T = ::core::hint::black_box(0);
+            let carry: $T = ::core::hint::black_box(0);
+            let mut out: [$T; $N] = [0; $N];
+            krabi_caliper::host::ctgrind::taint(&mult);
+            krabi_caliper::host::ctgrind::taint(&acc);
+            krabi_caliper::host::ctgrind::taint_val(&scalar);
+            krabi_caliper::host::ctgrind::taint_val(&carry);
+            let r = unsafe { $name(&mult, &acc, scalar, carry, &mut out) };
+            krabi_caliper::host::ctgrind::untaint(&out);
+            krabi_caliper::host::ctgrind::untaint_val(&r);
+            let _ = ::core::hint::black_box(out);
+            let _ = ::core::hint::black_box(r);
+        });
+    };
+}
+
 /// Carrying add: `(T,N) × (T,N) × bool → (T,N) + u8`.
 #[macro_export]
 macro_rules! fbx_ctgrind_carrying_add {

--- a/ct-verify/ct-fixtures/src/fixtures_cios.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cios.rs
@@ -1,0 +1,156 @@
+//! `modmath_cios::CiosRowOps` constant-time fixtures — the Montgomery
+//! multiply-accumulate row kernels that drive CIOS modular multiplication.
+//!
+//! Behind the `cios` cargo feature (which enables `fixed-bigint/cios`). Both
+//! `mul_acc_row` (Phase 1) and `mul_acc_shift_row` (Phase 2) are exercised on
+//! both carriers. The ops are always-CT by construction (one body generic over
+//! `P`, loops bounded on the public `N`/`len`), so they're regression-watch:
+//! pinned so a future change — like the `if top_hi_bit` that heapless
+//! `mul_acc_shift_row` used to carry — can't reintroduce a secret-dependent
+//! branch.
+//!
+//! ABI: `(mult, acc, scalar, carry) → acc' + carry_word`. The two single-limb
+//! `T` scalars are secret inputs; `acc` is written to `out`, the carry word is
+//! returned. Uses the `fbx_ctgrind_mul_acc` shape.
+
+use const_num_traits::Ct;
+use fixed_bigint::FixedUInt;
+use modmath_cios::CiosRowOps;
+
+// ── FixedUInt (Category C) ──
+
+macro_rules! emit_cios_mul_acc_row {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            mult_ptr: *const [$T; $N],
+            acc_ptr: *const [$T; $N],
+            scalar: $T,
+            carry: $T,
+            out_ptr: *mut [$T; $N],
+        ) -> $T {
+            let mult_arr = core::hint::black_box(unsafe { *mult_ptr });
+            let acc_arr = core::hint::black_box(unsafe { *acc_ptr });
+            let s = core::hint::black_box(scalar);
+            let c = core::hint::black_box(carry);
+            let mult = FixedUInt::<$T, $N, Ct>::from(mult_arr);
+            let mut acc = FixedUInt::<$T, $N, Ct>::from(acc_arr);
+            let cout = <FixedUInt<$T, $N, Ct> as CiosRowOps>::mul_acc_row(s, &mult, &mut acc, c);
+            unsafe {
+                *out_ptr = core::hint::black_box(*acc.words());
+            }
+            core::hint::black_box(cout)
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_mul_acc!($name, $T, $N);
+    };
+}
+emit_cios_mul_acc_row!(ct_fix__C__cios_mul_acc_row__u8__N16, u8, 16);
+emit_cios_mul_acc_row!(ct_fix__C__cios_mul_acc_row__u32__N4, u32, 4);
+emit_cios_mul_acc_row!(ct_fix__C__cios_mul_acc_row__u32__N16, u32, 16);
+emit_cios_mul_acc_row!(ct_fix__C__cios_mul_acc_row__u64__N4, u64, 4);
+
+macro_rules! emit_cios_mul_acc_shift_row {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(
+            mult_ptr: *const [$T; $N],
+            acc_ptr: *const [$T; $N],
+            scalar: $T,
+            acc_hi: $T,
+            out_ptr: *mut [$T; $N],
+        ) -> $T {
+            let mult_arr = core::hint::black_box(unsafe { *mult_ptr });
+            let acc_arr = core::hint::black_box(unsafe { *acc_ptr });
+            let s = core::hint::black_box(scalar);
+            let hi = core::hint::black_box(acc_hi);
+            let mult = FixedUInt::<$T, $N, Ct>::from(mult_arr);
+            let mut acc = FixedUInt::<$T, $N, Ct>::from(acc_arr);
+            let cout =
+                <FixedUInt<$T, $N, Ct> as CiosRowOps>::mul_acc_shift_row(s, &mult, &mut acc, hi);
+            unsafe {
+                *out_ptr = core::hint::black_box(*acc.words());
+            }
+            core::hint::black_box(cout)
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_mul_acc!($name, $T, $N);
+    };
+}
+emit_cios_mul_acc_shift_row!(ct_fix__C__cios_mul_acc_shift_row__u8__N16, u8, 16);
+emit_cios_mul_acc_shift_row!(ct_fix__C__cios_mul_acc_shift_row__u32__N4, u32, 4);
+emit_cios_mul_acc_shift_row!(ct_fix__C__cios_mul_acc_shift_row__u32__N16, u32, 16);
+emit_cios_mul_acc_shift_row!(ct_fix__C__cios_mul_acc_shift_row__u64__N4, u64, 4);
+
+// ── HeaplessBigInt (Category HC) ──
+
+#[cfg(feature = "heapless")]
+mod heapless_cios {
+    use super::*;
+    use fixed_bigint::HeaplessBigInt;
+
+    macro_rules! emit_h_cios_mul_acc_row {
+        ($name:ident, $T:ty, $N:literal) => {
+            #[no_mangle]
+            pub extern "C" fn $name(
+                mult_ptr: *const [$T; $N],
+                acc_ptr: *const [$T; $N],
+                scalar: $T,
+                carry: $T,
+                out_ptr: *mut [$T; $N],
+            ) -> $T {
+                let mult_arr = core::hint::black_box(unsafe { *mult_ptr });
+                let acc_arr = core::hint::black_box(unsafe { *acc_ptr });
+                let s = core::hint::black_box(scalar);
+                let c = core::hint::black_box(carry);
+                let mult = HeaplessBigInt::<$T, $N, Ct>::from_limbs(mult_arr, $N as u16);
+                let mut acc = HeaplessBigInt::<$T, $N, Ct>::from_limbs(acc_arr, $N as u16);
+                let cout =
+                    <HeaplessBigInt<$T, $N, Ct> as CiosRowOps>::mul_acc_row(s, &mult, &mut acc, c);
+                unsafe {
+                    *out_ptr = core::hint::black_box(*acc.all_limbs());
+                }
+                core::hint::black_box(cout)
+            }
+            #[cfg(feature = "ctgrind")]
+            fbx_ctgrind_mul_acc!($name, $T, $N);
+        };
+    }
+    emit_h_cios_mul_acc_row!(ct_fix__HC__cios_mul_acc_row__u8__N16, u8, 16);
+    emit_h_cios_mul_acc_row!(ct_fix__HC__cios_mul_acc_row__u32__N4, u32, 4);
+    emit_h_cios_mul_acc_row!(ct_fix__HC__cios_mul_acc_row__u32__N16, u32, 16);
+    emit_h_cios_mul_acc_row!(ct_fix__HC__cios_mul_acc_row__u64__N4, u64, 4);
+
+    macro_rules! emit_h_cios_mul_acc_shift_row {
+        ($name:ident, $T:ty, $N:literal) => {
+            #[no_mangle]
+            pub extern "C" fn $name(
+                mult_ptr: *const [$T; $N],
+                acc_ptr: *const [$T; $N],
+                scalar: $T,
+                acc_hi: $T,
+                out_ptr: *mut [$T; $N],
+            ) -> $T {
+                let mult_arr = core::hint::black_box(unsafe { *mult_ptr });
+                let acc_arr = core::hint::black_box(unsafe { *acc_ptr });
+                let s = core::hint::black_box(scalar);
+                let hi = core::hint::black_box(acc_hi);
+                let mult = HeaplessBigInt::<$T, $N, Ct>::from_limbs(mult_arr, $N as u16);
+                let mut acc = HeaplessBigInt::<$T, $N, Ct>::from_limbs(acc_arr, $N as u16);
+                let cout = <HeaplessBigInt<$T, $N, Ct> as CiosRowOps>::mul_acc_shift_row(
+                    s, &mult, &mut acc, hi,
+                );
+                unsafe {
+                    *out_ptr = core::hint::black_box(*acc.all_limbs());
+                }
+                core::hint::black_box(cout)
+            }
+            #[cfg(feature = "ctgrind")]
+            fbx_ctgrind_mul_acc!($name, $T, $N);
+        };
+    }
+    emit_h_cios_mul_acc_shift_row!(ct_fix__HC__cios_mul_acc_shift_row__u8__N16, u8, 16);
+    emit_h_cios_mul_acc_shift_row!(ct_fix__HC__cios_mul_acc_shift_row__u32__N4, u32, 4);
+    emit_h_cios_mul_acc_shift_row!(ct_fix__HC__cios_mul_acc_shift_row__u32__N16, u32, 16);
+    emit_h_cios_mul_acc_shift_row!(ct_fix__HC__cios_mul_acc_shift_row__u64__N4, u64, 4);
+}

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -33,6 +33,8 @@ mod fixtures_asym;
 mod fixtures_cat_a;
 mod fixtures_cat_b;
 mod fixtures_cat_c;
+#[cfg(feature = "cios")]
+mod fixtures_cios;
 mod fixtures_ct_traits;
 #[cfg(feature = "heapless")]
 mod fixtures_heapless;

--- a/src/heapless/cios.rs
+++ b/src/heapless/cios.rs
@@ -18,7 +18,7 @@
 
 use super::{HeaplessBigInt, zero};
 use crate::MachineWord;
-use const_num_traits::{CarryingAdd, CarryingMul, ConstOne, Personality};
+use const_num_traits::{CarryingAdd, CarryingMul, Personality};
 
 impl<T, const CAP: usize, P: Personality> modmath_cios::CiosRowOps for HeaplessBigInt<T, CAP, P>
 where
@@ -84,10 +84,65 @@ where
         if n > 0 {
             acc.limbs[n - 1] = top_low;
         }
-        if top_hi_bit {
-            <T as ConstOne>::ONE
-        } else {
-            zero()
-        }
+        // Convert the carry bool to a T-word branchlessly, matching
+        // `FixedUInt::mul_acc_shift_row`. An `if top_hi_bit { … }` would
+        // branch on a secret-derived carry bit under a `Ct` carrier; there is
+        // no generic `bool as T`, so fold it through `carrying_add`.
+        <T as CarryingAdd>::carrying_add(zero(), zero(), top_hi_bit).0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use const_num_traits::{Ct, Nct};
+    use modmath_cios::CiosRowOps;
+
+    /// The final carry word is produced by a branchless `carrying_add`
+    /// fold (not an `if`); it must still be exactly 0 or 1. Covers both the
+    /// no-overflow and the overflow (former `if top_hi_bit`) paths.
+    #[test]
+    fn mul_acc_shift_row_carry_bit_is_0_or_1() {
+        type H = HeaplessBigInt<u8, 2, Ct>;
+        // Tiny product, small acc_hi → no top overflow → 0.
+        let mult = H::from_limbs([1, 0], 2);
+        let mut acc = H::from_limbs([2, 0], 2);
+        assert_eq!(
+            <H as CiosRowOps>::mul_acc_shift_row(1, &mult, &mut acc, 3),
+            0
+        );
+        // Maximal product carry + maximal acc_hi → top overflows a byte → 1.
+        let mult = H::from_limbs([0xFF, 0xFF], 2);
+        let mut acc = H::from_limbs([0, 0], 2);
+        assert_eq!(
+            <H as CiosRowOps>::mul_acc_shift_row(0xFF, &mult, &mut acc, 0xFF),
+            1
+        );
+    }
+
+    /// Both personalities run the same body and must agree bit-for-bit,
+    /// including the branchless carry fold.
+    #[test]
+    fn row_ops_ct_matches_nct() {
+        type HN = HeaplessBigInt<u8, 4, Nct>;
+        type HC = HeaplessBigInt<u8, 4, Ct>;
+        let m = [0xAB, 0xCD, 0x12, 0x34];
+        let a = [0x10, 0x20, 0x30, 0x40];
+
+        let mut acc_n = HN::from_limbs(a, 4);
+        let cn = <HN as CiosRowOps>::mul_acc_row(0x7, &HN::from_limbs(m, 4), &mut acc_n, 0x11);
+        let mut acc_c = HC::from_limbs(a, 4);
+        let cc = <HC as CiosRowOps>::mul_acc_row(0x7, &HC::from_limbs(m, 4), &mut acc_c, 0x11);
+        assert_eq!(acc_n.all_limbs(), acc_c.all_limbs());
+        assert_eq!(cn, cc);
+
+        let mut sacc_n = HN::from_limbs(a, 4);
+        let sn =
+            <HN as CiosRowOps>::mul_acc_shift_row(0x9, &HN::from_limbs(m, 4), &mut sacc_n, 0xEE);
+        let mut sacc_c = HC::from_limbs(a, 4);
+        let sc =
+            <HC as CiosRowOps>::mul_acc_shift_row(0x9, &HC::from_limbs(m, 4), &mut sacc_c, 0xEE);
+        assert_eq!(sacc_n.all_limbs(), sacc_c.all_limbs());
+        assert_eq!(sn, sc);
     }
 }


### PR DESCRIPTION
## Why this exists

In #183 I deferred `CiosRowOps` as "always-CT, niche, needs infrastructure." That was the wrong call: gating it **found a real leak**. This PR does the infrastructure *and* fixes the bug.

## The leak (library fix)

Heapless `mul_acc_shift_row` (CIOS Montgomery Phase 2) ended in:

```rust
if top_hi_bit { <T as ConstOne>::ONE } else { zero() }
```

`top_hi_bit` is the carry-out of `carrying_add(carry, acc_hi)` — both operands secret-derived. That's a **branch on a secret bit**. Under a `Ct` carrier driving constant-time modular multiplication (RSA/ed25519-style), it leaks. FixedUInt's `mul_acc_shift_row` already avoided this — it folds the bool to a word branchlessly via `carrying_add(0, 0, bit)` with a comment saying exactly why. Heapless was **asymmetric**. Fixed it to match.

Heapless cios had **zero tests**; added two proving the branchless fold returns exactly `0`/`1` (both the no-overflow and overflow paths) and that `Ct` matches `Nct`.

## The gating (harness)

- New `cios` feature in ct-fixtures (enables `fixed-bigint/cios`, pulls `modmath-cios` to name the trait); the asm-grep driver and the ctgrind build both turn it on.
- **New two-scalar ABI shape** `fbx_ctgrind_mul_acc` (`(mult, acc, scalar, carry) → acc' + word`) — added as a one-macro local change in `ctgrind_shapes.rs`, no caliper release. This is the third novel shape #182's relocation has made cheap.
- 16 fixtures: `mul_acc_row` + `mul_acc_shift_row`, both carriers.
- Row-op impls loop on const `N` / public `len` (the shift-row bool→word fold is now branchless), so they're attested in the FixedUInt + heapless allowlists.

## Verification

496 fixtures, **0 violations on all 8 asm-grep targets**; the 16 cios fixtures register into the Valgrind taint runner (ctgrind CI). Full lib suite green including the new heapless cios tests. Default (non-`cios`) build unaffected.

That closes the CT-coverage backlog for real — no remaining deferred items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix a secret-dependent branch in heapless CIOS Montgomery row operations and add constant‑time coverage fixtures for CiosRowOps across FixedUInt and HeaplessBigInt.

Bug Fixes:
- Eliminate the `if` on the secret carry bit in heapless `mul_acc_shift_row` by replacing it with a branchless carry-bit fold via `carrying_add`, restoring constant‑time behavior.

Enhancements:
- Add unit tests to heapless CIOS row ops to validate the carry word is exactly 0/1 and that Ct and Nct personalities produce identical results.
- Introduce a new `fbx_ctgrind_mul_acc` ctgrind shape for two-scalar CIOS row ops and wire it into the ct-fixtures harness.
- Gate CiosRowOps through new `cios` ct-fixtures feature and extend asm-grep helper allowlists to cover FixedUInt and heapless CIOS row op implementations.

Build:
- Add optional `modmath-cios` dependency and `cios` Cargo feature to ct-fixtures to enable CiosRowOps-based fixtures.

CI:
- Enable the new `cios` fixtures in the ct-ctgrind and ct-driver configurations so CIOS row ops are exercised in constant‑time CI.

Tests:
- Add ctgrind-backed fixtures for `mul_acc_row` and `mul_acc_shift_row` across multiple word sizes and carriers to systematically gate CiosRowOps for constant‑time behavior.