### PR TITLE
Run hardware CT on every pull request

### DIFF
--- a/.github/workflows/hw-ct.yml
+++ b/.github/workflows/hw-ct.yml
@@ -8,10 +8,6 @@ on:
     branches: [main]
   pull_request:
 
-concurrency:
-  group: hw-ct-${{ github.repository }}
-  cancel-in-progress: false
-
 jobs:
   cyccnt:
     # CHANGE 1 — the rig-type label. Routes the job to any bench whose runner

--- a/.github/workflows/hw-ct.yml
+++ b/.github/workflows/hw-ct.yml
@@ -4,9 +4,11 @@
 name: hw-ct
 
 on:
-  workflow_dispatch:        # hardware runs are slow + serialized; trigger by hand
+  push:
+    branches: [main]
+  pull_request:
 
-concurrency:                # don't let two dispatches of this repo queue on the rig
+concurrency:
   group: hw-ct-${{ github.repository }}
   cancel-in-progress: false
 


### PR DESCRIPTION
## What

- Run the F407 hardware constant-time workflow automatically for every pull request.
- Run it again when changes land on `main`.

## Why

Hardware is a normal verification target, like the QEMU and cross-target jobs. Keeping the workflow manual-only hid qualification from the PR check set and allowed a current head to have no hardware result. The existing host-level rig lock and runner queue serialize access.

## Validation

- Workflow YAML passed the repository pre-commit hooks.
- Opening this PR should attach the `cyccnt` F407/J-Trace check automatically.

## Summary by Sourcery

CI:
- Trigger the hw-ct GitHub Actions workflow on pull_request and push to main, replacing manual workflow_dispatch-only runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers to run on pushes to the main branch and pull requests.
  * Removed the option to start the workflow manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->