### PR TITLE
Run F407 timing gate at 30 MHz

### DIFF
--- a/ct-verify/cyccnt-hardware/Cargo.toml
+++ b/ct-verify/cyccnt-hardware/Cargo.toml
@@ -22,6 +22,7 @@ carrier-u8x32 = []
 const-num-traits = { version = "0.2", default-features = false, features = ["ct"] }
 cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7"
+stm32f4xx-hal = { version = "0.22", features = ["stm32f407"] }
 krabi-caliper = { version = "0.1", features = ["cortex-m-dwt", "paired", "rtt"] }
 fixed-bigint = { path = "../..", default-features = false }
 ct-workload = { path = "../ct-workload", default-features = false }

--- a/ct-verify/cyccnt-hardware/README.md
+++ b/ct-verify/cyccnt-hardware/README.md
@@ -29,7 +29,7 @@ cargo run --release --features carrier-u8x32
 ```
 
 RTT output uses `krabi-caliper` schema version 1. It emits an `EM_BEGIN`
-record with qualified target and 16 MHz counter metadata, every individual A/B
+record with qualified target and 30 MHz counter metadata, every individual A/B
 sample as `EM_SAMPLE`, each policy decision as `EM_RESULT`, and a final
 `EM_SUMMARY`. It also mirrors the legacy `CT_BEGIN`, `CT_RESULT`, and
 `CT_SUMMARY` records for consumers still on that schema. The reporter uses a

--- a/ct-verify/cyccnt-hardware/krabi-caliper.toml
+++ b/ct-verify/cyccnt-hardware/krabi-caliper.toml
@@ -5,7 +5,7 @@ board = "jtrace-reference-board"
 mcu = "STM32F407VG"
 transport = "rtt"
 probe = "${KRABI_PROBE}"
-clock-frequency-hz = 16000000
+clock-frequency-hz = 30000000
 executable = "probe-rs"
 args = [
   "run",

--- a/ct-verify/cyccnt-hardware/src/main.rs
+++ b/ct-verify/cyccnt-hardware/src/main.rs
@@ -12,6 +12,7 @@ use fixed_bigint::FixedUInt;
 use krabi_caliper::cortex_m::DwtMeasurementPlatform;
 use krabi_caliper::report::Field;
 use krabi_caliper::suite::{PairedSuite, PairedSuiteConfig, PairedSuiteFields};
+use stm32f4xx_hal::{pac, prelude::*};
 
 const TRIALS: usize = 4;
 const BATCHES: usize = 16;
@@ -275,10 +276,14 @@ fn fixture_overflowing_add(a: &Words, b: &Words) -> bool {
 fn main() -> ! {
     let mut reporter = krabi_caliper::protocol::rtt::init_ct_compatible();
     let mut peripherals = cortex_m::Peripherals::take().unwrap();
+    // Stay within the F407's zero-wait-state flash range. This shortens wall
+    // time without introducing ART cache/prefetch jitter into cycle evidence.
+    let dp = pac::Peripherals::take().unwrap();
+    let _clocks = dp.RCC.constrain().cfgr.sysclk(30.MHz()).freeze();
     let mut counter = DwtMeasurementPlatform::enable(
         &mut peripherals.DCB,
         &mut peripherals.DWT,
-        Some(16_000_000),
+        Some(30_000_000),
     )
     .unwrap();
 
@@ -317,7 +322,7 @@ fn main() -> ! {
             target: "thumbv7em-none-eabihf",
             board: Some("stm32f407vg"),
             unit: krabi_caliper::Unit::CoreCycles,
-            frequency_hz: Some(16_000_000),
+            frequency_hz: Some(30_000_000),
             warmup_blocks: 2,
             batches: BATCHES,
             positive_max_spread: MAX_POSITIVE_SPREAD as u64,


### PR DESCRIPTION
## Summary

- configure the STM32F407 hardware timing fixture for a 30 MHz system clock
- qualify DWT evidence and campaign metadata at the actual 30 MHz frequency
- retain the existing CT sample counts, spread limit, and policy

## Why

Thirty megahertz stays within the F407 zero-wait-state flash regime while reducing hardware campaign wall time. Higher ART-assisted clocks introduced fetch jitter in the Ed25519 qualification; this keeps the deterministic measurement regime.

## Validation

- `cargo check --release --features carrier-u32x8,hardware-regressions` in `ct-verify/cyccnt-hardware`
- formatting and repository pre-commit checks except repository-wide clippy

Repository-wide clippy currently fails on the pre-existing duplicated `cios` cfg attribute in `src/fixeduint/cios_row_ops_impl.rs`; this PR does not touch that code.

## Summary by Sourcery

Configure the STM32F407 cycle-counting hardware fixture to run and report measurements at a 30 MHz system clock instead of 16 MHz.

Enhancements:
- Initialize STM32F407 system clocks via stm32f4xx-hal to operate at a 30 MHz zero-wait-state configuration for timing measurements.
- Update DWT measurement platform and reporting metadata to reflect the new 30 MHz frequency while keeping existing sampling and policy parameters.

Build:
- Add stm32f4xx-hal dependency for F407 clock configuration within the cyccnt-hardware crate.

Documentation:
- Adjust cyccnt-hardware README documentation to describe RTT output as using a 30 MHz counter for campaign metadata.

Chores:
- Update krabi-caliper configuration to declare a 30 MHz clock for the STM32F407 timing campaigns.