### PR TITLE
Attest secret-amount right shift with an isolation fixture

### DIFF
--- a/ct-verify/ct-fixtures/src/ctgrind_shapes.rs
+++ b/ct-verify/ct-fixtures/src/ctgrind_shapes.rs
@@ -323,8 +323,10 @@ macro_rules! fbx_ctgrind_carrying_add {
 }
 
 /// Pointer-based secret shift amount → array. `(*const u32) → (T,N)`.
+/// Direction-agnostic: the shape is identical for a secret-amount `<<` or
+/// `>>` (public value baked into the fixture body, only the amount tainted).
 #[macro_export]
-macro_rules! fbx_ctgrind_asym_shl_u32 {
+macro_rules! fbx_ctgrind_asym_shift_u32 {
     ($name:ident, $T:ty, $N:literal) => {
         krabi_caliper::ctgrind_fixture!($name, {
             unsafe extern "C" {

--- a/ct-verify/ct-fixtures/src/fixtures_asym.rs
+++ b/ct-verify/ct-fixtures/src/fixtures_asym.rs
@@ -65,7 +65,7 @@ macro_rules! emit_asym_one_shl {
             }
         }
         #[cfg(feature = "ctgrind")]
-        fbx_ctgrind_asym_shl_u32!($name, $T, $N);
+        fbx_ctgrind_asym_shift_u32!($name, $T, $N);
     };
 }
 
@@ -74,6 +74,41 @@ emit_asym_one_shl!(ct_fix__ASYM__one_shl__u16__N16, u16, 16);
 emit_asym_one_shl!(ct_fix__ASYM__one_shl__u32__N4, u32, 4);
 emit_asym_one_shl!(ct_fix__ASYM__one_shl__u32__N16, u32, 16);
 emit_asym_one_shl!(ct_fix__ASYM__one_shl__u64__N4, u64, 4);
+
+// =============================================================================
+// `Self::max_value() >> tainted_amount`
+//
+// The right-shift twin of `one_shl`: routes through `Shr<u32>` → `Shr<usize>`
+// → `const_shr_ct`, exercising the barrel's `black_box(bit_k)` select and the
+// per-layer cross-limb bit merge on a secret amount. This is the exact shape
+// the modexp ladder (`exp >> i`) and Montgomery REDC drive on secret data, so
+// it earns the same amount-only isolation as the left shift. `max_value` (all
+// bits set) is the public LHS so every amount produces a distinct result,
+// stressing the merge a degenerate `1 >> n` would not.
+// =============================================================================
+
+macro_rules! emit_asym_max_shr {
+    ($name:ident, $T:ty, $N:literal) => {
+        #[no_mangle]
+        pub extern "C" fn $name(amount_ptr: *const u32, out_ptr: *mut [$T; $N]) {
+            let amount = core::hint::black_box(unsafe { *amount_ptr });
+            let max = FixedUInt::<$T, $N, Ct>::from([<$T>::MAX; $N]);
+            let shifted = max >> amount;
+            let result = core::hint::black_box(*shifted.words());
+            unsafe {
+                *out_ptr = result;
+            }
+        }
+        #[cfg(feature = "ctgrind")]
+        fbx_ctgrind_asym_shift_u32!($name, $T, $N);
+    };
+}
+
+emit_asym_max_shr!(ct_fix__ASYM__max_shr__u8__N16, u8, 16);
+emit_asym_max_shr!(ct_fix__ASYM__max_shr__u16__N16, u16, 16);
+emit_asym_max_shr!(ct_fix__ASYM__max_shr__u32__N4, u32, 4);
+emit_asym_max_shr!(ct_fix__ASYM__max_shr__u32__N16, u32, 16);
+emit_asym_max_shr!(ct_fix__ASYM__max_shr__u64__N4, u64, 4);
 
 // =============================================================================
 // `subtle::ConditionallySelectable::conditional_select(zero, one, tainted_choice)`


### PR DESCRIPTION
The `asym` CT fixtures pin the shift-by-**secret-amount** property in isolation — public value, only the amount tainted — so a secret amount can't drive control flow through the branchless barrel. That existed for `<<` (`one_shl` → `const_shl_ct`) but had no `>>` twin, even though secret-amount right shift is the shape the modexp ladder (`exp >> i`) and Montgomery REDC drive on secret data.

- Add `max_shr` (`max_value() >> tainted_amount` → `const_shr_ct`) across the same five `(T,N)` instantiations as `one_shl`.
- Generalise the ctgrind shape macro (`fbx_ctgrind_asym_shl_u32` → `fbx_ctgrind_asym_shift_u32`) — the pointer-tainted-amount → array shape is direction-agnostic.

Right shift was already covered by the amount-tainted regular `shr_usize` fixture; this adds the same amount-only isolation the left shift has. Local asm-grep gate: +5 fixtures (509→514), 0 new violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add constant-time verification coverage for secret-amount right shifts and generalize the ctgrind shift shape macro.

Enhancements:
- Introduce asym `max_shr` fixtures that exercise `Self::max_value() >> tainted_amount` across multiple integer/length instantiations.
- Rename and generalize the ctgrind pointer-based secret shift amount shape macro to be direction-agnostic for both left and right shifts.

Tests:
- Expand ctgrind-backed constant-time fixtures to cover secret-amount right shifts using the new `max_shr` asym fixtures.