### PR TITLE
Sign-extend signed_shr on both carriers (#156)

### DIFF
--- a/src/fixeduint/prim_int_impl.rs
+++ b/src/fixeduint/prim_int_impl.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::machineword::ConstMachineWord;
 use const_num_traits::PrimBits;
-use const_num_traits::{Nct, Personality, PersonalityTag};
+use const_num_traits::{Bounded, Nct, Personality, PersonalityTag};
 
 c0nst::c0nst! {
     c0nst impl<T: [c0nst] ConstMachineWord + MachineWord, const N: usize, P: Personality> PrimBits for FixedUInt<T, N, P> {
@@ -85,10 +85,38 @@ c0nst::c0nst! {
             core::ops::Shl::<u32>::shl(self, n)
         }
         fn signed_shr(self, n: u32) -> Self {
-            // For unsigned types the sign bit is always 0, so the
-            // arithmetic (sign-extending) right shift produces the
-            // same result as the logical right shift.
-            core::ops::Shr::<u32>::shr(self, n)
+            // Arithmetic (sign-extending) right shift: the vacated top bits
+            // take the carrier's MSB, per the `PrimBits`/`PrimInt` contract
+            // (`(self as signed) >> n`). Branchless on the value — the sign
+            // bit is spread to a full-width mask via `bit * MAX` (the CT
+            // barrel's trick), so a `Ct` carrier never branches on the value;
+            // both shifts route through the `Shr` operator, which barrels a
+            // secret amount on `Ct`. The fill `sign_full ^ (sign_full >> n)`
+            // is the top-`n` sign bits when the MSB is set and zero otherwise,
+            // so a non-negative value shifts identically to `unsigned_shr`.
+            let logical = core::ops::Shr::<u32>::shr(self, n);
+            if N == 0 {
+                return logical;
+            }
+            let word_bits = FixedUInt::<T, N>::WORD_BITS;
+            let sign_bit = self.array[N - 1] >> (word_bits - 1);
+            let mask_word =
+                <T as core::ops::Mul>::mul(sign_bit, <T as Bounded>::max_value());
+            let mut sign_full = self;
+            let mut i = 0;
+            while i < N {
+                sign_full.array[i] = mask_word;
+                i += 1;
+            }
+            let sf_shr = core::ops::Shr::<u32>::shr(sign_full, n);
+            let mut result = logical;
+            let mut i = 0;
+            while i < N {
+                let fill = <T as core::ops::BitXor>::bitxor(mask_word, sf_shr.array[i]);
+                result.array[i] = <T as core::ops::BitOr>::bitor(logical.array[i], fill);
+                i += 1;
+            }
+            result
         }
         fn reverse_bits(self) -> Self {
             let mut ret = <Self as const_num_traits::ConstZero>::ZERO;
@@ -190,7 +218,9 @@ impl<T: MachineWord, const N: usize> num_traits::PrimInt for FixedUInt<T, N, Nct
         <Self as num_traits::PrimInt>::unsigned_shl(self, bits)
     }
     fn signed_shr(self, bits: u32) -> Self {
-        <Self as num_traits::PrimInt>::unsigned_shr(self, bits)
+        // Sign-extending shift, delegated to the single `PrimBits` body so both
+        // the num-traits and const-num-traits surfaces agree.
+        <Self as PrimBits>::signed_shr(self, bits)
     }
     fn unsigned_shl(self, bits: u32) -> Self {
         self << bits
@@ -331,7 +361,9 @@ mod tests {
             assert_eq!(USHL.array, [16, 0]);
             assert_eq!(USHR.array, [0xFF, 0x0F]);
             assert_eq!(SSHL.array, [16, 0]);
-            assert_eq!(SSHR.array, [0xFF, 0x0F]);
+            // V_FULL (0xFFFF) has its MSB set, so the arithmetic shift fills
+            // ones: -1 >> 4 == -1 == 0xFFFF (vs the logical 0x0FFF above).
+            assert_eq!(SSHR.array, [0xFF, 0xFF]);
             assert_eq!(REV.array, [0, 0x80]);
             assert_eq!(TO_BE.array, [0, 1]);
             assert_eq!(TO_LE.array, [1, 0]);

--- a/src/heapless/prim_bits.rs
+++ b/src/heapless/prim_bits.rs
@@ -17,7 +17,7 @@
 
 use super::{HeaplessBigInt, is_zero, zero};
 use crate::MachineWord;
-use const_num_traits::{Personality, PersonalityTag, PrimBits};
+use const_num_traits::{Bounded, Personality, PersonalityTag, PrimBits};
 use core::marker::PhantomData;
 
 /// Value width in bits (`len·word_bits`) — the width every PrimBits member
@@ -179,9 +179,36 @@ impl<T: MachineWord, const CAP: usize, P: Personality> PrimBits for HeaplessBigI
     }
 
     fn signed_shr(self, n: u32) -> Self {
-        // Unsigned carrier: heapless mirrors FixedUInt, which shifts logically
-        // (treats the value as unsigned), keeping the two carriers bit-for-bit.
-        <Self as PrimBits>::unsigned_shr(self, n)
+        // Arithmetic (sign-extending) right shift over the value width
+        // (`len·word_bits`), matching FixedUInt: the vacated top bits take the
+        // MSB. Branchless on the value — the sign bit is spread to a full-width
+        // mask via `bit * MAX` — and width-preserving, like `unsigned_shr`. The
+        // fill `sign_full ^ (sign_full >> n)` is the top-`n` sign bits when the
+        // MSB is set and zero otherwise, so a non-negative value shifts
+        // identically to `unsigned_shr`.
+        let logical = <Self as PrimBits>::unsigned_shr(self, n);
+        let len = self.len as usize;
+        if len == 0 {
+            return logical;
+        }
+        let word_bits = core::mem::size_of::<T>() * 8;
+        let sign_bit = self.limbs[len - 1] >> (word_bits - 1);
+        let mask_word = <T as core::ops::Mul>::mul(sign_bit, <T as Bounded>::max_value());
+        let mut sign_full = self;
+        let mut i = 0;
+        while i < len {
+            sign_full.limbs[i] = mask_word;
+            i += 1;
+        }
+        let sf_shr = <Self as PrimBits>::unsigned_shr(sign_full, n);
+        let mut result = logical;
+        let mut i = 0;
+        while i < len {
+            let fill = mask_word ^ sf_shr.limbs[i];
+            result.limbs[i] = logical.limbs[i] | fill;
+            i += 1;
+        }
+        result
     }
 
     // Little-endian host: in-memory order already matches, so to/from_le are

--- a/tests/carrier_generic/bits_and_compare.rs
+++ b/tests/carrier_generic/bits_and_compare.rs
@@ -59,11 +59,27 @@ fn prim_bits_bit_vocabulary() {
             PrimBits::rotate_right(C::from_u32(1), 1),
             C::from_u32(0x8000_0000)
         );
-        // shifts (unsigned == signed on an unsigned carrier)
+        // shifts: unsigned_shr is logical, signed_shr sign-extends from the
+        // MSB (#156). Run for both carriers, so fixed/heapless stay in parity.
         assert_eq!(PrimBits::unsigned_shl(C::from_u32(1), 4), C::from_u32(16));
         assert_eq!(PrimBits::unsigned_shr(C::from_u32(0x10), 4), C::from_u32(1));
         assert_eq!(PrimBits::signed_shl(C::from_u32(1), 4), C::from_u32(16));
+        // MSB clear → same as logical.
         assert_eq!(PrimBits::signed_shr(C::from_u32(0x10), 4), C::from_u32(1));
+        // MSB set → fills ones: 0x8000_0000 >> 1 == 0xC000_0000, >> 31 == all ones.
+        assert_eq!(
+            PrimBits::signed_shr(C::from_u32(0x8000_0000), 1),
+            C::from_u32(0xC000_0000)
+        );
+        assert_eq!(
+            PrimBits::signed_shr(C::from_u32(0x8000_0000), 31),
+            C::from_u32(0xFFFF_FFFF)
+        );
+        // unsigned_shr on the same input stays logical (does not sign-extend).
+        assert_eq!(
+            PrimBits::unsigned_shr(C::from_u32(0x8000_0000), 1),
+            C::from_u32(0x4000_0000)
+        );
         // byte / bit order
         assert_eq!(
             PrimBits::swap_bytes(C::from_u32(0x1234_5678)),

--- a/tests/carrier_num_traits.rs
+++ b/tests/carrier_num_traits.rs
@@ -188,12 +188,27 @@ fn prim_int() {
         assert_eq!(PrimInt::pow(C::at32(2), 10), C::at32(1024));
         assert_eq!(PrimInt::pow(C::at32(7), 3), C::at32(343));
 
-        // Shifts (delegated via PrimBits): unsigned == signed for the unsigned
-        // carrier, and both stay fixed-width.
+        // Shifts (delegated via PrimBits): unsigned_shr is logical, signed_shr
+        // sign-extends from the MSB (#156). Both stay fixed-width, and the
+        // assertions run for both carriers so fixed/heapless stay in parity.
         assert_eq!(PrimInt::unsigned_shl(C::at32(1), 31), C::at32(0x8000_0000));
         assert_eq!(PrimInt::unsigned_shr(C::at32(0x8000_0000), 31), C::at32(1));
         assert_eq!(PrimInt::signed_shl(C::at32(1), 31), C::at32(0x8000_0000));
-        assert_eq!(PrimInt::signed_shr(C::at32(0x8000_0000), 31), C::at32(1));
+        // MSB set → arithmetic shift fills ones: -2^31 >> 31 == -1, and
+        // >> 1 == 0xC000_0000 (the issue's acceptance criterion).
+        assert_eq!(
+            PrimInt::signed_shr(C::at32(0x8000_0000), 31),
+            C::at32(0xFFFF_FFFF)
+        );
+        assert_eq!(
+            PrimInt::signed_shr(C::at32(0x8000_0000), 1),
+            C::at32(0xC000_0000)
+        );
+        // MSB clear → identical to the logical shift.
+        assert_eq!(
+            PrimInt::signed_shr(C::at32(0x4000_0000), 1),
+            C::at32(0x2000_0000)
+        );
 
         // Endianness conversions round-trip.
         let v = C::at32(0x1234_5678);


### PR DESCRIPTION
Closes #156.

`PrimBits`/`PrimInt::signed_shr` performed a **logical** right shift on both `FixedUInt` and `HeaplessBigInt`, violating the contract that it sign-extend from the carrier's MSB (`(self as signed) >> n`). It was intentionally kept logical and cross-carrier-consistent in #154; this corrects it on both carriers together.

## Implementation
Arithmetic shift as `(self >> n) | (sign_full ^ (sign_full >> n))`, where `sign_full` is the MSB spread to a full-width mask via the `bit * MAX` trick. Consequences:
- **Branchless on the value** — a `Ct` carrier never branches on the sign bit — and both shifts route through the width-correct `>>` operator (barrel on `Ct`, width-preserving on heapless), so no new CT leak and no width regression.
- A non-negative value shifts identically to `unsigned_shr`; the logical/unsigned shift APIs are untouched.

- FixedUInt: `PrimBits::signed_shr` rewritten (const-callable, P-generic); `num_traits::PrimInt::signed_shr` now delegates to it instead of `unsigned_shr`.
- Heapless: `PrimBits::signed_shr` rewritten (width-preserving); its `PrimInt` bridge already delegates to PrimBits and inherits the fix.

## Acceptance criteria
- `0x8000_0000.signed_shr(1) == 0xC000_0000`, `.signed_shr(31) == 0xFFFF_FFFF` — asserted in the **shared** `carrier_generic` / `carrier_num_traits` harnesses, so they run for both carriers and pin fixed/heapless parity across u8×4 / u16×2 / u32×1.
- Logical/unsigned shift behavior unchanged (explicit `unsigned_shr` assertion on the same input).
- Nightly const-eval proof updated (`0xFFFF signed_shr 4 == 0xFFFF`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct signed_shr semantics to perform sign-extending right shifts across both FixedUInt and HeaplessBigInt carriers, ensuring consistency with PrimBits/PrimInt contracts.

Bug Fixes:
- Fix signed_shr to perform arithmetic (sign-extending) right shifts instead of logical shifts for FixedUInt carriers.
- Fix signed_shr to perform arithmetic (sign-extending) right shifts instead of logical shifts for HeaplessBigInt carriers.

Enhancements:
- Unify PrimInt::signed_shr to delegate through PrimBits so const-num-traits and num-traits surfaces share the same shift semantics.

Tests:
- Extend carrier_generic and carrier_num_traits shift tests to cover sign-extension behavior on MSB-set and MSB-clear values and maintain parity between fixed and heapless carriers.
- Update FixedUInt PrimBits tests to assert arithmetic right shift behavior on full-width -1 values.