### PR TITLE
Pin the Ct checked traits to cross-carrier parity

### DIFF
--- a/tests/carrier_generic.rs
+++ b/tests/carrier_generic.rs
@@ -15,6 +15,8 @@ mod harness;
 mod arithmetic;
 #[path = "carrier_generic/bits_and_compare.rs"]
 mod bits_and_compare;
+#[path = "carrier_generic/ct_checked.rs"]
+mod ct_checked;
 #[path = "carrier_generic/numeric.rs"]
 mod numeric;
 #[path = "carrier_generic/serialization.rs"]

--- a/tests/carrier_generic/ct_checked.rs
+++ b/tests/carrier_generic/ct_checked.rs
@@ -1,0 +1,123 @@
+//! Cross-carrier parity for the constant-time checked traits — `CtCheckedAdd`,
+//! `CtCheckedSub`, `CtCheckedMul`, and `CtNonZero`.
+//!
+//! The shared `Carrier` harness is `Nct`-only, so it can't reach these
+//! (they're `Ct`-personality). This file carries a parallel `CtCarrier`
+//! surface and runs each body for both `FixedUInt<_,_,Ct>` and
+//! `HeaplessBigInt<_,_,Ct>` at the shared 32-bit width. Both carriers already
+//! have per-carrier unit tests; what was missing is a check that the two impls
+//! agree on the same inputs — asserting each against the same expected
+//! `(value, validity)` pins them equal, extending the `HeaplessBigInt ≡
+//! FixedUInt` invariant to the masked-return CT surface.
+
+use crate::harness::{Bounded, CarryingMul, FixedUInt, HeaplessBigInt, MachineWord, Parity};
+use const_num_traits::ops::ct::{CtCheckedAdd, CtCheckedMul, CtCheckedSub};
+use const_num_traits::{Ct, CtNonZero, HasNonZero, One, WithPrecision, Zero};
+
+const MAX32: u32 = u32::MAX;
+
+/// The `Ct` checked-arithmetic surface both carriers implement, plus the
+/// width-pinning constructor. Mirrors `harness::Carrier` but for the Ct traits.
+pub(crate) trait CtCarrier:
+    Copy
+    + core::fmt::Debug
+    + PartialEq
+    + Zero
+    + One
+    + Bounded
+    + From<u32>
+    + WithPrecision
+    + CtCheckedAdd
+    + CtCheckedSub
+    + CtCheckedMul
+    + HasNonZero
+    + CtNonZero
+{
+    /// Pin `v` to the carrier's full 32-bit width, so the overflow boundaries
+    /// line up across carriers (identity on `FixedUInt`, a grow on heapless).
+    fn from_u32_ct(v: u32) -> Self {
+        <Self as From<u32>>::from(v).widen_to_precision(32)
+    }
+}
+
+impl<T, const N: usize> CtCarrier for FixedUInt<T, N, Ct> where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T> + subtle::ConstantTimeEq + Parity
+{
+}
+impl<T, const CAP: usize> CtCarrier for HeaplessBigInt<T, CAP, Ct> where
+    T: MachineWord + CarryingMul<Unsigned = T, Output = T> + subtle::ConstantTimeEq + Parity
+{
+}
+
+macro_rules! for_both_ct_carriers {
+    ($body:ident) => {{
+        $body::<FixedUInt<u8, 4, Ct>>();
+        $body::<HeaplessBigInt<u8, 4, Ct>>();
+        $body::<FixedUInt<u16, 2, Ct>>();
+        $body::<HeaplessBigInt<u16, 2, Ct>>();
+        $body::<FixedUInt<u32, 1, Ct>>();
+        $body::<HeaplessBigInt<u32, 1, Ct>>();
+    }};
+}
+
+#[test]
+fn ct_checked_add_parity() {
+    fn body<C: CtCarrier>() {
+        let a = C::from_u32_ct(250);
+        let b = C::from_u32_ct(5);
+        assert_eq!(
+            Option::<C>::from(a.ct_checked_add(&b)),
+            Some(C::from_u32_ct(255))
+        );
+        // Overflow at the shared 32-bit width masks to None on both carriers.
+        let max = C::from_u32_ct(MAX32);
+        let one = C::from_u32_ct(1);
+        assert_eq!(Option::<C>::from(max.ct_checked_add(&one)), None);
+    }
+    for_both_ct_carriers!(body);
+}
+
+#[test]
+fn ct_checked_sub_parity() {
+    fn body<C: CtCarrier>() {
+        let a = C::from_u32_ct(500);
+        let b = C::from_u32_ct(200);
+        assert_eq!(
+            Option::<C>::from(a.ct_checked_sub(&b)),
+            Some(C::from_u32_ct(300))
+        );
+        // Underflow masks to None.
+        let one = C::from_u32_ct(1);
+        let two = C::from_u32_ct(2);
+        assert_eq!(Option::<C>::from(one.ct_checked_sub(&two)), None);
+    }
+    for_both_ct_carriers!(body);
+}
+
+#[test]
+fn ct_checked_mul_parity() {
+    fn body<C: CtCarrier>() {
+        let a = C::from_u32_ct(1000);
+        let b = C::from_u32_ct(1000);
+        assert_eq!(
+            Option::<C>::from(a.ct_checked_mul(&b)),
+            Some(C::from_u32_ct(1_000_000))
+        );
+        // 100_000^2 = 10^10 overflows 32 bits → None on both carriers.
+        let big = C::from_u32_ct(100_000);
+        assert_eq!(Option::<C>::from(big.ct_checked_mul(&big)), None);
+    }
+    for_both_ct_carriers!(body);
+}
+
+#[test]
+fn into_nonzero_ct_parity() {
+    fn body<C: CtCarrier>() {
+        // Non-zero → the masked `CtOption` is Some; zero → None. This pins the
+        // validity flag across carriers (value recovery via the inherent
+        // `NonZero::get()` is covered per-carrier).
+        assert!(bool::from(C::from_u32_ct(7).into_nonzero_ct().is_some()));
+        assert!(bool::from(C::from_u32_ct(0).into_nonzero_ct().is_none()));
+    }
+    for_both_ct_carriers!(body);
+}


### PR DESCRIPTION
`CtCheckedAdd`/`CtCheckedSub`/`CtCheckedMul` and `CtNonZero` are implemented on both carriers and unit-tested per carrier, but the shared `carrier_generic` harness is **Nct-only** — nothing pinned the two Ct impls to agree with each other, despite `HeaplessBigInt ≡ FixedUInt` being the carrier invariant.

Adds a `CtCarrier` bound + `for_both_ct_carriers!` runner (the Ct twin of the existing `Carrier`/`for_both_carriers!`) and parity tests for all four traits at the shared 32-bit width: `Some` on the in-range case, `None` on overflow/underflow, and the `into_nonzero_ct` validity flag on zero vs non-zero. Each carrier is asserted against one ground-truth expected result, so the two impls are pinned equal across `FixedUInt<_,_,Ct>` and `HeaplessBigInt<_,_,Ct>` at u8×4 / u16×2 / u32×1.

Closes the cross-carrier coverage gap for the CT checked surface; no library change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add cross-carrier parity tests for constant-time checked traits to ensure Ct implementations on FixedUInt and HeaplessBigInt remain equivalent at the shared 32-bit width.

Tests:
- Introduce a CtCarrier test harness and for_both_ct_carriers! runner to exercise CtCheckedAdd, CtCheckedSub, CtCheckedMul, and CtNonZero across both carriers.
- Add parity tests verifying matching Some/None behavior for checked arithmetic and non-zero masking on FixedUInt and HeaplessBigInt at 32-bit configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cross-implementation coverage for constant-time checked arithmetic.
  * Verified consistent handling of overflow and underflow across supported numeric implementations.
  * Added parity checks for constant-time nonzero conversions, including zero and non-zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->