### PR TITLE
Workload catalog reorg: single-source Ct ops across emulated + hardware backends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     ".",
+    "ct-verify/ct-workload",
     "ct-verify/ct-fixtures",
     "ct-verify/ct-driver",
     "ct-verify/ct-ctgrind",
@@ -21,6 +22,7 @@ members = [
 # `--workspace` still reaches all six; this covers the default invocation only.
 default-members = [
     ".",
+    "ct-verify/ct-workload",
     "ct-verify/ct-driver",
     "ct-verify/ct-ctgrind",
 ]

--- a/ct-verify/ct-fixtures/Cargo.toml
+++ b/ct-verify/ct-fixtures/Cargo.toml
@@ -29,10 +29,11 @@ heapless = []
 # CiosRowOps (Montgomery row-op kernels) fixtures. Enables fixed-bigint's
 # `cios` feature and pulls modmath-cios in to name the trait. The driver turns
 # this on alongside `heapless` so both carriers' row ops are gated.
-cios = ["fixed-bigint/cios", "dep:modmath-cios"]
+cios = ["fixed-bigint/cios", "ct-workload/cios", "dep:modmath-cios"]
 
 [dependencies]
 fixed-bigint = { path = "../.." }
+ct-workload = { path = "../ct-workload" }
 modmath-cios = { version = "0.1.2", default-features = false, optional = true }
 const-num-traits = { version = "0.2.1", default-features = false, features = ["ct"] }
 num-integer = { version = "0.1", default-features = false }

--- a/ct-verify/ct-fixtures/src/catalog.rs
+++ b/ct-verify/ct-fixtures/src/catalog.rs
@@ -1,4 +1,4 @@
-//! Client-owned workload catalog (proof-of-concept slice).
+//! Client-owned workload catalog.
 //!
 //! Each Ct operation is declared **once** as a carrier-generic function; the
 //! backend adapters (asm-grep `extern "C"`, ctgrind taint, and — later — the
@@ -7,9 +7,16 @@
 //! words and reading it back — lives in [`FixtureCarrier`], not in every
 //! fixture.
 //!
-//! This slice covers the `bin` shape via `sat_add` on both carriers, to prove
-//! one op body feeds both the `A` (FixedUInt) and `HA` (Heapless) fixtures.
-//! Remaining shapes/ops are migrated on top of this.
+//! Every operation present on **both** carriers (FixedUInt `A/B/C/CT` and
+//! Heapless `HA/HB/HC/HCT`) routes through here: the `bin`/`un`/`count`/`pred`/
+//! `pred2`/`shift`/`checked_bin` shapes via the `emit_wl_*` adapters, plus the
+//! bespoke-ABI ops (carrying/borrowing, carrying_mul, cond_select, cios row
+//! ops) whose custom fixtures call the shared op body directly.
+//!
+//! Ops that live on only one carrier stay in their fixture file — the catalog
+//! removes cross-carrier duplication, and there is none to remove for
+//! `forget_ct`, `asym_*`, or the FixedUInt-only inherent `ct_checked_shl/shr/
+//! pow/next_power_of_two`.
 
 use const_num_traits::ops::ct::{
     CtCheckedAdd, CtCheckedMul, CtCheckedSub, CtIsPowerOfTwo, CtIsZero, CtParity,

--- a/ct-verify/ct-fixtures/src/catalog.rs
+++ b/ct-verify/ct-fixtures/src/catalog.rs
@@ -11,7 +11,11 @@
 //! one op body feeds both the `A` (FixedUInt) and `HA` (Heapless) fixtures.
 //! Remaining shapes/ops are migrated on top of this.
 
-use const_num_traits::{Ct, SaturatingAdd};
+use const_num_traits::{
+    AbsDiff, Ct, Midpoint, OverflowingAdd, OverflowingMul, OverflowingSub, SaturatingAdd,
+    SaturatingMul, SaturatingSub, WrappingAdd, WrappingMul, WrappingSub,
+};
+use core::ops::{BitAnd, BitOr, BitXor};
 use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
 
 /// Build a Ct carrier from an `[T; N]` word array and read it back. This is the
@@ -48,10 +52,64 @@ impl<T: MachineWord, const N: usize> FixtureCarrier<T, N> for HeaplessBigInt<T, 
 // These are also the exact entry points the DWT hardware suite calls, so the
 // workload body exists in exactly one place.
 
-/// `a.saturating_add(b)` at the operand width.
+/// `bin` shape: `(C, C) -> C`. One definition each, shared by both carriers.
 #[inline(always)]
 pub fn sat_add<C: SaturatingAdd<Output = C>>(a: C, b: C) -> C {
     SaturatingAdd::saturating_add(a, b)
+}
+#[inline(always)]
+pub fn sat_sub<C: SaturatingSub<Output = C>>(a: C, b: C) -> C {
+    SaturatingSub::saturating_sub(a, b)
+}
+#[inline(always)]
+pub fn sat_mul<C: SaturatingMul<Output = C>>(a: C, b: C) -> C {
+    SaturatingMul::saturating_mul(a, b)
+}
+#[inline(always)]
+pub fn abs_diff<C: AbsDiff<Output = C>>(a: C, b: C) -> C {
+    AbsDiff::abs_diff(a, b)
+}
+#[inline(always)]
+pub fn midpoint<C: Midpoint<Output = C>>(a: C, b: C) -> C {
+    Midpoint::midpoint(a, b)
+}
+#[inline(always)]
+pub fn bitand<C: BitAnd<Output = C>>(a: C, b: C) -> C {
+    BitAnd::bitand(a, b)
+}
+#[inline(always)]
+pub fn bitor<C: BitOr<Output = C>>(a: C, b: C) -> C {
+    BitOr::bitor(a, b)
+}
+#[inline(always)]
+pub fn bitxor<C: BitXor<Output = C>>(a: C, b: C) -> C {
+    BitXor::bitxor(a, b)
+}
+#[inline(always)]
+pub fn wrapping_add<C: WrappingAdd<Output = C>>(a: C, b: C) -> C {
+    WrappingAdd::wrapping_add(a, b)
+}
+#[inline(always)]
+pub fn wrapping_sub<C: WrappingSub<Output = C>>(a: C, b: C) -> C {
+    WrappingSub::wrapping_sub(a, b)
+}
+#[inline(always)]
+pub fn wrapping_mul<C: WrappingMul<Output = C>>(a: C, b: C) -> C {
+    WrappingMul::wrapping_mul(a, b)
+}
+/// Overflowing forms discard the flag — the fixture checks the value path's
+/// branch-freeness, and the ABI stays `bin`.
+#[inline(always)]
+pub fn overflowing_add<C: OverflowingAdd<Output = C>>(a: C, b: C) -> C {
+    OverflowingAdd::overflowing_add(a, b).0
+}
+#[inline(always)]
+pub fn overflowing_sub<C: OverflowingSub<Output = C>>(a: C, b: C) -> C {
+    OverflowingSub::overflowing_sub(a, b).0
+}
+#[inline(always)]
+pub fn overflowing_mul<C: OverflowingMul<Output = C>>(a: C, b: C) -> C {
+    OverflowingMul::overflowing_mul(a, b).0
 }
 
 /// `bin`-shape adapter: `(a, b) -> out`. Generates the `extern "C"` fixture

--- a/ct-verify/ct-fixtures/src/catalog.rs
+++ b/ct-verify/ct-fixtures/src/catalog.rs
@@ -1,0 +1,71 @@
+//! Client-owned workload catalog (proof-of-concept slice).
+//!
+//! Each Ct operation is declared **once** as a carrier-generic function; the
+//! backend adapters (asm-grep `extern "C"`, ctgrind taint, and — later — the
+//! DWT paired hardware suite) all drive that single definition. The one thing
+//! that genuinely differs between carriers — constructing the value from raw
+//! words and reading it back — lives in [`FixtureCarrier`], not in every
+//! fixture.
+//!
+//! This slice covers the `bin` shape via `sat_add` on both carriers, to prove
+//! one op body feeds both the `A` (FixedUInt) and `HA` (Heapless) fixtures.
+//! Remaining shapes/ops are migrated on top of this.
+
+use const_num_traits::{Ct, SaturatingAdd};
+use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
+
+/// Build a Ct carrier from an `[T; N]` word array and read it back. This is the
+/// only per-carrier plumbing a workload needs; everything else is generic.
+pub trait FixtureCarrier<T: Copy, const N: usize>: Sized {
+    fn from_words(words: [T; N]) -> Self;
+    fn to_words(&self) -> [T; N];
+}
+
+impl<T: MachineWord, const N: usize> FixtureCarrier<T, N> for FixedUInt<T, N, Ct> {
+    #[inline(always)]
+    fn from_words(words: [T; N]) -> Self {
+        FixedUInt::from(words)
+    }
+    #[inline(always)]
+    fn to_words(&self) -> [T; N] {
+        *self.words()
+    }
+}
+
+impl<T: MachineWord, const N: usize> FixtureCarrier<T, N> for HeaplessBigInt<T, N, Ct> {
+    #[inline(always)]
+    fn from_words(words: [T; N]) -> Self {
+        // Full-width `len == N` so it behaves bit-for-bit like `FixedUInt<T, N>`.
+        HeaplessBigInt::from_limbs(words, N as u16)
+    }
+    #[inline(always)]
+    fn to_words(&self) -> [T; N] {
+        *self.all_limbs()
+    }
+}
+
+// ── Workload ops (one definition per operation, carrier-generic) ──
+// These are also the exact entry points the DWT hardware suite calls, so the
+// workload body exists in exactly one place.
+
+/// `a.saturating_add(b)` at the operand width.
+#[inline(always)]
+pub fn sat_add<C: SaturatingAdd<Output = C>>(a: C, b: C) -> C {
+    SaturatingAdd::saturating_add(a, b)
+}
+
+/// `bin`-shape adapter: `(a, b) -> out`. Generates the `extern "C"` fixture
+/// (and, under the `ctgrind` feature, its taint registration) for one
+/// op × carrier × width by constructing the carrier through [`FixtureCarrier`],
+/// calling the shared catalog op, and reading the result back. The op and its
+/// input values are single-sourced; only the carrier + width vary here.
+#[macro_export]
+macro_rules! emit_wl_bin {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_bin!($sym, $T, $N, |aw, bw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
+            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a, b))
+        });
+    };
+}

--- a/ct-verify/ct-fixtures/src/catalog.rs
+++ b/ct-verify/ct-fixtures/src/catalog.rs
@@ -12,11 +12,13 @@
 //! Remaining shapes/ops are migrated on top of this.
 
 use const_num_traits::{
-    AbsDiff, Ct, Midpoint, OverflowingAdd, OverflowingMul, OverflowingSub, SaturatingAdd,
-    SaturatingMul, SaturatingSub, WrappingAdd, WrappingMul, WrappingSub,
+    AbsDiff, Ct, IsPowerOfTwo, Midpoint, NextPowerOfTwo, One, OverflowingAdd, OverflowingMul,
+    OverflowingSub, PrimBits, SaturatingAdd, SaturatingMul, SaturatingSub, UnboundedShl,
+    UnboundedShr, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
-use core::ops::{BitAnd, BitOr, BitXor};
+use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, ShlAssign, Shr, ShrAssign};
 use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
+use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
 
 /// Build a Ct carrier from an `[T; N]` word array and read it back. This is the
 /// only per-carrier plumbing a workload needs; everything else is generic.
@@ -112,6 +114,107 @@ pub fn overflowing_mul<C: OverflowingMul<Output = C>>(a: C, b: C) -> C {
     OverflowingMul::overflowing_mul(a, b).0
 }
 
+/// `un` shape: `(C) -> C`.
+#[inline(always)]
+pub fn not<C: Not<Output = C>>(a: C) -> C {
+    Not::not(a)
+}
+#[inline(always)]
+pub fn swap_bytes<C: PrimBits>(a: C) -> C {
+    PrimBits::swap_bytes(a)
+}
+#[inline(always)]
+pub fn reverse_bits<C: PrimBits>(a: C) -> C {
+    PrimBits::reverse_bits(a)
+}
+#[inline(always)]
+pub fn next_pow2<C: NextPowerOfTwo<Output = C>>(a: C) -> C {
+    NextPowerOfTwo::next_power_of_two(a)
+}
+#[inline(always)]
+pub fn wrapping_next_pow2<C: NextPowerOfTwo<Output = C>>(a: C) -> C {
+    NextPowerOfTwo::wrapping_next_power_of_two(a)
+}
+
+/// `count` shape: `(C) -> u32`.
+#[inline(always)]
+pub fn count_ones<C: PrimBits>(a: C) -> u32 {
+    PrimBits::count_ones(a)
+}
+#[inline(always)]
+pub fn leading_zeros<C: PrimBits>(a: C) -> u32 {
+    PrimBits::leading_zeros(a)
+}
+#[inline(always)]
+pub fn trailing_zeros<C: PrimBits>(a: C) -> u32 {
+    PrimBits::trailing_zeros(a)
+}
+
+/// `pred` shape: `(C) -> u8`.
+#[inline(always)]
+pub fn is_zero<C: Zero>(a: C) -> u8 {
+    Zero::is_zero(&a) as u8
+}
+#[inline(always)]
+pub fn is_one<C: One>(a: C) -> u8 {
+    One::is_one(&a) as u8
+}
+#[inline(always)]
+pub fn is_pow2<C: IsPowerOfTwo>(a: C) -> u8 {
+    IsPowerOfTwo::is_power_of_two(a) as u8
+}
+
+/// `pred2` shape: `(C, C) -> u8`.
+#[inline(always)]
+pub fn cmp<C: Ord>(a: C, b: C) -> u8 {
+    (a.cmp(&b) as i8) as u8
+}
+#[inline(always)]
+pub fn eq<C: PartialEq>(a: C, b: C) -> u8 {
+    (a == b) as u8
+}
+#[inline(always)]
+pub fn ct_eq<C: ConstantTimeEq>(a: C, b: C) -> u8 {
+    a.ct_eq(&b).unwrap_u8()
+}
+#[inline(always)]
+pub fn ct_gt<C: ConstantTimeGreater>(a: C, b: C) -> u8 {
+    a.ct_gt(&b).unwrap_u8()
+}
+#[inline(always)]
+pub fn ct_lt<C: ConstantTimeLess>(a: C, b: C) -> u8 {
+    a.ct_lt(&b).unwrap_u8()
+}
+
+/// `shift` shape: `(C, amount) -> C`. Assign forms mutate then return; the
+/// unbounded forms take a `u32` amount.
+#[inline(always)]
+pub fn shl_usize<C: Shl<usize, Output = C>>(a: C, n: usize) -> C {
+    a << n
+}
+#[inline(always)]
+pub fn shr_usize<C: Shr<usize, Output = C>>(a: C, n: usize) -> C {
+    a >> n
+}
+#[inline(always)]
+pub fn shl_assign<C: ShlAssign<usize>>(mut a: C, n: usize) -> C {
+    a <<= n;
+    a
+}
+#[inline(always)]
+pub fn shr_assign<C: ShrAssign<usize>>(mut a: C, n: usize) -> C {
+    a >>= n;
+    a
+}
+#[inline(always)]
+pub fn unbounded_shl<C: UnboundedShl<Output = C>>(a: C, n: u32) -> C {
+    UnboundedShl::unbounded_shl(a, n)
+}
+#[inline(always)]
+pub fn unbounded_shr<C: UnboundedShr<Output = C>>(a: C, n: u32) -> C {
+    UnboundedShr::unbounded_shr(a, n)
+}
+
 /// `bin`-shape adapter: `(a, b) -> out`. Generates the `extern "C"` fixture
 /// (and, under the `ctgrind` feature, its taint registration) for one
 /// op × carrier × width by constructing the carrier through [`FixtureCarrier`],
@@ -124,6 +227,62 @@ macro_rules! emit_wl_bin {
             let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
             let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
             <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a, b))
+        });
+    };
+}
+
+/// `un` shape: `(a) -> out`.
+#[macro_export]
+macro_rules! emit_wl_un {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_un!($sym, $T, $N, |aw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a))
+        });
+    };
+}
+
+/// `count` shape: `(a) -> u32`.
+#[macro_export]
+macro_rules! emit_wl_count {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_count!($sym, $T, $N, |aw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            $op(a)
+        });
+    };
+}
+
+/// `pred` shape: `(a) -> u8`.
+#[macro_export]
+macro_rules! emit_wl_pred {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_pred!($sym, $T, $N, |aw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            $op(a)
+        });
+    };
+}
+
+/// `pred2` shape: `(a, b) -> u8`.
+#[macro_export]
+macro_rules! emit_wl_pred2 {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_pred2!($sym, $T, $N, |aw, bw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
+            $op(a, b)
+        });
+    };
+}
+
+/// `shift` shape: `(a, amount) -> out`. `$NT` is the amount type (`usize`/`u32`).
+#[macro_export]
+macro_rules! emit_wl_shift {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal, $NT:ty) => {
+        $crate::ct_fix_shift!($sym, $T, $N, $NT, |aw, n| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a, n))
         });
     };
 }

--- a/ct-verify/ct-fixtures/src/catalog.rs
+++ b/ct-verify/ct-fixtures/src/catalog.rs
@@ -11,14 +11,19 @@
 //! one op body feeds both the `A` (FixedUInt) and `HA` (Heapless) fixtures.
 //! Remaining shapes/ops are migrated on top of this.
 
+use const_num_traits::ops::ct::{
+    CtCheckedAdd, CtCheckedMul, CtCheckedSub, CtIsPowerOfTwo, CtIsZero, CtParity,
+};
 use const_num_traits::{
-    AbsDiff, Ct, IsPowerOfTwo, Midpoint, NextPowerOfTwo, One, OverflowingAdd, OverflowingMul,
-    OverflowingSub, PrimBits, SaturatingAdd, SaturatingMul, SaturatingSub, UnboundedShl,
-    UnboundedShr, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    AbsDiff, BorrowingSub, CarryingAdd, CarryingMul, Ct, IsPowerOfTwo, Midpoint, NextPowerOfTwo,
+    One, OverflowingAdd, OverflowingMul, OverflowingSub, PrimBits, SaturatingAdd, SaturatingMul,
+    SaturatingSub, UnboundedShl, UnboundedShr, WrappingAdd, WrappingMul, WrappingSub, Zero,
 };
 use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, ShlAssign, Shr, ShrAssign};
 use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
-use subtle::{ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess};
+use subtle::{
+    Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
+};
 
 /// Build a Ct carrier from an `[T; N]` word array and read it back. This is the
 /// only per-carrier plumbing a workload needs; everything else is generic.
@@ -215,6 +220,85 @@ pub fn unbounded_shr<C: UnboundedShr<Output = C>>(a: C, n: u32) -> C {
     UnboundedShr::unbounded_shr(a, n)
 }
 
+/// `pred` shape via the masked-`Choice` `Ct*` traits.
+#[inline(always)]
+pub fn ct_is_odd<C: CtParity>(a: C) -> u8 {
+    a.ct_is_odd().unwrap_u8()
+}
+#[inline(always)]
+pub fn ct_is_zero<C: CtIsZero>(a: C) -> u8 {
+    a.ct_is_zero().unwrap_u8()
+}
+#[inline(always)]
+pub fn ct_is_pow2<C: CtIsPowerOfTwo>(a: C) -> u8 {
+    a.ct_is_power_of_two().unwrap_u8()
+}
+
+/// `checked_bin` shape: returns the masked `CtOption`; the adapter splits it
+/// into (value, validity) with a zero fallback.
+#[inline(always)]
+pub fn ct_checked_add<C: CtCheckedAdd>(a: C, b: C) -> subtle::CtOption<C> {
+    a.ct_checked_add(&b)
+}
+#[inline(always)]
+pub fn ct_checked_sub<C: CtCheckedSub>(a: C, b: C) -> subtle::CtOption<C> {
+    a.ct_checked_sub(&b)
+}
+#[inline(always)]
+pub fn ct_checked_mul<C: CtCheckedMul>(a: C, b: C) -> subtle::CtOption<C> {
+    a.ct_checked_mul(&b)
+}
+
+// ── Bespoke-ABI ops: op body single-sourced here; the fixtures keep their
+// custom `extern "C"` wrappers but call these so both carriers share the body.
+
+/// `(a, b, carry) -> (sum, carry_out)`.
+#[inline(always)]
+pub fn carrying_add<C: CarryingAdd<Output = C>>(a: C, b: C, carry: bool) -> (C, bool) {
+    CarryingAdd::carrying_add(a, b, carry)
+}
+/// `(a, b, borrow) -> (diff, borrow_out)`.
+#[inline(always)]
+pub fn borrowing_sub<C: BorrowingSub<Output = C>>(a: C, b: C, borrow: bool) -> (C, bool) {
+    BorrowingSub::borrowing_sub(a, b, borrow)
+}
+/// Widening `(a, b, carry) -> (lo, hi)`.
+#[inline(always)]
+pub fn carrying_mul<C: CarryingMul<Unsigned = C, Output = C>>(a: C, b: C, carry: C) -> (C, C) {
+    CarryingMul::carrying_mul(a, b, carry)
+}
+/// Branchless select of `a`/`b` on `choice`'s low bit.
+#[inline(always)]
+pub fn cond_select<C: ConditionallySelectable>(a: C, b: C, choice: u8) -> C {
+    C::conditional_select(&a, &b, Choice::from(choice))
+}
+
+/// CIOS Montgomery row ops. `acc` is taken by value and returned (the fixture
+/// then writes it out) alongside the carry word, so the op stays a plain
+/// value→value function callable from any backend.
+#[cfg(feature = "cios")]
+#[inline(always)]
+pub fn cios_mul_acc_row<C: modmath_cios::CiosRowOps>(
+    scalar: C::Word,
+    mult: C,
+    mut acc: C,
+    carry: C::Word,
+) -> (C, C::Word) {
+    let c = <C as modmath_cios::CiosRowOps>::mul_acc_row(scalar, &mult, &mut acc, carry);
+    (acc, c)
+}
+#[cfg(feature = "cios")]
+#[inline(always)]
+pub fn cios_mul_acc_shift_row<C: modmath_cios::CiosRowOps>(
+    scalar: C::Word,
+    mult: C,
+    mut acc: C,
+    acc_hi: C::Word,
+) -> (C, C::Word) {
+    let c = <C as modmath_cios::CiosRowOps>::mul_acc_shift_row(scalar, &mult, &mut acc, acc_hi);
+    (acc, c)
+}
+
 /// `bin`-shape adapter: `(a, b) -> out`. Generates the `extern "C"` fixture
 /// (and, under the `ctgrind` feature, its taint registration) for one
 /// op × carrier × width by constructing the carrier through [`FixtureCarrier`],
@@ -283,6 +367,27 @@ macro_rules! emit_wl_shift {
         $crate::ct_fix_shift!($sym, $T, $N, $NT, |aw, n| {
             let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
             <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a, n))
+        });
+    };
+}
+
+/// `checked_bin` shape: `(a, b) -> (out, u8)`. The op returns a `CtOption`;
+/// this splits it into the value (zero fallback) and the validity byte.
+#[macro_export]
+macro_rules! emit_wl_checked_bin {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_checked_bin!($sym, $T, $N, |aw, bw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
+            let res = $op(a, b);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(
+                <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words([0; $N]),
+            );
+            (
+                <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&value),
+                valid,
+            )
         });
     };
 }

--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -54,14 +54,11 @@ emit_eq!(ct_fix__A__eq__u64__N4, u64, 4);
 // SaturatingAdd / Sub / Mul
 // =============================================================================
 
+// Migrated to the workload catalog: the op body (`catalog::sat_add`) is shared
+// with the Heapless `HA` fixture and, later, the DWT hardware suite.
 macro_rules! emit_sat_add {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = SaturatingAdd::saturating_add(x, y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::sat_add, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_sat_add!(ct_fix__A__sat_add__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -69,12 +69,7 @@ emit_sat_add!(ct_fix__A__sat_add__u64__N4, u64, 4);
 
 macro_rules! emit_sat_sub {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = SaturatingSub::saturating_sub(x, y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::sat_sub, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_sat_sub!(ct_fix__A__sat_sub__u8__N16, u8, 16);
@@ -85,12 +80,7 @@ emit_sat_sub!(ct_fix__A__sat_sub__u64__N4, u64, 4);
 
 macro_rules! emit_sat_mul {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = SaturatingMul::saturating_mul(x, y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::sat_mul, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_sat_mul!(ct_fix__A__sat_mul__u8__N16, u8, 16);
@@ -206,12 +196,7 @@ emit_unbounded_shr!(ct_fix__A__unbounded_shr__u64__N4, u64, 4);
 
 macro_rules! emit_abs_diff {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = AbsDiff::abs_diff(x, y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::abs_diff, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_abs_diff!(ct_fix__A__abs_diff__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_a.rs
@@ -20,11 +20,7 @@ use crate::{ct_fix_bin, ct_fix_count, ct_fix_pred, ct_fix_pred2, ct_fix_shift, c
 
 macro_rules! emit_cmp {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            (x.cmp(&y) as i8) as u8
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::cmp, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_cmp!(ct_fix__A__cmp__u8__N16, u8, 16);
@@ -37,11 +33,7 @@ emit_cmp!(ct_fix__A__cmp__u64__N4, u64, 4);
 // distinct code path from the `subtle::ct_eq` fixtured in category B.
 macro_rules! emit_eq {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            (x == y) as u8
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::eq, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_eq!(ct_fix__A__eq__u8__N16, u8, 16);
@@ -95,11 +87,7 @@ emit_sat_mul!(ct_fix__A__sat_mul__u64__N4, u64, 4);
 
 macro_rules! emit_shl_usize {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, usize, |a, n| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let r = x << n;
-            *r.words()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::shl_usize, FixedUInt<$T, $N, Ct>, $T, $N, usize);
     };
 }
 emit_shl_usize!(ct_fix__A__shl_usize__u8__N16, u8, 16);
@@ -110,11 +98,7 @@ emit_shl_usize!(ct_fix__A__shl_usize__u64__N4, u64, 4);
 
 macro_rules! emit_shr_usize {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, usize, |a, n| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let r = x >> n;
-            *r.words()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::shr_usize, FixedUInt<$T, $N, Ct>, $T, $N, usize);
     };
 }
 emit_shr_usize!(ct_fix__A__shr_usize__u8__N16, u8, 16);
@@ -128,11 +112,7 @@ emit_shr_usize!(ct_fix__A__shr_usize__u64__N4, u64, 4);
 // const_shl_ct/const_shr_ct barrels.
 macro_rules! emit_shl_assign {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, usize, |a, n| {
-            let mut x = FixedUInt::<$T, $N, Ct>::from(a);
-            x <<= n;
-            *x.words()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::shl_assign, FixedUInt<$T, $N, Ct>, $T, $N, usize);
     };
 }
 emit_shl_assign!(ct_fix__A__shl_assign__u8__N16, u8, 16);
@@ -143,11 +123,7 @@ emit_shl_assign!(ct_fix__A__shl_assign__u64__N4, u64, 4);
 
 macro_rules! emit_shr_assign {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, usize, |a, n| {
-            let mut x = FixedUInt::<$T, $N, Ct>::from(a);
-            x >>= n;
-            *x.words()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::shr_assign, FixedUInt<$T, $N, Ct>, $T, $N, usize);
     };
 }
 emit_shr_assign!(ct_fix__A__shr_assign__u8__N16, u8, 16);
@@ -162,11 +138,7 @@ emit_shr_assign!(ct_fix__A__shr_assign__u64__N4, u64, 4);
 
 macro_rules! emit_unbounded_shl {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, u32, |a, n| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let r = UnboundedShl::unbounded_shl(x, n);
-            *r.words()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::unbounded_shl, FixedUInt<$T, $N, Ct>, $T, $N, u32);
     };
 }
 emit_unbounded_shl!(ct_fix__A__unbounded_shl__u8__N16, u8, 16);
@@ -177,11 +149,7 @@ emit_unbounded_shl!(ct_fix__A__unbounded_shl__u64__N4, u64, 4);
 
 macro_rules! emit_unbounded_shr {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, u32, |a, n| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let r = UnboundedShr::unbounded_shr(x, n);
-            *r.words()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::unbounded_shr, FixedUInt<$T, $N, Ct>, $T, $N, u32);
     };
 }
 emit_unbounded_shr!(ct_fix__A__unbounded_shr__u8__N16, u8, 16);
@@ -211,10 +179,7 @@ emit_abs_diff!(ct_fix__A__abs_diff__u64__N4, u64, 4);
 
 macro_rules! emit_is_pow2 {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            IsPowerOfTwo::is_power_of_two(x) as u8
-        });
+        crate::emit_wl_pred!($name, crate::catalog::is_pow2, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_is_pow2!(ct_fix__A__is_pow2__u8__N16, u8, 16);
@@ -229,11 +194,7 @@ emit_is_pow2!(ct_fix__A__is_pow2__u64__N4, u64, 4);
 
 macro_rules! emit_next_pow2 {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let r = NextPowerOfTwo::next_power_of_two(x);
-            *r.words()
-        });
+        crate::emit_wl_un!($name, crate::catalog::next_pow2, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_next_pow2!(ct_fix__A__next_pow2__u8__N16, u8, 16);
@@ -247,10 +208,7 @@ emit_next_pow2!(ct_fix__A__next_pow2__u64__N4, u64, 4);
 // (not MAX) via its own const_ct_select chain.
 macro_rules! emit_wrapping_next_pow2 {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            *NextPowerOfTwo::wrapping_next_power_of_two(x).words()
-        });
+        crate::emit_wl_un!($name, crate::catalog::wrapping_next_pow2, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_wrapping_next_pow2!(ct_fix__A__wrapping_next_pow2__u8__N16, u8, 16);
@@ -297,10 +255,7 @@ emit_tz!(ct_fix__A__trailing_zeros__u64__N4, u64, 4);
 
 macro_rules! emit_is_zero {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            <FixedUInt<$T, $N, Ct> as Zero>::is_zero(&x) as u8
-        });
+        crate::emit_wl_pred!($name, crate::catalog::is_zero, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_is_zero!(ct_fix__A__is_zero__u8__N16, u8, 16);
@@ -311,10 +266,7 @@ emit_is_zero!(ct_fix__A__is_zero__u64__N4, u64, 4);
 
 macro_rules! emit_is_one {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            <FixedUInt<$T, $N, Ct> as One>::is_one(&x) as u8
-        });
+        crate::emit_wl_pred!($name, crate::catalog::is_one, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_is_one!(ct_fix__A__is_one__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
@@ -18,11 +18,7 @@ use crate::{
 
 macro_rules! emit_ct_eq {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            x.ct_eq(&y).unwrap_u8()
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::ct_eq, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_eq!(ct_fix__B__ct_eq__u8__N16, u8, 16);
@@ -33,11 +29,7 @@ emit_ct_eq!(ct_fix__B__ct_eq__u64__N4, u64, 4);
 
 macro_rules! emit_ct_gt {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            x.ct_gt(&y).unwrap_u8()
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::ct_gt, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_gt!(ct_fix__B__ct_gt__u8__N16, u8, 16);
@@ -48,11 +40,7 @@ emit_ct_gt!(ct_fix__B__ct_gt__u64__N4, u64, 4);
 
 macro_rules! emit_ct_lt {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            x.ct_lt(&y).unwrap_u8()
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::ct_lt, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_lt!(ct_fix__B__ct_lt__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_b.rs
@@ -70,7 +70,7 @@ macro_rules! emit_cond_select {
             let c = core::hint::black_box(choice);
             let x = FixedUInt::<$T, $N, Ct>::from(a_arr);
             let y = FixedUInt::<$T, $N, Ct>::from(b_arr);
-            let r = FixedUInt::<$T, $N, Ct>::conditional_select(&x, &y, subtle::Choice::from(c));
+            let r = crate::catalog::cond_select(x, y, c);
             let result = core::hint::black_box(*r.words());
             unsafe {
                 *out_ptr = result;
@@ -137,14 +137,7 @@ emit_nz_cond_select!(ct_fix__B__nz_cond_select__u64__N4, u64, 4);
 
 macro_rules! emit_ct_checked_add {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_checked_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let res = x.ct_checked_add(&y);
-            let valid = res.is_some().unwrap_u8();
-            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
-            (*value.words(), valid)
-        });
+        crate::emit_wl_checked_bin!($name, crate::catalog::ct_checked_add, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_checked_add!(ct_fix__B__ct_checked_add__u8__N16, u8, 16);
@@ -155,14 +148,7 @@ emit_ct_checked_add!(ct_fix__B__ct_checked_add__u64__N4, u64, 4);
 
 macro_rules! emit_ct_checked_sub {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_checked_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let res = x.ct_checked_sub(&y);
-            let valid = res.is_some().unwrap_u8();
-            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
-            (*value.words(), valid)
-        });
+        crate::emit_wl_checked_bin!($name, crate::catalog::ct_checked_sub, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_checked_sub!(ct_fix__B__ct_checked_sub__u8__N16, u8, 16);
@@ -173,14 +159,7 @@ emit_ct_checked_sub!(ct_fix__B__ct_checked_sub__u64__N4, u64, 4);
 
 macro_rules! emit_ct_checked_mul {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_checked_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let res = x.ct_checked_mul(&y);
-            let valid = res.is_some().unwrap_u8();
-            let value = res.unwrap_or(FixedUInt::<$T, $N, Ct>::from([0; $N]));
-            (*value.words(), valid)
-        });
+        crate::emit_wl_checked_bin!($name, crate::catalog::ct_checked_mul, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_checked_mul!(ct_fix__B__ct_checked_mul__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
@@ -35,12 +35,7 @@ emit_not!(ct_fix__C__not__u64__N4, u64, 4);
 
 macro_rules! emit_bitand {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = BitAnd::bitand(x, y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::bitand, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_bitand!(ct_fix__C__bitand__u8__N16, u8, 16);
@@ -50,12 +45,7 @@ emit_bitand!(ct_fix__C__bitand__u64__N4, u64, 4);
 
 macro_rules! emit_bitor {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = BitOr::bitor(x, y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::bitor, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_bitor!(ct_fix__C__bitor__u8__N16, u8, 16);
@@ -65,12 +55,7 @@ emit_bitor!(ct_fix__C__bitor__u64__N4, u64, 4);
 
 macro_rules! emit_bitxor {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = BitXor::bitxor(x, y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::bitxor, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_bitxor!(ct_fix__C__bitxor__u8__N16, u8, 16);
@@ -101,12 +86,7 @@ emit_overflowing_add!(ct_fix__C__overflowing_add__u64__N4, u64, 4);
 
 macro_rules! emit_wrapping_mul {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = WrappingMul::wrapping_mul(&x, &y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::wrapping_mul, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_wrapping_mul!(ct_fix__C__wrapping_mul__u8__N16, u8, 16);
@@ -191,11 +171,7 @@ emit_borrowing_sub!(ct_fix__C__borrowing_sub__u64__N4, u64, 4);
 // forms discard the flag; the body's branch-freeness is what's scanned.
 macro_rules! emit_wrapping_add {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            *WrappingAdd::wrapping_add(&x, &y).words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::wrapping_add, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_wrapping_add!(ct_fix__C__wrapping_add__u8__N16, u8, 16);
@@ -204,11 +180,7 @@ emit_wrapping_add!(ct_fix__C__wrapping_add__u64__N4, u64, 4);
 
 macro_rules! emit_wrapping_sub {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            *WrappingSub::wrapping_sub(&x, &y).words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::wrapping_sub, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_wrapping_sub!(ct_fix__C__wrapping_sub__u8__N16, u8, 16);
@@ -217,12 +189,7 @@ emit_wrapping_sub!(ct_fix__C__wrapping_sub__u64__N4, u64, 4);
 
 macro_rules! emit_overflowing_sub {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let (r, _ov) = OverflowingSub::overflowing_sub(&x, &y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::overflowing_sub, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_overflowing_sub!(ct_fix__C__overflowing_sub__u8__N16, u8, 16);
@@ -231,12 +198,7 @@ emit_overflowing_sub!(ct_fix__C__overflowing_sub__u64__N4, u64, 4);
 
 macro_rules! emit_overflowing_mul {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let (r, _ov) = OverflowingMul::overflowing_mul(&x, &y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::overflowing_mul, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_overflowing_mul!(ct_fix__C__overflowing_mul__u8__N16, u8, 16);
@@ -283,12 +245,7 @@ emit_carrying_mul!(ct_fix__C__carrying_mul__u64__N4, u64, 4);
 
 macro_rules! emit_midpoint {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let y = FixedUInt::<$T, $N, Ct>::from(b);
-            let r = Midpoint::midpoint(x, y);
-            *r.words()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::midpoint, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_midpoint!(ct_fix__C__midpoint__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
@@ -21,11 +21,7 @@ use crate::{ct_fix_bin, ct_fix_count, ct_fix_un};
 
 macro_rules! emit_not {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let r = Not::not(x);
-            *r.words()
-        });
+        crate::emit_wl_un!($name, crate::catalog::not, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_not!(ct_fix__C__not__u8__N16, u8, 16);
@@ -259,10 +255,7 @@ emit_midpoint!(ct_fix__C__midpoint__u64__N4, u64, 4);
 
 macro_rules! emit_count_ones {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_count!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            PrimBits::count_ones(x)
-        });
+        crate::emit_wl_count!($name, crate::catalog::count_ones, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_count_ones!(ct_fix__C__count_ones__u8__N16, u8, 16);
@@ -272,11 +265,7 @@ emit_count_ones!(ct_fix__C__count_ones__u64__N4, u64, 4);
 
 macro_rules! emit_swap_bytes {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let r = PrimBits::swap_bytes(x);
-            *r.words()
-        });
+        crate::emit_wl_un!($name, crate::catalog::swap_bytes, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_swap_bytes!(ct_fix__C__swap_bytes__u8__N16, u8, 16);
@@ -286,11 +275,7 @@ emit_swap_bytes!(ct_fix__C__swap_bytes__u64__N4, u64, 4);
 
 macro_rules! emit_reverse_bits {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            let r = PrimBits::reverse_bits(x);
-            *r.words()
-        });
+        crate::emit_wl_un!($name, crate::catalog::reverse_bits, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_reverse_bits!(ct_fix__C__reverse_bits__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cat_c.rs
@@ -114,7 +114,7 @@ macro_rules! emit_carrying_add {
             let c = core::hint::black_box(carry);
             let x = FixedUInt::<$T, $N, Ct>::from(a_arr);
             let y = FixedUInt::<$T, $N, Ct>::from(b_arr);
-            let (r, co) = CarryingAdd::carrying_add(x, y, c);
+            let (r, co) = crate::catalog::carrying_add(x, y, c);
             let result = core::hint::black_box(*r.words());
             unsafe {
                 *out_ptr = result;
@@ -146,7 +146,7 @@ macro_rules! emit_borrowing_sub {
             let bin = core::hint::black_box(borrow);
             let x = FixedUInt::<$T, $N, Ct>::from(a_arr);
             let y = FixedUInt::<$T, $N, Ct>::from(b_arr);
-            let (r, bo) = BorrowingSub::borrowing_sub(x, y, bin);
+            let (r, bo) = crate::catalog::borrowing_sub(x, y, bin);
             let result = core::hint::black_box(*r.words());
             unsafe {
                 *out_ptr = result;
@@ -220,7 +220,7 @@ macro_rules! emit_carrying_mul {
             let x = FixedUInt::<$T, $N, Ct>::from(a);
             let y = FixedUInt::<$T, $N, Ct>::from(b);
             let cin = FixedUInt::<$T, $N, Ct>::from(cy);
-            let (lo, hi) = CarryingMul::carrying_mul(x, y, cin);
+            let (lo, hi) = crate::catalog::carrying_mul(x, y, cin);
             unsafe {
                 *lo_ptr = core::hint::black_box(*lo.words());
                 *hi_ptr = core::hint::black_box(*hi.words());

--- a/ct-verify/ct-fixtures/src/fixtures_cios.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_cios.rs
@@ -34,8 +34,8 @@ macro_rules! emit_cios_mul_acc_row {
             let s = core::hint::black_box(scalar);
             let c = core::hint::black_box(carry);
             let mult = FixedUInt::<$T, $N, Ct>::from(mult_arr);
-            let mut acc = FixedUInt::<$T, $N, Ct>::from(acc_arr);
-            let cout = <FixedUInt<$T, $N, Ct> as CiosRowOps>::mul_acc_row(s, &mult, &mut acc, c);
+            let acc = FixedUInt::<$T, $N, Ct>::from(acc_arr);
+            let (acc, cout) = crate::catalog::cios_mul_acc_row(s, mult, acc, c);
             unsafe {
                 *out_ptr = core::hint::black_box(*acc.words());
             }
@@ -65,9 +65,8 @@ macro_rules! emit_cios_mul_acc_shift_row {
             let s = core::hint::black_box(scalar);
             let hi = core::hint::black_box(acc_hi);
             let mult = FixedUInt::<$T, $N, Ct>::from(mult_arr);
-            let mut acc = FixedUInt::<$T, $N, Ct>::from(acc_arr);
-            let cout =
-                <FixedUInt<$T, $N, Ct> as CiosRowOps>::mul_acc_shift_row(s, &mult, &mut acc, hi);
+            let acc = FixedUInt::<$T, $N, Ct>::from(acc_arr);
+            let (acc, cout) = crate::catalog::cios_mul_acc_shift_row(s, mult, acc, hi);
             unsafe {
                 *out_ptr = core::hint::black_box(*acc.words());
             }
@@ -104,9 +103,8 @@ mod heapless_cios {
                 let s = core::hint::black_box(scalar);
                 let c = core::hint::black_box(carry);
                 let mult = HeaplessBigInt::<$T, $N, Ct>::from_limbs(mult_arr, $N as u16);
-                let mut acc = HeaplessBigInt::<$T, $N, Ct>::from_limbs(acc_arr, $N as u16);
-                let cout =
-                    <HeaplessBigInt<$T, $N, Ct> as CiosRowOps>::mul_acc_row(s, &mult, &mut acc, c);
+                let acc = HeaplessBigInt::<$T, $N, Ct>::from_limbs(acc_arr, $N as u16);
+                let (acc, cout) = crate::catalog::cios_mul_acc_row(s, mult, acc, c);
                 unsafe {
                     *out_ptr = core::hint::black_box(*acc.all_limbs());
                 }
@@ -136,10 +134,8 @@ mod heapless_cios {
                 let s = core::hint::black_box(scalar);
                 let hi = core::hint::black_box(acc_hi);
                 let mult = HeaplessBigInt::<$T, $N, Ct>::from_limbs(mult_arr, $N as u16);
-                let mut acc = HeaplessBigInt::<$T, $N, Ct>::from_limbs(acc_arr, $N as u16);
-                let cout = <HeaplessBigInt<$T, $N, Ct> as CiosRowOps>::mul_acc_shift_row(
-                    s, &mult, &mut acc, hi,
-                );
+                let acc = HeaplessBigInt::<$T, $N, Ct>::from_limbs(acc_arr, $N as u16);
+                let (acc, cout) = crate::catalog::cios_mul_acc_shift_row(s, mult, acc, hi);
                 unsafe {
                     *out_ptr = core::hint::black_box(*acc.all_limbs());
                 }

--- a/ct-verify/ct-fixtures/src/fixtures_ct_traits.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_ct_traits.rs
@@ -35,10 +35,7 @@ use crate::{ct_fix_bin, ct_fix_checked_bin, ct_fix_checked_un, ct_fix_pred};
 
 macro_rules! emit_ct_is_odd {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            x.ct_is_odd().unwrap_u8()
-        });
+        crate::emit_wl_pred!($name, crate::catalog::ct_is_odd, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_is_odd!(ct_fix__CT__ct_is_odd__u8__N16, u8, 16);
@@ -53,10 +50,7 @@ emit_ct_is_odd!(ct_fix__CT__ct_is_odd__u64__N4, u64, 4);
 
 macro_rules! emit_ct_is_zero {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            x.ct_is_zero().unwrap_u8()
-        });
+        crate::emit_wl_pred!($name, crate::catalog::ct_is_zero, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_is_zero!(ct_fix__CT__ct_is_zero__u8__N16, u8, 16);
@@ -71,10 +65,7 @@ emit_ct_is_zero!(ct_fix__CT__ct_is_zero__u64__N4, u64, 4);
 
 macro_rules! emit_ct_is_pow2 {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = FixedUInt::<$T, $N, Ct>::from(a);
-            x.ct_is_power_of_two().unwrap_u8()
-        });
+        crate::emit_wl_pred!($name, crate::catalog::ct_is_pow2, FixedUInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_ct_is_pow2!(ct_fix__CT__ct_is_pow2__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -497,7 +497,7 @@ macro_rules! emit_h_carrying_add {
             let c = core::hint::black_box(carry);
             let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a_arr, $N as u16);
             let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b_arr, $N as u16);
-            let (r, co) = CarryingAdd::carrying_add(x, y, c);
+            let (r, co) = crate::catalog::carrying_add(x, y, c);
             let result = core::hint::black_box(*r.all_limbs());
             unsafe {
                 *out_ptr = result;
@@ -529,7 +529,7 @@ macro_rules! emit_h_borrowing_sub {
             let bin = core::hint::black_box(borrow);
             let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a_arr, $N as u16);
             let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b_arr, $N as u16);
-            let (r, bo) = BorrowingSub::borrowing_sub(x, y, bin);
+            let (r, bo) = crate::catalog::borrowing_sub(x, y, bin);
             let result = core::hint::black_box(*r.all_limbs());
             unsafe {
                 *out_ptr = result;
@@ -603,7 +603,7 @@ macro_rules! emit_h_carrying_mul {
             let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
             let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
             let cin = HeaplessBigInt::<$T, $N, Ct>::from_limbs(cy, $N as u16);
-            let (lo, hi) = CarryingMul::carrying_mul(x, y, cin);
+            let (lo, hi) = crate::catalog::carrying_mul(x, y, cin);
             unsafe {
                 *lo_ptr = core::hint::black_box(*lo.all_limbs());
                 *hi_ptr = core::hint::black_box(*hi.all_limbs());
@@ -671,10 +671,7 @@ emit_h_reverse_bits!(ct_fix__HC__reverse_bits__u64__N4, u64, 4);
 // CtParity::ct_is_odd
 macro_rules! emit_h_ct_is_odd {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            x.ct_is_odd().unwrap_u8()
-        });
+        crate::emit_wl_pred!($name, crate::catalog::ct_is_odd, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_is_odd!(ct_fix__HCT__ct_is_odd__u8__N16, u8, 16);
@@ -686,10 +683,7 @@ emit_h_ct_is_odd!(ct_fix__HCT__ct_is_odd__u64__N4, u64, 4);
 // CtIsZero::ct_is_zero
 macro_rules! emit_h_ct_is_zero {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            CtIsZero::ct_is_zero(&x).unwrap_u8()
-        });
+        crate::emit_wl_pred!($name, crate::catalog::ct_is_zero, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_is_zero!(ct_fix__HCT__ct_is_zero__u8__N16, u8, 16);
@@ -701,10 +695,7 @@ emit_h_ct_is_zero!(ct_fix__HCT__ct_is_zero__u64__N4, u64, 4);
 // CtIsPowerOfTwo::ct_is_power_of_two
 macro_rules! emit_h_ct_is_pow2 {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            x.ct_is_power_of_two().unwrap_u8()
-        });
+        crate::emit_wl_pred!($name, crate::catalog::ct_is_pow2, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_is_pow2!(ct_fix__HCT__ct_is_pow2__u8__N16, u8, 16);
@@ -716,14 +707,7 @@ emit_h_ct_is_pow2!(ct_fix__HCT__ct_is_pow2__u64__N4, u64, 4);
 // CtCheckedAdd / CtCheckedSub / CtCheckedMul (CtOption-returning)
 macro_rules! emit_h_ct_checked_add {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_checked_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let res = <HeaplessBigInt<$T, $N, Ct> as CtCheckedAdd>::ct_checked_add(&x, &y);
-            let valid = res.is_some().unwrap_u8();
-            let value = res.unwrap_or(HeaplessBigInt::<$T, $N, Ct>::from_limbs([0; $N], $N as u16));
-            (*value.all_limbs(), valid)
-        });
+        crate::emit_wl_checked_bin!($name, crate::catalog::ct_checked_add, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_checked_add!(ct_fix__HCT__ct_checked_add__u8__N16, u8, 16);
@@ -734,14 +718,7 @@ emit_h_ct_checked_add!(ct_fix__HCT__ct_checked_add__u64__N4, u64, 4);
 
 macro_rules! emit_h_ct_checked_sub {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_checked_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let res = <HeaplessBigInt<$T, $N, Ct> as CtCheckedSub>::ct_checked_sub(&x, &y);
-            let valid = res.is_some().unwrap_u8();
-            let value = res.unwrap_or(HeaplessBigInt::<$T, $N, Ct>::from_limbs([0; $N], $N as u16));
-            (*value.all_limbs(), valid)
-        });
+        crate::emit_wl_checked_bin!($name, crate::catalog::ct_checked_sub, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_checked_sub!(ct_fix__HCT__ct_checked_sub__u8__N16, u8, 16);
@@ -752,14 +729,7 @@ emit_h_ct_checked_sub!(ct_fix__HCT__ct_checked_sub__u64__N4, u64, 4);
 
 macro_rules! emit_h_ct_checked_mul {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_checked_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let res = <HeaplessBigInt<$T, $N, Ct> as CtCheckedMul>::ct_checked_mul(&x, &y);
-            let valid = res.is_some().unwrap_u8();
-            let value = res.unwrap_or(HeaplessBigInt::<$T, $N, Ct>::from_limbs([0; $N], $N as u16));
-            (*value.all_limbs(), valid)
-        });
+        crate::emit_wl_checked_bin!($name, crate::catalog::ct_checked_mul, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_checked_mul!(ct_fix__HCT__ct_checked_mul__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -211,14 +211,11 @@ emit_h_midpoint!(ct_fix__HC__midpoint__u64__N4, u64, 4);
 // =============================================================================
 
 // SaturatingAdd / Sub / Mul
+// Migrated to the workload catalog: same `catalog::sat_add` op body as the
+// FixedUInt `A` fixture — one definition, both carriers.
 macro_rules! emit_h_sat_add {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = SaturatingAdd::saturating_add(x, y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::sat_add, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_sat_add!(ct_fix__HA__sat_add__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -193,11 +193,7 @@ emit_h_wrapping_next_pow2!(ct_fix__HA__wrapping_next_pow2__u64__N4, u64, 4);
 
 macro_rules! emit_h_midpoint {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            *Midpoint::midpoint(x, y).all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::midpoint, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_midpoint!(ct_fix__HC__midpoint__u8__N16, u8, 16);
@@ -226,12 +222,7 @@ emit_h_sat_add!(ct_fix__HA__sat_add__u64__N4, u64, 4);
 
 macro_rules! emit_h_sat_sub {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = SaturatingSub::saturating_sub(x, y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::sat_sub, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_sat_sub!(ct_fix__HA__sat_sub__u8__N16, u8, 16);
@@ -242,12 +233,7 @@ emit_h_sat_sub!(ct_fix__HA__sat_sub__u64__N4, u64, 4);
 
 macro_rules! emit_h_sat_mul {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = SaturatingMul::saturating_mul(x, y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::sat_mul, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_sat_mul!(ct_fix__HA__sat_mul__u8__N16, u8, 16);
@@ -259,12 +245,7 @@ emit_h_sat_mul!(ct_fix__HA__sat_mul__u64__N4, u64, 4);
 // AbsDiff
 macro_rules! emit_h_abs_diff {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = AbsDiff::abs_diff(x, y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::abs_diff, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_abs_diff!(ct_fix__HA__abs_diff__u8__N16, u8, 16);
@@ -500,12 +481,7 @@ emit_h_not!(ct_fix__HC__not__u64__N4, u64, 4);
 
 macro_rules! emit_h_bitand {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = BitAnd::bitand(x, y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::bitand, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_bitand!(ct_fix__HC__bitand__u8__N16, u8, 16);
@@ -516,12 +492,7 @@ emit_h_bitand!(ct_fix__HC__bitand__u64__N4, u64, 4);
 
 macro_rules! emit_h_bitor {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = BitOr::bitor(x, y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::bitor, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_bitor!(ct_fix__HC__bitor__u8__N16, u8, 16);
@@ -532,12 +503,7 @@ emit_h_bitor!(ct_fix__HC__bitor__u64__N4, u64, 4);
 
 macro_rules! emit_h_bitxor {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = BitXor::bitxor(x, y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::bitxor, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_bitxor!(ct_fix__HC__bitxor__u8__N16, u8, 16);
@@ -550,12 +516,7 @@ emit_h_bitxor!(ct_fix__HC__bitxor__u64__N4, u64, 4);
 // overflow bool; the body's branch-freeness is what we check.
 macro_rules! emit_h_overflowing_add {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let (r, _ov) = OverflowingAdd::overflowing_add(&x, &y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::overflowing_add, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_overflowing_add!(ct_fix__HC__overflowing_add__u8__N16, u8, 16);
@@ -566,12 +527,7 @@ emit_h_overflowing_add!(ct_fix__HC__overflowing_add__u64__N4, u64, 4);
 
 macro_rules! emit_h_wrapping_mul {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let r = WrappingMul::wrapping_mul(&x, &y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::wrapping_mul, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_wrapping_mul!(ct_fix__HC__wrapping_mul__u8__N16, u8, 16);
@@ -649,11 +605,7 @@ emit_h_borrowing_sub!(ct_fix__HC__borrowing_sub__u64__N4, u64, 4);
 // branch. Overflowing forms discard the flag.
 macro_rules! emit_h_wrapping_add {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            *WrappingAdd::wrapping_add(&x, &y).all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::wrapping_add, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_wrapping_add!(ct_fix__HC__wrapping_add__u8__N16, u8, 16);
@@ -662,11 +614,7 @@ emit_h_wrapping_add!(ct_fix__HC__wrapping_add__u64__N4, u64, 4);
 
 macro_rules! emit_h_wrapping_sub {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            *WrappingSub::wrapping_sub(&x, &y).all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::wrapping_sub, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_wrapping_sub!(ct_fix__HC__wrapping_sub__u8__N16, u8, 16);
@@ -675,12 +623,7 @@ emit_h_wrapping_sub!(ct_fix__HC__wrapping_sub__u64__N4, u64, 4);
 
 macro_rules! emit_h_overflowing_sub {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let (r, _ov) = OverflowingSub::overflowing_sub(&x, &y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::overflowing_sub, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_overflowing_sub!(ct_fix__HC__overflowing_sub__u8__N16, u8, 16);
@@ -689,12 +632,7 @@ emit_h_overflowing_sub!(ct_fix__HC__overflowing_sub__u64__N4, u64, 4);
 
 macro_rules! emit_h_overflowing_mul {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_bin!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            let (r, _ov) = OverflowingMul::overflowing_mul(&x, &y);
-            *r.all_limbs()
-        });
+        crate::emit_wl_bin!($name, crate::catalog::overflowing_mul, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_overflowing_mul!(ct_fix__HC__overflowing_mul__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/fixtures_heapless.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_heapless.rs
@@ -54,10 +54,7 @@ use crate::{
 
 macro_rules! emit_h_shl_usize {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, usize, |a, n| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            *(x << n).all_limbs()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::shl_usize, HeaplessBigInt<$T, $N, Ct>, $T, $N, usize);
     };
 }
 emit_h_shl_usize!(ct_fix__HA__shl_usize__u8__N16, u8, 16);
@@ -68,10 +65,7 @@ emit_h_shl_usize!(ct_fix__HA__shl_usize__u64__N4, u64, 4);
 
 macro_rules! emit_h_shr_usize {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, usize, |a, n| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            *(x >> n).all_limbs()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::shr_usize, HeaplessBigInt<$T, $N, Ct>, $T, $N, usize);
     };
 }
 emit_h_shr_usize!(ct_fix__HA__shr_usize__u8__N16, u8, 16);
@@ -84,11 +78,7 @@ emit_h_shr_usize!(ct_fix__HA__shr_usize__u64__N4, u64, 4);
 // routing the Ct arm through the same barrels as `<<`/`>>`.
 macro_rules! emit_h_shl_assign {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, usize, |a, n| {
-            let mut x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            x <<= n;
-            *x.all_limbs()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::shl_assign, HeaplessBigInt<$T, $N, Ct>, $T, $N, usize);
     };
 }
 emit_h_shl_assign!(ct_fix__HA__shl_assign__u8__N16, u8, 16);
@@ -99,11 +89,7 @@ emit_h_shl_assign!(ct_fix__HA__shl_assign__u64__N4, u64, 4);
 
 macro_rules! emit_h_shr_assign {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, usize, |a, n| {
-            let mut x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            x >>= n;
-            *x.all_limbs()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::shr_assign, HeaplessBigInt<$T, $N, Ct>, $T, $N, usize);
     };
 }
 emit_h_shr_assign!(ct_fix__HA__shr_assign__u8__N16, u8, 16);
@@ -120,10 +106,7 @@ emit_h_shr_assign!(ct_fix__HA__shr_assign__u64__N4, u64, 4);
 
 macro_rules! emit_h_unbounded_shl {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, u32, |a, n| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            *UnboundedShl::unbounded_shl(x, n).all_limbs()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::unbounded_shl, HeaplessBigInt<$T, $N, Ct>, $T, $N, u32);
     };
 }
 emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u8__N16, u8, 16);
@@ -134,10 +117,7 @@ emit_h_unbounded_shl!(ct_fix__HA__unbounded_shl__u64__N4, u64, 4);
 
 macro_rules! emit_h_unbounded_shr {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_shift!($name, $T, $N, u32, |a, n| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            *UnboundedShr::unbounded_shr(x, n).all_limbs()
-        });
+        crate::emit_wl_shift!($name, crate::catalog::unbounded_shr, HeaplessBigInt<$T, $N, Ct>, $T, $N, u32);
     };
 }
 emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u8__N16, u8, 16);
@@ -149,10 +129,7 @@ emit_h_unbounded_shr!(ct_fix__HA__unbounded_shr__u64__N4, u64, 4);
 // is_power_of_two (predicate, no shift), next_power_of_two (via ct_shl barrel).
 macro_rules! emit_h_is_pow2 {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            IsPowerOfTwo::is_power_of_two(x) as u8
-        });
+        crate::emit_wl_pred!($name, crate::catalog::is_pow2, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_is_pow2!(ct_fix__HA__is_pow2__u8__N16, u8, 16);
@@ -163,10 +140,7 @@ emit_h_is_pow2!(ct_fix__HA__is_pow2__u64__N4, u64, 4);
 
 macro_rules! emit_h_next_pow2 {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            *NextPowerOfTwo::next_power_of_two(x).all_limbs()
-        });
+        crate::emit_wl_un!($name, crate::catalog::next_pow2, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_next_pow2!(ct_fix__HA__next_pow2__u8__N16, u8, 16);
@@ -179,10 +153,7 @@ emit_h_next_pow2!(ct_fix__HA__next_pow2__u64__N4, u64, 4);
 // (ZERO on overflow, not MAX).
 macro_rules! emit_h_wrapping_next_pow2 {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            *NextPowerOfTwo::wrapping_next_power_of_two(x).all_limbs()
-        });
+        crate::emit_wl_un!($name, crate::catalog::wrapping_next_pow2, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_wrapping_next_pow2!(ct_fix__HA__wrapping_next_pow2__u8__N16, u8, 16);
@@ -286,10 +257,7 @@ emit_h_tz!(ct_fix__HA__trailing_zeros__u64__N4, u64, 4);
 // Zero::is_zero / One::is_one
 macro_rules! emit_h_is_zero {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            <HeaplessBigInt<$T, $N, Ct> as Zero>::is_zero(&x) as u8
-        });
+        crate::emit_wl_pred!($name, crate::catalog::is_zero, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_is_zero!(ct_fix__HA__is_zero__u8__N16, u8, 16);
@@ -300,10 +268,7 @@ emit_h_is_zero!(ct_fix__HA__is_zero__u64__N4, u64, 4);
 
 macro_rules! emit_h_is_one {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            <HeaplessBigInt<$T, $N, Ct> as One>::is_one(&x) as u8
-        });
+        crate::emit_wl_pred!($name, crate::catalog::is_one, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_is_one!(ct_fix__HA__is_one__u8__N16, u8, 16);
@@ -316,11 +281,7 @@ emit_h_is_one!(ct_fix__HA__is_one__u64__N4, u64, 4);
 // the `subtle::ct_eq` fixtured in category HB.
 macro_rules! emit_h_eq {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            (x == y) as u8
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::eq, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_eq!(ct_fix__HA__eq__u8__N16, u8, 16);
@@ -335,11 +296,7 @@ emit_h_eq!(ct_fix__HA__eq__u64__N4, u64, 4);
 
 macro_rules! emit_h_ct_eq {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            x.ct_eq(&y).unwrap_u8()
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::ct_eq, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_eq!(ct_fix__HB__ct_eq__u8__N16, u8, 16);
@@ -350,11 +307,7 @@ emit_h_ct_eq!(ct_fix__HB__ct_eq__u64__N4, u64, 4);
 
 macro_rules! emit_h_ct_gt {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            x.ct_gt(&y).unwrap_u8()
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::ct_gt, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_gt!(ct_fix__HB__ct_gt__u8__N16, u8, 16);
@@ -365,11 +318,7 @@ emit_h_ct_gt!(ct_fix__HB__ct_gt__u64__N4, u64, 4);
 
 macro_rules! emit_h_ct_lt {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            x.ct_lt(&y).unwrap_u8()
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::ct_lt, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_ct_lt!(ct_fix__HB__ct_lt__u8__N16, u8, 16);
@@ -466,11 +415,7 @@ emit_h_nz_cond_select!(ct_fix__HB__nz_cond_select__u64__N4, u64, 4);
 // Bitwise: Not / BitAnd / BitOr / BitXor
 macro_rules! emit_h_not {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let r = Not::not(x);
-            *r.all_limbs()
-        });
+        crate::emit_wl_un!($name, crate::catalog::not, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_not!(ct_fix__HC__not__u8__N16, u8, 16);
@@ -676,11 +621,7 @@ emit_h_carrying_mul!(ct_fix__HC__carrying_mul__u64__N4, u64, 4);
 // Ord::cmp — folded to u8 (Less=0xFF, Equal=0, Greater=1).
 macro_rules! emit_h_cmp {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_pred2!($name, $T, $N, |a, b| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let y = HeaplessBigInt::<$T, $N, Ct>::from_limbs(b, $N as u16);
-            (x.cmp(&y) as i8) as u8
-        });
+        crate::emit_wl_pred2!($name, crate::catalog::cmp, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_cmp!(ct_fix__HC__cmp__u8__N16, u8, 16);
@@ -692,10 +633,7 @@ emit_h_cmp!(ct_fix__HC__cmp__u64__N4, u64, 4);
 // Bit counts: count_ones / swap_bytes / reverse_bits
 macro_rules! emit_h_count_ones {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_count!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            PrimBits::count_ones(x)
-        });
+        crate::emit_wl_count!($name, crate::catalog::count_ones, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_count_ones!(ct_fix__HC__count_ones__u8__N16, u8, 16);
@@ -706,11 +644,7 @@ emit_h_count_ones!(ct_fix__HC__count_ones__u64__N4, u64, 4);
 
 macro_rules! emit_h_swap_bytes {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let r = PrimBits::swap_bytes(x);
-            *r.all_limbs()
-        });
+        crate::emit_wl_un!($name, crate::catalog::swap_bytes, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_swap_bytes!(ct_fix__HC__swap_bytes__u8__N16, u8, 16);
@@ -721,11 +655,7 @@ emit_h_swap_bytes!(ct_fix__HC__swap_bytes__u64__N4, u64, 4);
 
 macro_rules! emit_h_reverse_bits {
     ($name:ident, $T:ty, $N:literal) => {
-        ct_fix_un!($name, $T, $N, |a| {
-            let x = HeaplessBigInt::<$T, $N, Ct>::from_limbs(a, $N as u16);
-            let r = PrimBits::reverse_bits(x);
-            *r.all_limbs()
-        });
+        crate::emit_wl_un!($name, crate::catalog::reverse_bits, HeaplessBigInt<$T, $N, Ct>, $T, $N);
     };
 }
 emit_h_reverse_bits!(ct_fix__HC__reverse_bits__u8__N16, u8, 16);

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -29,9 +29,13 @@
 #[macro_use]
 mod ctgrind_shapes;
 
-// Client-owned workload catalog: each op declared once, carrier-generic, with
-// the backend adapters (extern-C here, ctgrind, DWT hardware) driving it.
-pub mod catalog;
+// The workload catalog (carrier-generic op fns + `FixtureCarrier`) lives in the
+// standalone `ct-workload` crate so the no_std DWT hardware suite can share it;
+// re-exported here as `catalog` so fixtures keep referencing `crate::catalog::*`.
+pub use ct_workload as catalog;
+
+// `emit_wl_*` adapters that turn a catalog op into an extern-C fixture.
+mod wl_shapes;
 
 mod fixtures_asym;
 mod fixtures_cat_a;

--- a/ct-verify/ct-fixtures/src/lib.rs
+++ b/ct-verify/ct-fixtures/src/lib.rs
@@ -29,6 +29,10 @@
 #[macro_use]
 mod ctgrind_shapes;
 
+// Client-owned workload catalog: each op declared once, carrier-generic, with
+// the backend adapters (extern-C here, ctgrind, DWT hardware) driving it.
+pub mod catalog;
+
 mod fixtures_asym;
 mod fixtures_cat_a;
 mod fixtures_cat_b;

--- a/ct-verify/ct-fixtures/src/wl_shapes.rs
+++ b/ct-verify/ct-fixtures/src/wl_shapes.rs
@@ -1,0 +1,95 @@
+//! `emit_wl_*` fixture adapters: turn a shared `ct_workload` op into an
+//! `extern "C"` fixture (+ its ctgrind registration) per carrier × width.
+
+/// `bin`-shape adapter: `(a, b) -> out`. Generates the `extern "C"` fixture
+/// (and, under the `ctgrind` feature, its taint registration) for one
+/// op × carrier × width by constructing the carrier through [`FixtureCarrier`],
+/// calling the shared catalog op, and reading the result back. The op and its
+/// input values are single-sourced; only the carrier + width vary here.
+#[macro_export]
+macro_rules! emit_wl_bin {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_bin!($sym, $T, $N, |aw, bw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
+            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a, b))
+        });
+    };
+}
+
+/// `un` shape: `(a) -> out`.
+#[macro_export]
+macro_rules! emit_wl_un {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_un!($sym, $T, $N, |aw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a))
+        });
+    };
+}
+
+/// `count` shape: `(a) -> u32`.
+#[macro_export]
+macro_rules! emit_wl_count {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_count!($sym, $T, $N, |aw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            $op(a)
+        });
+    };
+}
+
+/// `pred` shape: `(a) -> u8`.
+#[macro_export]
+macro_rules! emit_wl_pred {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_pred!($sym, $T, $N, |aw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            $op(a)
+        });
+    };
+}
+
+/// `pred2` shape: `(a, b) -> u8`.
+#[macro_export]
+macro_rules! emit_wl_pred2 {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_pred2!($sym, $T, $N, |aw, bw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
+            $op(a, b)
+        });
+    };
+}
+
+/// `shift` shape: `(a, amount) -> out`. `$NT` is the amount type (`usize`/`u32`).
+#[macro_export]
+macro_rules! emit_wl_shift {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal, $NT:ty) => {
+        $crate::ct_fix_shift!($sym, $T, $N, $NT, |aw, n| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a, n))
+        });
+    };
+}
+
+/// `checked_bin` shape: `(a, b) -> (out, u8)`. The op returns a `CtOption`;
+/// this splits it into the value (zero fallback) and the validity byte.
+#[macro_export]
+macro_rules! emit_wl_checked_bin {
+    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
+        $crate::ct_fix_checked_bin!($sym, $T, $N, |aw, bw| {
+            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
+            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
+            let res = $op(a, b);
+            let valid = res.is_some().unwrap_u8();
+            let value = res.unwrap_or(
+                <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words([0; $N]),
+            );
+            (
+                <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&value),
+                valid,
+            )
+        });
+    };
+}

--- a/ct-verify/ct-workload/Cargo.toml
+++ b/ct-verify/ct-workload/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ct-workload"
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.86"
+publish = false
+description = "Carrier-generic Ct workload ops shared by the CT-verify fixtures and the DWT hardware suite."
+
+[features]
+cios = ["dep:modmath-cios"]
+
+[dependencies]
+fixed-bigint = { path = "../..", default-features = false }
+const-num-traits = { version = "0.2.1", default-features = false, features = ["ct"] }
+subtle = { version = "2.6", default-features = false }
+modmath-cios = { version = "0.1.2", default-features = false, optional = true }

--- a/ct-verify/ct-workload/src/lib.rs
+++ b/ct-verify/ct-workload/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 //! Client-owned workload catalog.
 //!
 //! Each Ct operation is declared **once** as a carrier-generic function; the
@@ -22,11 +24,12 @@ use const_num_traits::ops::ct::{
     CtCheckedAdd, CtCheckedMul, CtCheckedSub, CtIsPowerOfTwo, CtIsZero, CtParity,
 };
 use const_num_traits::{
-    AbsDiff, BorrowingSub, CarryingAdd, CarryingMul, Ct, IsPowerOfTwo, Midpoint, NextPowerOfTwo,
-    One, OverflowingAdd, OverflowingMul, OverflowingSub, PrimBits, SaturatingAdd, SaturatingMul,
-    SaturatingSub, UnboundedShl, UnboundedShr, WrappingAdd, WrappingMul, WrappingSub, Zero,
+    AbsDiff, BorrowingSub, CarryingAdd, CarryingMul, Ct, Ilog10, IsPowerOfTwo, Midpoint,
+    NextPowerOfTwo, One, OverflowingAdd, OverflowingMul, OverflowingSub, PrimBits, SaturatingAdd,
+    SaturatingMul, SaturatingSub, UnboundedShl, UnboundedShr, WrappingAdd, WrappingMul,
+    WrappingSub, Zero,
 };
-use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, ShlAssign, Shr, ShrAssign};
+use core::ops::{BitAnd, BitOr, BitXor, Div, Not, Shl, ShlAssign, Shr, ShrAssign};
 use fixed_bigint::{FixedUInt, HeaplessBigInt, MachineWord};
 use subtle::{
     Choice, ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater, ConstantTimeLess,
@@ -306,95 +309,42 @@ pub fn cios_mul_acc_shift_row<C: modmath_cios::CiosRowOps>(
     (acc, c)
 }
 
-/// `bin`-shape adapter: `(a, b) -> out`. Generates the `extern "C"` fixture
-/// (and, under the `ctgrind` feature, its taint registration) for one
-/// op × carrier × width by constructing the carrier through [`FixtureCarrier`],
-/// calling the shared catalog op, and reading the result back. The op and its
-/// input values are single-sourced; only the carrier + width vary here.
-#[macro_export]
-macro_rules! emit_wl_bin {
-    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
-        $crate::ct_fix_bin!($sym, $T, $N, |aw, bw| {
-            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
-            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
-            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a, b))
-        });
-    };
+// ── Ops used only by the DWT hardware suite (single-carrier, not fixtured on
+// both carriers, but the workload body still lives here so the rig calls the
+// same catalog as the emulated backends). ──
+
+/// Scalar checked shift/pow — inherent methods on `FixedUInt` (Heapless has no
+/// equivalent), wrapped in a trait so a workload can call them generically.
+pub trait CtScalarChecked: Sized {
+    fn wl_ct_checked_shl(self, n: u32) -> subtle::CtOption<Self>;
+    fn wl_ct_checked_pow(self, exp: u32) -> subtle::CtOption<Self>;
+}
+impl<T: MachineWord, const N: usize> CtScalarChecked for FixedUInt<T, N, Ct> {
+    #[inline(always)]
+    fn wl_ct_checked_shl(self, n: u32) -> subtle::CtOption<Self> {
+        self.ct_checked_shl(n)
+    }
+    #[inline(always)]
+    fn wl_ct_checked_pow(self, exp: u32) -> subtle::CtOption<Self> {
+        self.ct_checked_pow(exp)
+    }
+}
+#[inline(always)]
+pub fn ct_checked_shl<C: CtScalarChecked>(a: C, n: u32) -> subtle::CtOption<C> {
+    a.wl_ct_checked_shl(n)
+}
+#[inline(always)]
+pub fn ct_checked_pow<C: CtScalarChecked>(a: C, exp: u32) -> subtle::CtOption<C> {
+    a.wl_ct_checked_pow(exp)
 }
 
-/// `un` shape: `(a) -> out`.
-#[macro_export]
-macro_rules! emit_wl_un {
-    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
-        $crate::ct_fix_un!($sym, $T, $N, |aw| {
-            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
-            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a))
-        });
-    };
+/// Negative-control ops (variable-time on `Nct` carriers): plain division and
+/// base-10 log. Generic over the op trait, so the rig drives an `Nct` carrier.
+#[inline(always)]
+pub fn nct_div<C: Div<Output = C>>(a: C, b: C) -> C {
+    a / b
 }
-
-/// `count` shape: `(a) -> u32`.
-#[macro_export]
-macro_rules! emit_wl_count {
-    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
-        $crate::ct_fix_count!($sym, $T, $N, |aw| {
-            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
-            $op(a)
-        });
-    };
-}
-
-/// `pred` shape: `(a) -> u8`.
-#[macro_export]
-macro_rules! emit_wl_pred {
-    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
-        $crate::ct_fix_pred!($sym, $T, $N, |aw| {
-            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
-            $op(a)
-        });
-    };
-}
-
-/// `pred2` shape: `(a, b) -> u8`.
-#[macro_export]
-macro_rules! emit_wl_pred2 {
-    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
-        $crate::ct_fix_pred2!($sym, $T, $N, |aw, bw| {
-            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
-            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
-            $op(a, b)
-        });
-    };
-}
-
-/// `shift` shape: `(a, amount) -> out`. `$NT` is the amount type (`usize`/`u32`).
-#[macro_export]
-macro_rules! emit_wl_shift {
-    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal, $NT:ty) => {
-        $crate::ct_fix_shift!($sym, $T, $N, $NT, |aw, n| {
-            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
-            <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&$op(a, n))
-        });
-    };
-}
-
-/// `checked_bin` shape: `(a, b) -> (out, u8)`. The op returns a `CtOption`;
-/// this splits it into the value (zero fallback) and the validity byte.
-#[macro_export]
-macro_rules! emit_wl_checked_bin {
-    ($sym:ident, $op:path, $carrier:ty, $T:ty, $N:literal) => {
-        $crate::ct_fix_checked_bin!($sym, $T, $N, |aw, bw| {
-            let a = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(aw);
-            let b = <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words(bw);
-            let res = $op(a, b);
-            let valid = res.is_some().unwrap_u8();
-            let value = res.unwrap_or(
-                <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::from_words([0; $N]),
-            );
-            (
-                <$carrier as $crate::catalog::FixtureCarrier<$T, $N>>::to_words(&value),
-                valid,
-            )
-        });
-    };
+#[inline(always)]
+pub fn nct_ilog10<C: Ilog10>(a: C) -> u32 {
+    Ilog10::ilog10(a)
 }

--- a/ct-verify/cyccnt-hardware/Cargo.toml
+++ b/ct-verify/cyccnt-hardware/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2024"
 publish = false
 
 [features]
+default = ["hardware-smoke"]
+# Coverage tiers. `hardware-smoke` is the representative baseline set (7
+# positives + 2 negative controls) run on every dispatch. A `hardware-regressions`
+# tier (carrying_mul, cios, shifts, heapless) rides on top in a later step —
+# the ops already exist in the catalog, so it's a tag + input vectors.
+hardware-smoke = []
 carrier-u32x8 = []
 carrier-u32x16 = []
 carrier-u8x32 = []
@@ -15,4 +21,5 @@ cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
 krabi-caliper = { version = "0.1", features = ["cortex-m-dwt", "paired", "rtt"] }
 fixed-bigint = { path = "../..", default-features = false }
+ct-workload = { path = "../ct-workload", default-features = false }
 subtle = { version = "2.6", default-features = false }

--- a/ct-verify/cyccnt-hardware/Cargo.toml
+++ b/ct-verify/cyccnt-hardware/Cargo.toml
@@ -7,10 +7,13 @@ publish = false
 [features]
 default = ["hardware-smoke"]
 # Coverage tiers. `hardware-smoke` is the representative baseline set (7
-# positives + 2 negative controls) run on every dispatch. A `hardware-regressions`
-# tier (carrying_mul, cios, shifts, heapless) rides on top in a later step —
-# the ops already exist in the catalog, so it's a tag + input vectors.
+# positives + 2 negative controls) run on every dispatch. `hardware-regressions`
+# adds the paths where leaks were found or nearly found — the shift barrel,
+# carrying_mul's carry tail, the cios shift row (the #184 `if top_hi_bit` fix),
+# and the HeaplessBigInt carrier the smoke tier never exercises. All reuse the
+# shared catalog; cios pulls its op in via `ct-workload/cios`.
 hardware-smoke = []
+hardware-regressions = ["ct-workload/cios", "fixed-bigint/cios"]
 carrier-u32x8 = []
 carrier-u32x16 = []
 carrier-u8x32 = []

--- a/ct-verify/cyccnt-hardware/krabi-caliper.toml
+++ b/ct-verify/cyccnt-hardware/krabi-caliper.toml
@@ -26,19 +26,19 @@ artifact-extension = ""
 [[case-sets.fixed-bigint-cyccnt]]
 name = "u32x8"
 binary = "fixed-bigint-cyccnt-hardware"
-features = ["carrier-u32x8"]
+features = ["carrier-u32x8", "hardware-regressions"]
 expected-suite = "fixed-bigint-cyccnt"
 
 [[case-sets.fixed-bigint-cyccnt]]
 name = "u32x16"
 binary = "fixed-bigint-cyccnt-hardware"
-features = ["carrier-u32x16"]
+features = ["carrier-u32x16", "hardware-regressions"]
 expected-suite = "fixed-bigint-cyccnt"
 
 [[case-sets.fixed-bigint-cyccnt]]
 name = "u8x32"
 binary = "fixed-bigint-cyccnt-hardware"
-features = ["carrier-u8x32"]
+features = ["carrier-u8x32", "hardware-regressions"]
 expected-suite = "fixed-bigint-cyccnt"
 
 [campaigns.fixed-bigint-jtrace-f407]

--- a/ct-verify/cyccnt-hardware/src/main.rs
+++ b/ct-verify/cyccnt-hardware/src/main.rs
@@ -1,14 +1,17 @@
 #![no_main]
 #![no_std]
 
-use const_num_traits::{Ct, Ilog10, Nct, Zero};
+use const_num_traits::{Ct, Nct};
 use core::hint::black_box;
 use cortex_m_rt::entry;
+// Every measured op body comes from the shared workload catalog — the same
+// definitions the emulated (asm-grep / ctgrind) backends drive. This file only
+// constructs inputs, calls the catalog op, and consumes the result.
+use ct_workload as catalog;
 use fixed_bigint::FixedUInt;
 use krabi_caliper::cortex_m::DwtMeasurementPlatform;
 use krabi_caliper::report::Field;
 use krabi_caliper::suite::{PairedSuite, PairedSuiteConfig, PairedSuiteFields};
-use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
 
 const TRIALS: usize = 4;
 const BATCHES: usize = 16;
@@ -47,11 +50,14 @@ type Words = [Word; N];
 type CtUInt = FixedUInt<Word, N, Ct>;
 type NctUInt = FixedUInt<Word, N, Nct>;
 
+// The `is_some().unwrap_u8()` / `unwrap_or(zero)` split of a checked op's
+// `CtOption` is the measurement harness's concern (write value, keep validity),
+// so it stays here; the op itself is `catalog::ct_checked_*`.
 #[inline(never)]
 fn fixture_ct_eq(a: &Words, b: &Words) -> bool {
     let x = CtUInt::from(black_box(*a));
     let y = CtUInt::from(black_box(*b));
-    let _ = black_box(x.ct_eq(&y).unwrap_u8());
+    let _ = black_box(catalog::ct_eq(x, y));
     true
 }
 
@@ -61,14 +67,14 @@ fn fixture_conditional_select(choice: u8) -> bool {
     let mut one_words = [0; N];
     one_words[0] = 1;
     let one = CtUInt::from(one_words);
-    let selected = CtUInt::conditional_select(&zero, &one, Choice::from(black_box(choice)));
+    let selected = catalog::cond_select(zero, one, black_box(choice));
     let _ = black_box(*selected.words());
     true
 }
 
 #[inline(never)]
 fn fixture_checked_add(a: &Words, b: &Words) -> bool {
-    let result = CtUInt::from(black_box(*a)).ct_checked_add(&CtUInt::from(black_box(*b)));
+    let result = catalog::ct_checked_add(CtUInt::from(black_box(*a)), CtUInt::from(black_box(*b)));
     let valid = result.is_some().unwrap_u8();
     let value = result.unwrap_or(CtUInt::from([0; N]));
     let _ = black_box((*value.words(), valid));
@@ -77,7 +83,7 @@ fn fixture_checked_add(a: &Words, b: &Words) -> bool {
 
 #[inline(never)]
 fn fixture_checked_mul(a: &Words, b: &Words) -> bool {
-    let result = CtUInt::from(black_box(*a)).ct_checked_mul(&CtUInt::from(black_box(*b)));
+    let result = catalog::ct_checked_mul(CtUInt::from(black_box(*a)), CtUInt::from(black_box(*b)));
     let valid = result.is_some().unwrap_u8();
     let value = result.unwrap_or(CtUInt::from([0; N]));
     let _ = black_box((*value.words(), valid));
@@ -86,7 +92,7 @@ fn fixture_checked_mul(a: &Words, b: &Words) -> bool {
 
 #[inline(never)]
 fn fixture_checked_shl(a: &Words, amount: u32) -> bool {
-    let result = CtUInt::from(black_box(*a)).ct_checked_shl(black_box(amount));
+    let result = catalog::ct_checked_shl(CtUInt::from(black_box(*a)), black_box(amount));
     let valid = result.is_some().unwrap_u8();
     let value = result.unwrap_or(CtUInt::from([0; N]));
     let _ = black_box((*value.words(), valid));
@@ -97,7 +103,7 @@ fn fixture_checked_shl(a: &Words, amount: u32) -> bool {
 fn fixture_checked_pow(exp: u32) -> bool {
     let mut base_words = [0; N];
     base_words[0] = 2;
-    let result = CtUInt::from(base_words).ct_checked_pow(black_box(exp));
+    let result = catalog::ct_checked_pow(CtUInt::from(base_words), black_box(exp));
     let valid = result.is_some().unwrap_u8();
     let value = result.unwrap_or(CtUInt::from([0; N]));
     let _ = black_box((*value.words(), valid));
@@ -106,22 +112,20 @@ fn fixture_checked_pow(exp: u32) -> bool {
 
 #[inline(never)]
 fn fixture_is_zero(a: &Words) -> bool {
-    let value = CtUInt::from(black_box(*a));
-    let _ = black_box(value.is_zero());
+    let _ = black_box(catalog::is_zero(CtUInt::from(black_box(*a))));
     true
 }
 
 #[inline(never)]
 fn fixture_nct_div(a: &Words, b: &Words) -> bool {
-    let value = NctUInt::from(black_box(*a)) / NctUInt::from(black_box(*b));
+    let value = catalog::nct_div(NctUInt::from(black_box(*a)), NctUInt::from(black_box(*b)));
     let _ = black_box(*value.words());
     true
 }
 
 #[inline(never)]
 fn fixture_nct_ilog10(a: &Words) -> bool {
-    let value = NctUInt::from(black_box(*a));
-    let _ = black_box(Ilog10::ilog10(value));
+    let _ = black_box(catalog::nct_ilog10(NctUInt::from(black_box(*a))));
     true
 }
 

--- a/ct-verify/cyccnt-hardware/src/main.rs
+++ b/ct-verify/cyccnt-hardware/src/main.rs
@@ -129,6 +129,66 @@ fn fixture_nct_ilog10(a: &Words) -> bool {
     true
 }
 
+// ── hardware-regressions tier: the paths where leaks were found or nearly
+// found. A/B pairs are chosen so a non-CT implementation would separate in
+// cycles (small vs large shift amount, minimal vs maximal carry propagation,
+// no-overflow vs overflow in the cios shift row). All use the shared catalog.
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_shl_usize(a: &Words, amount: usize) -> bool {
+    let r = catalog::shl_usize(CtUInt::from(black_box(*a)), black_box(amount));
+    let _ = black_box(*r.words());
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_carrying_mul(a: &Words, b: &Words, carry: &Words) -> bool {
+    let (lo, hi) = catalog::carrying_mul(
+        CtUInt::from(black_box(*a)),
+        CtUInt::from(black_box(*b)),
+        CtUInt::from(black_box(*carry)),
+    );
+    let _ = black_box((*lo.words(), *hi.words()));
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_cios_shift(mult: &Words, acc: &Words, scalar: Word, acc_hi: Word) -> bool {
+    let (acc2, cout) = catalog::cios_mul_acc_shift_row(
+        black_box(scalar),
+        CtUInt::from(black_box(*mult)),
+        CtUInt::from(black_box(*acc)),
+        black_box(acc_hi),
+    );
+    let _ = black_box((*acc2.words(), cout));
+    true
+}
+
+// HeaplessBigInt — the carrier the smoke tier never touches. Held full-width
+// (`len == N`) so it matches `FixedUInt<Word, N>`.
+#[cfg(feature = "hardware-regressions")]
+type HUInt = fixed_bigint::HeaplessBigInt<Word, N, Ct>;
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_h_sat_add(a: &Words, b: &Words) -> bool {
+    let x = HUInt::from_limbs(black_box(*a), N as u16);
+    let y = HUInt::from_limbs(black_box(*b), N as u16);
+    let _ = black_box(*catalog::sat_add(x, y).all_limbs());
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_h_shl_usize(a: &Words, amount: usize) -> bool {
+    let x = HUInt::from_limbs(black_box(*a), N as u16);
+    let _ = black_box(*catalog::shl_usize(x, black_box(amount)).all_limbs());
+    true
+}
+
 #[entry]
 fn main() -> ! {
     let mut reporter = krabi_caliper::protocol::rtt::init_ct_compatible();
@@ -244,6 +304,52 @@ fn main() -> ! {
             fixture_nct_ilog10,
         )
         .unwrap();
+
+    #[cfg(feature = "hardware-regressions")]
+    {
+        let max_shift = (N * Word::BITS as usize) - 1;
+        suite
+            .positive(
+                "shl_usize",
+                &(&sparse, 1usize),
+                &(&sparse, max_shift),
+                |&(a, amount)| fixture_shl_usize(a, amount),
+            )
+            .unwrap();
+        suite
+            .positive(
+                "carrying_mul",
+                &(&zero, &zero, &zero),
+                &(&dense, &dense, &dense),
+                |&(a, b, c)| fixture_carrying_mul(a, b, c),
+            )
+            .unwrap();
+        suite
+            .positive(
+                "cios_mul_acc_shift_row",
+                &(&sparse, &zero, 3 as Word, 0 as Word),
+                &(&dense, &dense, Word::MAX, Word::MAX),
+                |&(m, a, s, h)| fixture_cios_shift(m, a, s, h),
+            )
+            .unwrap();
+        suite
+            .positive(
+                "h_sat_add",
+                &(&zero, &zero),
+                &(&sparse, &dense),
+                |&(a, b)| fixture_h_sat_add(a, b),
+            )
+            .unwrap();
+        suite
+            .positive(
+                "h_shl_usize",
+                &(&sparse, 1usize),
+                &(&sparse, max_shift),
+                |&(a, amount)| fixture_h_shl_usize(a, amount),
+            )
+            .unwrap();
+    }
+
     suite.finish().unwrap();
     loop {
         cortex_m::asm::nop();

--- a/ct-verify/cyccnt-hardware/src/main.rs
+++ b/ct-verify/cyccnt-hardware/src/main.rs
@@ -189,6 +189,88 @@ fn fixture_h_shl_usize(a: &Words, amount: usize) -> bool {
     true
 }
 
+// ── modmath secret-path primitives: the CT ops the live crypto stack runs on
+// secret residues/exponents but which the smoke tier never measures. RSA's
+// blinded modexp drives ct_lt/ct_is_zero/ct_is_odd (CIOS reduce + safegcd_ct
+// inverse), borrowing_sub (CIOS final conditional −modulus), and cios_mul_acc_row
+// (the non-shift CIOS row, run every Montgomery multiply); ed25519's FieldCt
+// add/sub drives wrapping_add/wrapping_sub/overflowing_add on secret scalars.
+// A/B pairs flip the branch a non-CT impl would take (zero↔dense, even↔odd,
+// minimal↔maximal borrow/carry propagation).
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_ct_lt(a: &Words, b: &Words) -> bool {
+    let _ = black_box(catalog::ct_lt(
+        CtUInt::from(black_box(*a)),
+        CtUInt::from(black_box(*b)),
+    ));
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_ct_is_zero(a: &Words) -> bool {
+    let _ = black_box(catalog::ct_is_zero(CtUInt::from(black_box(*a))));
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_ct_is_odd(a: &Words) -> bool {
+    let _ = black_box(catalog::ct_is_odd(CtUInt::from(black_box(*a))));
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_borrowing_sub(a: &Words, b: &Words, borrow: bool) -> bool {
+    let (diff, bout) = catalog::borrowing_sub(
+        CtUInt::from(black_box(*a)),
+        CtUInt::from(black_box(*b)),
+        black_box(borrow),
+    );
+    let _ = black_box((*diff.words(), bout));
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_cios_row(mult: &Words, acc: &Words, scalar: Word, carry: Word) -> bool {
+    let (acc2, cout) = catalog::cios_mul_acc_row(
+        black_box(scalar),
+        CtUInt::from(black_box(*mult)),
+        CtUInt::from(black_box(*acc)),
+        black_box(carry),
+    );
+    let _ = black_box((*acc2.words(), cout));
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_wrapping_add(a: &Words, b: &Words) -> bool {
+    let r = catalog::wrapping_add(CtUInt::from(black_box(*a)), CtUInt::from(black_box(*b)));
+    let _ = black_box(*r.words());
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_wrapping_sub(a: &Words, b: &Words) -> bool {
+    let r = catalog::wrapping_sub(CtUInt::from(black_box(*a)), CtUInt::from(black_box(*b)));
+    let _ = black_box(*r.words());
+    true
+}
+
+#[cfg(feature = "hardware-regressions")]
+#[inline(never)]
+fn fixture_overflowing_add(a: &Words, b: &Words) -> bool {
+    let r = catalog::overflowing_add(CtUInt::from(black_box(*a)), CtUInt::from(black_box(*b)));
+    let _ = black_box(*r.words());
+    true
+}
+
 #[entry]
 fn main() -> ! {
     let mut reporter = krabi_caliper::protocol::rtt::init_ct_compatible();
@@ -346,6 +428,59 @@ fn main() -> ! {
                 &(&sparse, 1usize),
                 &(&sparse, max_shift),
                 |&(a, amount)| fixture_h_shl_usize(a, amount),
+            )
+            .unwrap();
+
+        // modmath secret-path primitives (see fixture comment above).
+        suite
+            .positive("ct_lt", &(&zero, &dense), &(&dense, &zero), |&(a, b)| {
+                fixture_ct_lt(a, b)
+            })
+            .unwrap();
+        suite
+            .positive("ct_is_zero", &zero, &dense, fixture_ct_is_zero)
+            .unwrap();
+        suite
+            .positive("ct_is_odd", &zero, &one, fixture_ct_is_odd)
+            .unwrap();
+        suite
+            .positive(
+                "borrowing_sub",
+                &(&zero, &zero, false),
+                &(&dense, &dense, true),
+                |&(a, b, borrow)| fixture_borrowing_sub(a, b, borrow),
+            )
+            .unwrap();
+        suite
+            .positive(
+                "cios_mul_acc_row",
+                &(&sparse, &zero, 3 as Word, 0 as Word),
+                &(&dense, &dense, Word::MAX, Word::MAX),
+                |&(m, a, s, c)| fixture_cios_row(m, a, s, c),
+            )
+            .unwrap();
+        suite
+            .positive(
+                "wrapping_add",
+                &(&zero, &zero),
+                &(&dense, &dense),
+                |&(a, b)| fixture_wrapping_add(a, b),
+            )
+            .unwrap();
+        suite
+            .positive(
+                "wrapping_sub",
+                &(&dense, &zero),
+                &(&zero, &dense),
+                |&(a, b)| fixture_wrapping_sub(a, b),
+            )
+            .unwrap();
+        suite
+            .positive(
+                "overflowing_add",
+                &(&zero, &zero),
+                &(&dense, &dense),
+                |&(a, b)| fixture_overflowing_add(a, b),
             )
             .unwrap();
     }


### PR DESCRIPTION
Extracts one client-owned **workload catalog** and drives all three CT backends from it — closing the duplication where `cyccnt-hardware` re-implemented ops the asm-grep/ctgrind fixtures already had.

## Phase 0 — catalog under the emulated surface
- New `ct-workload` crate (no_std): each Ct op declared **once**, carrier-generic, plus the `FixtureCarrier` construct/extract trait. ct-fixtures re-exports it as `catalog` and keeps the `emit_wl_*` adapters that generate the `extern "C"` fixtures.
- **Every op present on both carriers** (FixedUInt + Heapless) now single-sourced: bin/un/count/pred/pred2/shift/checked_bin shapes + the bespoke ABIs (carrying/borrowing, carrying_mul, cond_select, cios row ops). ~48 op fns.
- Single-carrier ops (forget_ct, asym_*, FixedUInt-only inherent checked-scalar) correctly stay in place — no cross-carrier duplication to remove.
- Gate output unchanged: 496 fixtures, 0 violations on all 8 targets, verified after every shape. ctgrind + lib tests green.

## Phase 1 — hardware suite onto the catalog
- `cyccnt-hardware` depends on `ct-workload`; every measured op body is now a `catalog::*` call (ct_eq, cond_select, ct_checked_{add,mul,shl,pow}, is_zero, nct_div, nct_ilog10). No fixed-bigint op body remains in `main.rs`.
- Catalog ops are `#[inline(always)]`, fixtures `#[inline(never)]` → the op inlines into the measured symbol, so codegen and cycle counts match #178's baseline. All three carrier widths build for `thumbv7em-none-eabihf`.
- Rig verification (run 30168230675): the `hw-ct` DWT suite reproduced #178's baseline on the physical F407 — 7 positives BelowThreshold, 2 Nct controls tripping, equivalent spread. A refactor, not a coverage change.

## Phase 2 — hardware-regressions tier
- New `hardware-regressions` feature adds 5 measured cases targeting the paths where CT leaks were found or nearly found, all reusing the shared catalog (no new op bodies):
  - `shl_usize` — the shift barrel (shift-by-1 vs by width−1)
  - `carrying_mul` — the widening carry tail (min vs max carry)
  - `cios_mul_acc_shift_row` — the #184 `if top_hi_bit` fix (no-overflow vs overflow inputs)
  - `h_sat_add`, `h_shl_usize` — the HeaplessBigInt carrier the smoke tier never exercises
- Rig verification (run 30168780068): all 5 cases **BelowThreshold on all three carriers** (u32×8, u32×16, u8×32); both Nct controls still trip by millions of cycles. The DWT cycle counter now corroborates the #180/#184 fixes on real silicon, alongside asm-grep and Valgrind.

- Follow-up (run 30170451089): a call-site trace of the live crypto stack (rsa_heapless / ed25519_heapless, both on modmath 0.6.x) found eight CT primitives run on **secret** data that the tier didn't measure — `ct_lt`, `ct_is_zero`, `ct_is_odd` (CIOS reduce + `safegcd_ct` inverse), `borrowing_sub` (CIOS final conditional −modulus), `cios_mul_acc_row` (non-shift CIOS row, once per Montgomery multiply), and `wrapping_add`/`wrapping_sub`/`overflowing_add` (ed25519 FieldCt add/sub on secret scalars). All eight added as positives on all three carriers (each already a catalog op → fixtures + A/B vectors only); **all BelowThreshold**. The rig now attests every fixed-bigint CT primitive the shipping crypto crates drive on secret data, not a representative subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared workload catalog supporting arithmetic, bitwise, comparison, shifting, checked, and constant-time operations.
  * Added broader hardware regression coverage, including modular multiplication and secret-path primitives.
  * Added configurable hardware smoke and regression test modes.

* **Refactor**
  * Standardized fixture generation across fixed-width and heapless implementations.
  * Expanded support for reusable constant-time workload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
